### PR TITLE
fix: turn off source maps by default

### DIFF
--- a/tools/ice-scripts/CHANGELOG.md
+++ b/tools/ice-scripts/CHANGELOG.md
@@ -1,8 +1,12 @@
 # ice-scripts Changelog
 
+## 1.8.3
+
+- [fix] 修复默认开启 UglifyJsPlugin sourceMap 引起的内存溢出问题，更新为默认关闭 sourceMap
+
 ## 1.8.2
 
-- [chore] 降级  webpack-plugin-import 到 0.2.1 解决部分组件样式引入失败的问题
+- [chore] 降级 webpack-plugin-import 到 0.2.1 解决部分组件样式引入失败的问题
 
 ## 1.8.1
 
@@ -23,7 +27,7 @@
 
 ## 1.7.8
 
-- [chore] dev模式下第一次编译成功后自动用本地浏览器打开对应地址
+- [chore] dev 模式下第一次编译成功后自动用本地浏览器打开对应地址
 
 ## 1.7.7
 

--- a/tools/ice-scripts/lib/config/getRules.js
+++ b/tools/ice-scripts/lib/config/getRules.js
@@ -34,7 +34,7 @@ const CSS_MODULE_CONF = {
   options: {
     sourceMap: true,
     modules: true,
-    localIdentName: '[folder]--[local]--[hash:base64:7]'
+    localIdentName: '[folder]--[local]--[hash:base64:7]',
   },
 };
 module.exports = (buildConfig = {}, themeConfig) => {
@@ -52,7 +52,6 @@ module.exports = (buildConfig = {}, themeConfig) => {
     },
   ];
 
-
   const theme = buildConfig.theme || buildConfig.themePackage;
 
   if (theme) {
@@ -63,13 +62,22 @@ module.exports = (buildConfig = {}, themeConfig) => {
   const iceThemeLoaderConf = {
     loader: require.resolve('ice-skin-loader'),
     options: {
-      themeFile: theme && path.join(paths.appNodeModules, `${theme}/variables.scss`),
+      themeFile:
+        theme && path.join(paths.appNodeModules, `${theme}/variables.scss`),
       themeConfig,
     },
   };
 
-  const sassLoaderConf = [CSS_LOADER_CONF, ...sassLoadersConf, iceThemeLoaderConf];
-  const sassModuleConf = [CSS_MODULE_CONF, ...sassLoadersConf, iceThemeLoaderConf];
+  const sassLoaderConf = [
+    CSS_LOADER_CONF,
+    ...sassLoadersConf,
+    iceThemeLoaderConf,
+  ];
+  const sassModuleConf = [
+    CSS_MODULE_CONF,
+    ...sassLoadersConf,
+    iceThemeLoaderConf,
+  ];
   // refs: https://github.com/webpack-contrib/mini-css-extract-plugin
   const miniCssExtractPluginLoader = { loader: MiniCssExtractPlugin.loader };
 

--- a/tools/ice-scripts/lib/config/webpack.config.prod.js
+++ b/tools/ice-scripts/lib/config/webpack.config.prod.js
@@ -20,7 +20,7 @@ module.exports = function getWebpackConfigProd({ entry, buildConfig }) {
       minimize: !process.env.DEBUG,
       minimizer: [
         new UglifyJsPlugin({
-          sourceMap: process.env.SOURCEMAP !== 'none' || false,
+          sourceMap: process.env.SOURCEMAP && process.env.SOURCEMAP !== 'none',
           cache: true,
           parallel: true,
           uglifyOptions: {

--- a/tools/ice-scripts/lib/config/webpack.config.prod.js
+++ b/tools/ice-scripts/lib/config/webpack.config.prod.js
@@ -1,11 +1,18 @@
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const webpackMerge = require('webpack-merge');
+const colors = require('chalk');
 
 const getWebpackConfigBasic = require('./webpack.config.basic');
 
 module.exports = function getWebpackConfigProd({ entry, buildConfig }) {
   const baseConfig = getWebpackConfigBasic({ entry, buildConfig });
+
+  console.log(
+    colors.green('Info:'),
+    'process.env.SOURCEMAP',
+    process.env.SOURCEMAP
+  );
 
   return webpackMerge(baseConfig, {
     devtool: process.env.SOURCEMAP || 'none',
@@ -13,7 +20,7 @@ module.exports = function getWebpackConfigProd({ entry, buildConfig }) {
       minimize: !process.env.DEBUG,
       minimizer: [
         new UglifyJsPlugin({
-          sourceMap: true,
+          sourceMap: process.env.SOURCEMAP !== 'none' || false,
           cache: true,
           parallel: true,
           uglifyOptions: {

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -98,7 +98,7 @@
     "webpack-dev-server": "3.1.9",
     "webpack-filter-warnings-plugin": "1.2.0",
     "webpack-merge": "4.1.4",
-    "webpack-plugin-import": "0.2.1",
+    "webpack-plugin-import": "0.2.3",
     "webpack-simple-progress-plugin": "0.0.4",
     "webpack-sources": "1.3.0"
   },

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
修复默认开启 UglifyJsPlugin sourceMap 引起的内存溢出问题，更新为默认关闭 sourceMap