### PR TITLE
feat: webpackrc 支持导出 function 并透传给用户一些上下文

### DIFF
--- a/tools/ice-scripts/lib/config/getUserConfig.js
+++ b/tools/ice-scripts/lib/config/getUserConfig.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const fs = require('fs');
 const colors = require('chalk');
+const webpack = require('webpack');
 
 // const jsonConfigFile = '.webpackrc';
 const jsConfigFile = '.webpackrc.js';
@@ -22,10 +23,19 @@ module.exports = (opts = {}) => {
     console.log(colors.green('Info:'), '注入 .webpackrc.js 的配置');
     // no cache
     delete require.cache[webpackRCJSPath];
-    const config = require(webpackRCJSPath); // eslint-disable-line
+    let config = require(webpackRCJSPath); // eslint-disable-line
+
     // support es module
-    if (config.default) {
-      Object.assign(userConfig, config.default);
+    config = config.default || config;
+
+    if (typeof config === 'function') {
+      // 支持 .webpack.rc.js 导出一个 function，用于向用户传递一些上下文环境
+
+      // 提供给开发者的上下文
+      const context = {
+        webpack,
+      };
+      Object.assign(userConfig, config(context));
     } else {
       Object.assign(userConfig, config);
     }

--- a/tools/ice-scripts/lib/config/getUserConfig.js
+++ b/tools/ice-scripts/lib/config/getUserConfig.js
@@ -29,7 +29,7 @@ module.exports = (opts = {}) => {
     config = config.default || config;
 
     if (typeof config === 'function') {
-      // 支持 .webpack.rc.js 导出一个 function，用于向用户传递一些上下文环境
+      // 支持 .webpackrc.js 导出一个 function，用于向用户传递一些上下文环境
 
       // 提供给开发者的上下文
       const context = {


### PR DESCRIPTION

- 解决问题：用户在 .webpack.rc.js 里使用 webpack 时（webpack.DefinePlugin）需要在项目里依赖一个 webpack，这个 webpack 跟 ice-scripts 的 webpack 版本可能会冲突导致构建出错，因此通过 function 的方式将内置的 webpack 透传给用户，保证只有一个 webpack 版本
- 文档下周在统一的工程文档上一起加
- 使用：

```js
// .wepackrc.js
module.exports = (context) => {
  const { webpack } = context;

  return {
    plugins: [
      new webpack.DefinePlugin({
         ASSETS_VERSION: '0.0.1',
      })
    ]
  }
};
```