### PR TITLE
fix: support es7 decorators

### DIFF
--- a/react-materials/scaffolds/ice-coreui-admin/config-overrides.js
+++ b/react-materials/scaffolds/ice-coreui-admin/config-overrides.js
@@ -8,6 +8,8 @@ module.exports = function override(config) {
     config
   );
 
+  config = injectBabelPlugin('transform-decorators-legacy', config);
+
   config.plugins.push(
     new WebpackPluginImport([
       {

--- a/react-materials/scaffolds/ice-coreui-admin/package.json
+++ b/react-materials/scaffolds/ice-coreui-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icedesign/coreui-admin-template",
-  "version": "1.0.5",
-  "description": "该模板基于社区的 CoreUI 改造而成，支持 CoreUI 的所有功能，同时也支持飞冰基础组件和区块的使用， 支持 Iceworks 一键创建项目和完整的 GUI 操作",
+  "version": "1.0.6",
+  "description": "该模板基于社区的 CoreUI 改造而成，使用 react-scripts 构建，支持 CoreUI 的所有功能，同时也支持飞冰基础组件和区块的使用， 支持 Iceworks 一键创建项目和完整的 GUI 操作",
   "homepage": "https://alibaba.github.io/ice/scaffold-preview/ice-coreui-admin/index.html",
   "license": "MIT",
   "keywords": [
@@ -34,6 +34,7 @@
     "babel-eslint": "^8.0.3",
     "babel-jest": "^23.0.1",
     "babel-plugin-import": "^1.8.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-babel": "^4.1.1",
@@ -73,7 +74,9 @@
     "type": "react",
     "name": "ice-coreui-admin",
     "title": "ICE CoreUI Admin",
-    "categories": ["Dashboard"],
+    "categories": [
+      "Dashboard"
+    ],
     "screenshot": "https://img.alicdn.com/tfs/TB1hoK.ETtYBeNjy1XdXXXXyVXa-2840-1596.png"
   },
   "engines": {

--- a/react-materials/scaffolds/ice-creative-dashboard/config-overrides.js
+++ b/react-materials/scaffolds/ice-creative-dashboard/config-overrides.js
@@ -8,6 +8,8 @@ module.exports = function override(config) {
     config
   );
 
+  config = injectBabelPlugin('transform-decorators-legacy', config);
+
   config.plugins.push(
     new WebpackPluginImport([
       {

--- a/react-materials/scaffolds/ice-creative-dashboard/package.json
+++ b/react-materials/scaffolds/ice-creative-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icedesign/creative-dashboard",
-  "version": "1.0.1",
-  "description": "该模板基于社区的 now-ui-dashboard-react 改造而成，默认使用 react-bootstrap 组件，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
+  "version": "1.0.2",
+  "description": "该模板基于社区的 now-ui-dashboard-react 改造而成，默认使用 react-bootstrap 组件和 react-scripts 构建，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
   "homepage": "https://alibaba.github.io/ice/scaffold-preview/ice-creative-dashboard/index.html",
   "license": "MIT",
   "keywords": [
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "babel-plugin-import": "^1.8.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-babel": "^4.1.1",
@@ -61,7 +62,9 @@
     "type": "react",
     "name": "ice-creative-dashboard",
     "title": "ICE Creative Dashboard",
-    "categories": ["Dashboard"],
+    "categories": [
+      "Dashboard"
+    ],
     "screenshot": "https://img.alicdn.com/tfs/TB1BOaQb56guuRjy1XdXXaAwpXa-2840-1596.png"
   },
   "engines": {

--- a/react-materials/scaffolds/ice-light-bootstrap-dashboard/config-overrides.js
+++ b/react-materials/scaffolds/ice-light-bootstrap-dashboard/config-overrides.js
@@ -8,6 +8,8 @@ module.exports = function override(config) {
     config
   );
 
+  config = injectBabelPlugin('transform-decorators-legacy', config);
+
   config.plugins.push(
     new WebpackPluginImport([
       {

--- a/react-materials/scaffolds/ice-light-bootstrap-dashboard/package.json
+++ b/react-materials/scaffolds/ice-light-bootstrap-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icedesign/ice-light-bootstrap-dashboard",
-  "version": "1.0.4",
-  "description": "该模板基于社区的 light-bootstrap-dashboard 改造而成，默认使用 react-bootstrap 组件，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
+  "version": "1.0.5",
+  "description": "该模板基于社区的 light-bootstrap-dashboard 改造而成，默认使用 react-bootstrap 组件和 react-scripts 构建，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
   "homepage": "https://alibaba.github.io/ice/scaffold-preview/ice-light-bootstrap-dashboard/index.html",
   "license": "MIT",
   "keywords": [
@@ -21,6 +21,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "babel-plugin-import": "^1.8.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-babel": "^4.1.1",
@@ -59,7 +60,9 @@
     "type": "react",
     "name": "ice-light-bootstrap-dashboard",
     "title": "ICE Light Bootstrap Dashboard",
-    "categories": ["行业领域"],
+    "categories": [
+      "Dashboard"
+    ],
     "screenshot": "https://img.alicdn.com/tfs/TB1265Oay6guuRjy1XdXXaAwpXa-2840-1596.png"
   },
   "engines": {

--- a/react-materials/scaffolds/ice-material-dashboard/config-overrides.js
+++ b/react-materials/scaffolds/ice-material-dashboard/config-overrides.js
@@ -8,6 +8,8 @@ module.exports = function override(config) {
     config
   );
 
+  config = injectBabelPlugin('transform-decorators-legacy', config);
+
   config.plugins.push(
     new WebpackPluginImport([
       {

--- a/react-materials/scaffolds/ice-material-dashboard/package.json
+++ b/react-materials/scaffolds/ice-material-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@icedesign/ice-material-dashboard-scaffold",
-  "version": "1.0.2",
-  "description": "该模板基于社区的 material-dashboard-react 改造而成，默认使用 material-ui 组件，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
+  "version": "1.0.3",
+  "description": "该模板基于社区的 material-dashboard-react 改造而成，默认使用 material-ui 组件和 react-scripts 构建，同时也支持飞冰基础组件和区块的使用，支持 Iceworks 一键创建项目和完整的 GUI 操作",
   "homepage": "https://alibaba.github.io/ice/scaffold-preview/ice-material-dashboard/index.html",
   "license": "MIT",
   "dependencies": {
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "babel-plugin-import": "^1.8.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-babel": "^4.1.1",
@@ -57,7 +58,9 @@
   "scaffoldConfig": {
     "name": "ice-material-dashboard",
     "title": "ICE Material Dashboard",
-    "categories": ["Dashboard"],
+    "categories": [
+      "Dashboard"
+    ],
     "screenshot": "https://img.alicdn.com/tfs/TB1lJJDFntYBeNjy1XdXXXXyVXa-2840-1596.png"
   },
   "engines": {


### PR DESCRIPTION
**修复 react-scripts 构建器不支持 ES7 decorator 的问题**
  1. 通过 react-app-rewired 的 injectBabelPlugin 接口配置 `transform-decorators-legacy`
  2. 对模板描述进行补充，说明是使用 react-scripts 作为构建器
  3. 对模板进行分类区分，四个社区引入的模板都归类于 Dashboard 类

不建议将该类模板改为使用 ice-scripts 作为构建器，理由是，对 Iceworks 来说，是一个通用的接入方式，只需要满足 package.json 的 scripts 里有 `npm run start` 和 `npm run build` 即可，另外用户也可以自定义接入模板，也不一定使用 ice-scripts 作为构建器。