### PR TITLE
default baseUrl

### DIFF
--- a/vue-materials/scaffolds/d2-admin-ice/vue.config.js
+++ b/vue-materials/scaffolds/d2-admin-ice/vue.config.js
@@ -6,7 +6,7 @@ function resolve (dir) {
 }
 
 // 基础路径 注意发布之前要先修改这里
-const baseUrl = '/d2-admin-ice-preview/'
+const baseUrl = '/'
 
 module.exports = {
   baseUrl: baseUrl, // 根据你的实际情况更改这里


### PR DESCRIPTION
设置 `baseUrl = '/'` 解决使用客户端启动项目时点击 GUI 上的预览地址无效（必须访问终端里生成的地址）问题