### PR TITLE
fix: safari 下 input 不能直接被flex布局包裹

### DIFF
--- a/react-materials/scaffolds/ice-design-pro/src/pages/GeneralTable/components/CustomForm/CustomForm.jsx
+++ b/react-materials/scaffolds/ice-design-pro/src/pages/GeneralTable/components/CustomForm/CustomForm.jsx
@@ -41,7 +41,7 @@ class CustomForm extends Component {
         <div style={styles.formItem}>
           <span style={styles.formLabel}>{item.label}：</span>
           <IceFormBinder {...item.formBinderProps}>
-            <Input {...item.componentProps} style={{ width: '100%' }} />
+            <span style={{ width: '100%' }}><Input {...item.componentProps} style={{ width: '100%' }} /></span>
           </IceFormBinder>
           <div style={styles.formError}>
             <IceFormError name={item.formBinderProps.name} />


### PR DESCRIPTION
input 为了支持ie9 使用的是table布局，所以配合的FormItem 也没有用 flex 布局。如果自己写布局要注意这个点。

![image](https://user-images.githubusercontent.com/5189853/53016022-71717100-3487-11e9-9cf9-18f6a189f4fe.png)

