### PR TITLE
fix: css images relative path

### DIFF
--- a/tools/ice-scripts/lib/config/getEntry.js
+++ b/tools/ice-scripts/lib/config/getEntry.js
@@ -29,7 +29,7 @@ module.exports = function getEntry(cwd) {
     }
 
     if (entry) {
-      console.log(colors.blue('TIPS:'), 'package.json 存在 entry 配置');
+      console.log(colors.yellow('Info:'), 'package.json 存在 entry 配置');
       return entry;
     }
   }

--- a/tools/ice-scripts/lib/config/getEntryByPages.js
+++ b/tools/ice-scripts/lib/config/getEntryByPages.js
@@ -44,7 +44,7 @@ module.exports = () => {
         entryObj[pageName] = filePath;
       }
     });
-    console.log(colors.blue('TIPS:'), 'entry 未指定，使用 pages 作为默认。');
+    console.log(colors.yellow('Info:'), 'entry 未指定，使用 pages 作为默认。');
     return entryObj;
   } catch (err) {
     throw err;

--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -7,6 +7,7 @@ const path = require('path');
 const SimpleProgressPlugin = require('webpack-simple-progress-plugin');
 const webpack = require('webpack');
 const WebpackPluginImport = require('webpack-plugin-import');
+const colors = require('chalk');
 
 const AppendStyleWebpackPlugin = require('../plugins/append-style-webpack-plugin');
 const normalizeEntry = require('../utils/normalizeEntry');
@@ -69,13 +70,15 @@ module.exports = function(paths, { buildConfig = {}, themeConfig = {} }) {
       {
         libraryName: /@alifd\/.*/,
         stylePath: 'style.js',
-      }
+      },
     ]),
   ];
 
-  const localization = buildConfig.localization || false;
-
-  if (localization) {
+  if (paths.publicUrl === './') {
+    console.log(
+      colors.yellow('Info:'),
+      '离线化构建项目，自动下载网络资源，请耐心等待'
+    );
     plugins.push(
       new ExtractCssAssetsWebpackPlugin({
         outputPath: 'assets',
@@ -131,7 +134,11 @@ module.exports = function(paths, { buildConfig = {}, themeConfig = {} }) {
 
   if (skinOverridePath && fs.existsSync(skinOverridePath)) {
     // eslint-disable-next-line no-console
-    console.log('皮肤 override 文件存在, 添加...');
+    console.log(
+      colors.yellow('Info:'),
+      '皮肤 override 文件存在',
+      path.join(themePackage, 'override.scss')
+    );
     plugins.push(
       new AppendStyleWebpackPlugin({
         variableFile: variableFilePath,

--- a/tools/ice-scripts/lib/config/getProxyConfig.js
+++ b/tools/ice-scripts/lib/config/getProxyConfig.js
@@ -18,7 +18,7 @@ module.exports = (opts = {}) => {
 
       if (pkgData.proxyConfig) {
         console.log(
-          colors.blue('\nTIPS:'),
+          colors.blue('\nInfo:'),
           '读取 package.json 里 proxyConfig 代理配置.'
         );
 

--- a/tools/ice-scripts/lib/config/getRules.js
+++ b/tools/ice-scripts/lib/config/getRules.js
@@ -46,7 +46,7 @@ module.exports = (paths, buildConfig = {}) => {
   const theme = buildConfig.theme || buildConfig.themePackage;
   if (theme) {
     // eslint-disable-next-line no-console
-    console.log(colors.cyan('Tip:'), '使用皮肤包', theme);
+    console.log(colors.yellow('Info:'), '使用皮肤包', theme);
     sassLoaders.push({
       loader: require.resolve('ice-skin-loader'),
       options: {
@@ -54,15 +54,30 @@ module.exports = (paths, buildConfig = {}) => {
       },
     });
   }
+
+  const cssPublicUrl = paths.publicUrl === './' ? '../' : paths.publicUrl;
   return [
     {
       test: /\.scss$/,
-      use: withCssHotLoader([MiniCssExtractPlugin.loader, ...sassLoaders]),
+      use: withCssHotLoader([
+        {
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            publicPath: cssPublicUrl,
+          },
+        },
+        ...sassLoaders,
+      ]),
     },
     {
       test: /\.css$/,
       use: withCssHotLoader([
-        MiniCssExtractPlugin.loader,
+        {
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            publicPath: cssPublicUrl,
+          },
+        },
         {
           loader: CSS_LOADER,
           options: {
@@ -78,7 +93,12 @@ module.exports = (paths, buildConfig = {}) => {
     {
       test: /\.less$/,
       use: withCssHotLoader([
-        MiniCssExtractPlugin.loader,
+        {
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            publicPath: cssPublicUrl,
+          },
+        },
         {
           loader: CSS_LOADER,
           options: {

--- a/tools/ice-scripts/lib/config/getUserConfig.js
+++ b/tools/ice-scripts/lib/config/getUserConfig.js
@@ -19,7 +19,7 @@ module.exports = (opts = {}) => {
   // todo support .webpackrc file
   if (fs.existsSync(webpackRCJSPath)) {
     // eslint-disable-next-line no-console
-    console.log(colors.blue('TIPS:'), '注入 .webpackrc.js 的配置.');
+    console.log(colors.yellow('Info:'), '注入 .webpackrc.js 的配置');
     // no cache
     delete require.cache[webpackRCJSPath];
     const config = require(webpackRCJSPath); // eslint-disable-line
@@ -33,7 +33,7 @@ module.exports = (opts = {}) => {
 
   if (userConfig.entry) {
     // eslint-disable-next-line no-console
-    console.log(colors.blue('TIPS:'), '.webpackrc.js 存在 entry 配置');
+    console.log(colors.yellow('Info:'), '.webpackrc.js 存在 entry 配置');
   }
 
   return userConfig;

--- a/tools/ice-scripts/lib/config/paths.js
+++ b/tools/ice-scripts/lib/config/paths.js
@@ -1,7 +1,6 @@
 const { realpathSync } = require('fs');
 const { resolve } = require('path');
 const url = require('url');
-const pathExists = require('path-exists');
 
 function resolveSDK(relativePath) {
   return resolve(__dirname, relativePath);

--- a/tools/ice-scripts/lib/utils/validationSassAvailable.js
+++ b/tools/ice-scripts/lib/utils/validationSassAvailable.js
@@ -11,7 +11,7 @@ module.exports = function() {
       console.log('');
       console.log(colors.red('ERROR:'), 'ice-scripts 已终止');
       console.log(colors.yellow('INFO:'), '当前 node-sass 无法运行');
-      console.log(colors.blue('TIPS:'), '您可以尝试执行以下命令重装修复:');
+      console.log(colors.yellow('Info:'), '您可以尝试执行以下命令重装修复:');
       console.log('    ', colors.magenta('npm install node-sass'));
       console.log('');
       reject();

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Close https://github.com/alibaba/ice/issues/738  

webpack 构建设置 `publicPath: './'` 将资源离线化，css 中的相对资源由 loader 处理。

```js
const MiniCssExtractPlugin = require("mini-css-extract-plugin");
module.exports = {
  plugins: [
    new MiniCssExtractPlugin({
      // Options similar to the same options in webpackOptions.output
      // both options are optional
      filename: "[name].css",
      chunkFilename: "[id].css"
    })
  ],
  module: {
    rules: [
      {
        test: /\.css$/,
        use: [
          {
            loader: MiniCssExtractPlugin.loader,
            options: {
              // you can specify a publicPath here
              // by default it use publicPath in webpackOptions.output
              publicPath: '../'
            }
          },
          "css-loader"
        ]
      }
    ]
  }
}
```

https://github.com/webpack-contrib/mini-css-extract-plugin#minimal-example