### PR TITLE
修复依赖缺失问题

### DIFF
--- a/tools/ice-devtools/CHANGELOG.md
+++ b/tools/ice-devtools/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ice-scripts Changelog
 
+## 2.0.7
+- [bugfix] 修复依赖缺失问题
+
 ## 2.0.6
 - [bugfix] 修复 generate 时报 babel-core 找不到的问题
 - [bugfix] 添加 file-loader, 解决大图片的加载失败问题

--- a/tools/ice-devtools/CHANGELOG.md
+++ b/tools/ice-devtools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ice-scripts Changelog
 
-## 2.0.7
+## 2.0.8
 - [bugfix] 修复依赖缺失问题
 
 ## 2.0.6

--- a/tools/ice-devtools/package.json
+++ b/tools/ice-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-devtools",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "ice 物料开发者工具",
   "main": "bin/ice-devtools.js",
   "bin": {

--- a/tools/ice-devtools/package.json
+++ b/tools/ice-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-devtools",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "ice 物料开发者工具",
   "main": "bin/ice-devtools.js",
   "bin": {
@@ -36,6 +36,9 @@
     "async": "^2.6.1",
     "babel-loader": "^8.0.5",
     "babel-plugin-import": "^1.11.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-lib-import": "^0.1.0",
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
     "consolidate": "^0.15.1",


### PR DESCRIPTION
原因： 本地 link 测试 ice-devtools 时，依赖找到了上一级（ice）的 node_modules 下，所以没有暴露依赖缺失的问题。

解决方案：正式发布前先发beta验证