### PR TITLE
Update EditorInfoDialog.jsx

### DIFF
--- a/react-materials/blocks/OperationTable/src/EditorInfoDialog.jsx
+++ b/react-materials/blocks/OperationTable/src/EditorInfoDialog.jsx
@@ -56,8 +56,8 @@ class FormDialog extends Component {
                 <span style={styles.label}>标题</span>
               </Col>
               <Col span={18}>
-                <IceFormBinder required max={20} message="当前标题必填">
-                  <Input style={styles.formField} name="title" />
+                <IceFormBinder required max={20} name="title" message="当前标题必填">
+                  <Input style={styles.formField} />
                 </IceFormBinder>
                 <IceFormError name="title" />
               </Col>
@@ -67,11 +67,10 @@ class FormDialog extends Component {
                 <span style={styles.label}>类型</span>
               </Col>
               <Col span={18}>
-                <IceFormBinder>
+                <IceFormBinder name="type">
                   <Select
                     dataSource={typeData}
                     style={styles.formField}
-                    name="type"
                   />
                 </IceFormBinder>
               </Col>


### PR DESCRIPTION
原因： `name`属性需要放在`IceFormBinder`组件上
解决报错： 
```
FormBinderWrapper.js:73 Uncaught Error: The name attribute is required in <FormBinder> component
    at Object.IceFormBinderWrapper._this.getter (FormBinderWrapper.js:73)
    at FormBinder.js:138
    at FormBinder.render (FormBinder.js:140)
    at finishClassComponent (react-dom.development.js:14400)
    at updateClassComponent (react-dom.development.js:14355)
    at beginWork (react-dom.development.js:15222)
    at performUnitOfWork (react-dom.development.js:18789)
    at workLoop (react-dom.development.js:18829)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at replayUnitOfWork (react-dom.development.js:18061)
    at renderRoot (react-dom.development.js:18945)
    at performWorkOnRoot (react-dom.development.js:19809)
    at performWork (react-dom.development.js:19721)
    at performSyncWork (react-dom.development.js:19695)
    at interactiveUpdates$1 (react-dom.development.js:19964)
    at interactiveUpdates (react-dom.development.js:2169)
    at dispatchInteractiveEvent (react-dom.development.js:4878)
```