### PR TITLE
添加.gitignore

### DIFF
--- a/scaffolds/ice-design-cms/.gitignore
+++ b/scaffolds/ice-design-cms/.gitignore
@@ -1,0 +1,17 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# production
+/build
+/dist
+
+# misc
+.idea/
+.happypack
+.DS_Store
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
发现就 cms 这个模板里面没有 .gitignore， 自己创建了项目一般会直接 git init 和 git add . （发现多加了好多多余内容），然后看其他模板都有这个 .gitignore ,遂感觉可以直接复制过来就可以用