### PR TITLE
fix: eslint config for scaffords

### DIFF
--- a/scaffords/ice-design-lite/.eslintrc
+++ b/scaffords/ice-design-lite/.eslintrc
@@ -10,13 +10,12 @@
     }
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "mocha": true
   },
-  "plugins": [
-    "react",
-    "babel"
-  ],
+  "plugins": ["react", "babel"],
   "rules": {
+    "react/prefer-stateless-function": 0,
     "no-console": 0,
     "no-use-before-define": 0,
     "jsx-a11y/label-has-for": 0,
@@ -33,10 +32,7 @@
     "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [
-          ".js",
-          ".jsx"
-        ]
+        "extensions": [".js", ".jsx"]
       }
     ],
     "import/extensions": 0,
@@ -50,10 +46,7 @@
     "no-redeclare": 0,
     "react/require-extension": 0,
     "react/no-danger": 0,
-    "comma-dangle": [
-      "error",
-      "always-multiline"
-    ],
+    "comma-dangle": ["error", "always-multiline"],
     "function-paren-newline": 0,
     "object-curly-newline": 0,
     "no-restricted-globals": 0

--- a/scaffords/ice-design-pro/.eslintignore
+++ b/scaffords/ice-design-pro/.eslintignore
@@ -9,4 +9,3 @@ coverage/
 # 忽略文件
 **/*-min.js
 **/*.min.js
-src/routes.jsx

--- a/scaffords/ice-design-pro/.eslintrc
+++ b/scaffords/ice-design-pro/.eslintrc
@@ -10,13 +10,12 @@
     }
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "mocha": true
   },
-  "plugins": [
-    "react",
-    "babel"
-  ],
+  "plugins": ["react", "babel"],
   "rules": {
+    "react/prefer-stateless-function": 0,
     "no-console": 0,
     "jsx-a11y/label-has-for": 0,
     "jsx-a11y/no-static-element-interactions": 0,
@@ -33,10 +32,7 @@
     "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [
-          ".js",
-          ".jsx"
-        ]
+        "extensions": [".js", ".jsx"]
       }
     ],
     "import/extensions": 0,
@@ -50,10 +46,7 @@
     "no-redeclare": 0,
     "react/require-extension": 0,
     "react/no-danger": 0,
-    "comma-dangle": [
-      "error",
-      "always-multiline"
-    ],
+    "comma-dangle": ["error", "always-multiline"],
     "function-paren-newline": 0,
     "object-curly-newline": 0,
     "no-restricted-globals": 0,


### PR DESCRIPTION
fix #74 

env 增加 "mocha": true 是因为后边我们会增加单测

.eslintignore 不应该忽略任何 src 的文件