### PR TITLE
fix: 修复删除 variables.scss 后变量不存在问题

### DIFF
--- a/tools/ice-scripts/CHANGELOG.md
+++ b/tools/ice-scripts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ice-scripts Changelog
 
+## 1.8.0
+
+- [fix] 没有配置 theme 也需要走 ice-skin-loader 的逻辑
+- [chore] 升级 ice-skin-loader 到 0.2.x
+- [chore] 移除 css-prefix-plugin
+
 ## 1.7.9
 
 - [feat] build 支持 `customWebpackConfig` 参数

--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -8,7 +8,6 @@ const path = require('path');
 const SimpleProgressPlugin = require('webpack-simple-progress-plugin');
 const webpack = require('webpack');
 const WebpackPluginImport = require('webpack-plugin-import');
-const CssPrefixPlugin = require('css-prefix-plugin');
 
 const AppendStyleWebpackPlugin = require('../plugins/append-style-webpack-plugin');
 const normalizeEntry = require('../utils/normalizeEntry');
@@ -74,18 +73,18 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
     console.log(
       colors.red(
         'Deprecated:',
-        'themeConfig.cssPrefix 已废弃，请使用 buildConfig.nextPrefix 代替'
+        'themeConfig.cssPrefix 已废弃，请使用 themeConfig.nextPrefix 代替'
       )
     );
   }
 
-  // 组件升级到 next 1.x 默认使用 "nextfd-" 前缀
-  // 解决 @icedesign/base 和 @alifd/next 共存的问题
+  // 废弃 1.7.9 版本之前 buildConfig.nextPrefix 的配置
   if (buildConfig.nextPrefix) {
-    plugins.push(
-      new CssPrefixPlugin({
-        '$css-prefix': 'nextfd-',
-      })
+    console.log(
+      colors.red(
+        'Deprecated:',
+        'buildConfig.nextPrefix 已废弃，请使用 themeConfig.nextPrefix 代替'
+      )
     );
   }
 

--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -68,26 +68,6 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
     ]),
   ];
 
-  // 废弃 1.7.9 版本之前 themeConfig.cssPrefix 的配置
-  if (themeConfig.cssPrefix) {
-    console.log(
-      colors.red(
-        'Deprecated:',
-        'themeConfig.cssPrefix 已废弃，请使用 themeConfig.nextPrefix 代替'
-      )
-    );
-  }
-
-  // 废弃 1.7.9 版本之前 buildConfig.nextPrefix 的配置
-  if (buildConfig.nextPrefix) {
-    console.log(
-      colors.red(
-        'Deprecated:',
-        'buildConfig.nextPrefix 已废弃，请使用 themeConfig.nextPrefix 代替'
-      )
-    );
-  }
-
   // 增加 html 输出，支持多页面应用
   Array.prototype.push.apply(plugins, getEntryHtmlPlugins(entry));
 

--- a/tools/ice-scripts/lib/config/getRules.js
+++ b/tools/ice-scripts/lib/config/getRules.js
@@ -23,7 +23,7 @@ function withCssHotLoader(loaders) {
   return loaders;
 }
 
-module.exports = (buildConfig = {}) => {
+module.exports = (buildConfig = {}, themeConfig) => {
   const babelConfig = getBabelConfig(buildConfig);
   const sassLoaders = [
     {
@@ -45,16 +45,19 @@ module.exports = (buildConfig = {}) => {
   ];
 
   const theme = buildConfig.theme || buildConfig.themePackage;
+
   if (theme) {
     // eslint-disable-next-line no-console
-    console.log(colors.green('Info:'), '使用皮肤包', theme);
-    sassLoaders.push({
-      loader: require.resolve('ice-skin-loader'),
-      options: {
-        themeFile: path.join(paths.appNodeModules, `${theme}/variables.scss`),
-      },
-    });
+    console.log(colors.green('Info:'), '使用主题包', theme);
   }
+
+  sassLoaders.push({
+    loader: require.resolve('ice-skin-loader'),
+    options: {
+      themeFile: theme && path.join(paths.appNodeModules, `${theme}/variables.scss`),
+      themeConfig,
+    },
+  });
 
   // refs: https://github.com/webpack-contrib/mini-css-extract-plugin
   const miniCssExtractPluginLoader = { loader: MiniCssExtractPlugin.loader };

--- a/tools/ice-scripts/lib/config/webpack.config.basic.js
+++ b/tools/ice-scripts/lib/config/webpack.config.basic.js
@@ -65,7 +65,7 @@ module.exports = function getWebpackConfigBasic({ entry, buildConfig = {} }) {
         ? { react: 'window.React', 'react-dom': 'window.ReactDOM' }
         : {},
     module: {
-      rules: getRules(buildConfig),
+      rules: getRules(buildConfig, themeConfig),
     },
     plugins: getPlugins({ entry, buildConfig, themeConfig }),
     optimization: {

--- a/tools/ice-scripts/lib/dev.js
+++ b/tools/ice-scripts/lib/dev.js
@@ -27,6 +27,7 @@ const openBrowser = require('react-dev-utils/openBrowser');
 /* eslint no-console:off */
 
 module.exports = async function(args, subprocess) {
+
   // 与 iceworks 客户端通信
   const send = function(data) {
     iceworksClient.send(data);

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.7.9",
+  "version": "1.8.0",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {
@@ -62,7 +62,6 @@
     "copy-webpack-plugin": "4.5.3",
     "css-hot-loader": "1.4.2",
     "css-loader": "1.0.1",
-    "css-prefix-plugin": "^0.0.1",
     "debug": "4.0.1",
     "decamelize": "^2.0.0",
     "deep-assign": "2.0.0",
@@ -73,7 +72,7 @@
     "gulp": "3.9.1",
     "html-webpack-plugin": "3.2.0",
     "http-proxy-middleware": "0.19.0",
-    "ice-skin-loader": "0.1.5",
+    "ice-skin-loader": "0.2.0",
     "inquirer": "5.2.0",
     "less": "3.8.1",
     "less-loader": "4.1.0",

--- a/tools/ice-skin-loader/README.md
+++ b/tools/ice-skin-loader/README.md
@@ -2,23 +2,26 @@
 
 定制 ICE 主题：
 
-- 根据 `themeFile` 参数获取对应的 sass 变量覆盖默认的变量
-- 根据项目目录的 `package.json` 里的 theme 字段定制自定义 sass 变量
+- 根据 `themeFile` 获取对应的 sass 变量覆盖默认的组件变量
+- 根据 `themeConfig` 自定义变量
   - 根据 `primary-color` `secondary-color` 计算出相关的品牌色
   - 根据 `icon-font-path`, `icon-font-name`, `font-custom-path` 实现图标和字体本件的本地化
-  - 其他变量自定义
-
+  - 根据 nextPrefix 实现更改 next 1.x 的 css 前缀
+  - 其他单个变量覆盖
 
 ## 使用
 
-- 通过 `themeFile` 参数传入变量文件
-- 在项目目录下 package.json 的 `themeConfig` 中定义相关 sass 变量
-
 ```js
-loaders.push({
+{
   loader: require.resolve('ice-skin-loader'),
   options: {
-    themeFile: path.join(__diranme, `variables.scss`),
+    themeFile: path.join(appName, `variables.scss`),
+    themeConfig: {
+      nextPrefix: 'nextfd-',
+      'primary-color': 'green',
+      'secondary-color': 'green',
+      'icon-font-path': '@xxxx'
+    }
   }
-});
+};
 ```

--- a/tools/ice-skin-loader/README.md
+++ b/tools/ice-skin-loader/README.md
@@ -1,2 +1,24 @@
-# Ice Skin Loader
-> 提供皮肤支持
+# ice-skin-loader
+
+定制 ICE 主题：
+
+- 根据 `themeFile` 参数获取对应的 sass 变量覆盖默认的变量
+- 根据项目目录的 `package.json` 里的 theme 字段定制自定义 sass 变量
+  - 根据 `primary-color` `secondary-color` 计算出相关的品牌色
+  - 根据 `icon-font-path`, `icon-font-name`, `font-custom-path` 实现图标和字体本件的本地化
+  - 其他变量自定义
+
+
+## 使用
+
+- 通过 `themeFile` 参数传入变量文件
+- 在项目目录下 package.json 的 `themeConfig` 中定义相关 sass 变量
+
+```js
+loaders.push({
+  loader: require.resolve('ice-skin-loader'),
+  options: {
+    themeFile: path.join(__diranme, `variables.scss`),
+  }
+});
+```

--- a/tools/ice-skin-loader/lib/createSkinExtraContent.js
+++ b/tools/ice-skin-loader/lib/createSkinExtraContent.js
@@ -27,15 +27,16 @@ function getVariableMappingString(key, value) {
 
   switch (key) {
     case 'primary-color':
+      // 根据用户配置动态计算主品牌色相关的多个变量
       return primaryColor(value);
     case 'secondary-color':
+      // 根据用户配置动态计算次品牌色相关的多个变量
       return secondaryColor(value);
-
     case 'icon-font-path':
     case 'icon-font-name':
     case 'font-custom-path':
+      // 根据用户配置覆盖变量
       return `$${key}: ${JSON.stringify(value)};`;
-
     default:
       if (/icon\-content\-/.test(key)) {
         return `$${key}: ${JSON.stringify(value)};`;

--- a/tools/ice-skin-loader/lib/index.js
+++ b/tools/ice-skin-loader/lib/index.js
@@ -1,49 +1,53 @@
-const chalk = require('chalk');
 const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
 const loaderUtils = require('loader-utils');
-const md5 = require('md5');
-const pathExists = require('path-exists');
-const createSkinExtraContent = require('./createSkinExtraContent');
+const generateVarsByThemeConfig = require('./generateVarsByThemeConfig');
 
-const skinContentCache = {};
+let themeFileVars = '';
+let themeConfigVars = '';
+
+module.exports = function (source) {
+  const options = loaderUtils.getOptions(this);
+  const { themeFile, themeConfig } = options;
+  const modulePath = path.relative(this.rootContext, this.resourcePath);
+
+  let prefixVars = '';
+  if (themeConfig.nextPrefix && /@alifd\/next\/lib\/(.+).scss$/.test(modulePath)) {
+    // 将 next 1.x 的 prefix 改为 "nextfd-" 前缀
+    prefixVars = `$css-prefix: "${themeConfig.nextPrefix}";`;
+  }
+
+  if (themeFile) {
+    if (!themeFileVars) {
+      try {
+        themeFileVars = deleteEmptyLine(fs.readFileSync(themeFile).toString());
+      } catch (err) {
+        console.log(chalk.red('\n[Error] 不存在主题文件：'), themeFile, err);
+        // 防止重复读取不存在的文件
+        themeFileVars = '  ';
+      }
+    }
+  }
+
+  try {
+    themeConfigVars = themeConfigVars || generateVarsByThemeConfig(themeConfig);
+  } catch (err) {
+    console.error(chalk.red('\n[Error] generateVarsByThemeConfig 出错'), err);
+    themeConfigVars = '  ';
+  }
+
+  // 权重 themeConfigVars > themeFileVars > source
+  return `${themeFileVars}\n${themeConfigVars}\n${prefixVars}\n${source}`;
+};
+
 
 // delete empty lines
 function deleteEmptyLine(str) {
-  const filterLines = str.split('\n').filter(function(line) {
+  const filterLines = str.split('\n').filter((line) => {
     return line !== '';
   });
 
   filterLines.push('');
   return filterLines.join('\n');
 }
-
-// 根据 package.json 配置生成自定义变量
-const extraContent = createSkinExtraContent();
-
-module.exports = function(source) {
-  const options = loaderUtils.getOptions(this);
-  const themeFile = options.themeFile;
-  if (!themeFile) {
-    return source;
-  }
-
-  // 计算 md5 值，避免中文路径的问题
-  const filePathHash = md5(themeFile);
-  let themeFileContent;
-
-  if (skinContentCache.hasOwnProperty(filePathHash)) {
-    // 读取缓存
-    themeFileContent = skinContentCache[filePathHash];
-  } else if (pathExists.sync(themeFile)) {
-    // 读取文件
-    themeFileContent = fs.readFileSync(themeFile).toString();
-    skinContentCache[filePathHash] = deleteEmptyLine(themeFileContent);
-  } else {
-    // 文件不存在
-    console.log(chalk.red('\n[Error] 不存在皮肤文件:'), themeFile);
-    themeFileContent = '';
-    skinContentCache[filePathHash] = '';
-  }
-
-  return themeFileContent + '\n' + extraContent + '\n' + source;
-};

--- a/tools/ice-skin-loader/lib/index.js
+++ b/tools/ice-skin-loader/lib/index.js
@@ -14,7 +14,7 @@ module.exports = function (source) {
 
   let prefixVars = '';
   if (themeConfig.nextPrefix && /@alifd\/next\/lib\/(.+).scss$/.test(modulePath)) {
-    // 将 next 1.x 的 prefix 改为 "nextfd-" 前缀
+    // 将 next 1.x 的 prefix 从 next- 改为自定义前缀，解决 0.x&1.x 混用的问题
     prefixVars = `$css-prefix: "${themeConfig.nextPrefix}";`;
   }
 
@@ -37,7 +37,7 @@ module.exports = function (source) {
     themeConfigVars = '  ';
   }
 
-  // 权重 themeConfigVars > themeFileVars > source
+  // 权重 prefixVars > themeConfigVars > themeFileVars > source
   return `${themeFileVars}\n${themeConfigVars}\n${prefixVars}\n${source}`;
 };
 

--- a/tools/ice-skin-loader/package.json
+++ b/tools/ice-skin-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-skin-loader",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "ice skin loader",
   "main": "lib/index.js",
   "keywords": [
@@ -10,11 +10,9 @@
   "license": "MIT",
   "dependencies": {
     "@icedesign/skin": "^0.1.13",
-    "chalk": "^2.3.0",
+    "chalk": "^2.4.1",
     "kebab-case": "^1.0.0",
     "loader-utils": "^1.1.0",
-    "md5": "^2.2.1",
-    "path-exists": "^3.0.0",
     "tinycolor2": "^1.4.1"
   },
   "publishConfig": {


### PR DESCRIPTION
## 改动点

- 不删除 `import variables.scss` 语句，不确定之前为什么这么做，事实上是有副作用的，比如主题包里的变量不全
- 取代 css-prefix-plugin 的功能，发布后删除 css-prefix 这个包
  - 将配置从 buildConfig 移到 themeConfig 打脸x1
  - 考虑到需要结合 configProvider，用户还是得自定义 prefix，所以讲原先的 bool 改回 string，打脸x2
- themeConfig 由 ice-scripts 传入，loader 自己读文件不合理
- 修复没有 theme 就不进 skin-loader 的 bug
- 代码重构&补充文档

## 发布

- ice-scripts 1.7.9 -> 1.8.0
- ice-skin-loader 0.1.0 -> 0.2.0
