### PR TITLE
feat: ice-scripts build support sourcemap

### DIFF
--- a/tools/ice-scripts/bin/ice-build.js
+++ b/tools/ice-scripts/bin/ice-build.js
@@ -9,6 +9,7 @@ const optionsAttachToEnv = require('../lib/utils/optionsAttachToEnv');
 program
   .option('--debug', 'debug 模式下不压缩')
   .option('--hash', '构建后的资源带 hash 版本')
+  .option('--sourcemap <type>', '构建后的资源带 sourcemap 文件', /^([a-z-]*source-map|eval|none)$/i, 'none')
   .option('--project-type <type>', '项目类型, node|web', /^(node|web)$/i, 'web')
   .option('-s, --skip-install', '跳过安装依赖')
   .option(

--- a/tools/ice-scripts/lib/config/webpack.config.prod.js
+++ b/tools/ice-scripts/lib/config/webpack.config.prod.js
@@ -8,11 +8,12 @@ module.exports = function getWebpackConfigProd({ entry, buildConfig }) {
   const baseConfig = getWebpackConfigBasic({ entry, buildConfig });
 
   return webpackMerge(baseConfig, {
-    devtool: 'none',
+    devtool: process.env.SOURCEMAP || 'none',
     optimization: {
       minimize: !process.env.DEBUG,
       minimizer: [
         new UglifyJsPlugin({
+          sourceMap: true,
           cache: true,
           parallel: true,
           uglifyOptions: {


### PR DESCRIPTION
前端监控系统在线上js报错后往往需要sourcemap文件用来精确定位错误。
但是发现ice build中的devtool被写死成none
现希望能放开该配置项