### PR TITLE
fix: 依赖 next 的组件重新构建发版&增加react&react-dom的dev依赖&修复部分组件 export 语法

### DIFF
--- a/react-materials/components/balloon-confirm/package.json
+++ b/react-materials/components/balloon-confirm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/balloon-confirm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ICE 气泡确认框",
   "main": "lib/index.js",
   "files": [
@@ -33,6 +33,10 @@
   "dependencies": {
     "@alifd/next": "^1.x",
     "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "componentConfig": {
     "name": "balloon-confirm",

--- a/react-materials/components/container/package.json
+++ b/react-materials/components/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/container",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "lib/index.js",
   "files": [
@@ -30,8 +30,9 @@
     "@alifd/next": "^1.x",
     "prop-types": "^15.5.8"
   },
-  "typings": "lib/index.d.ts",
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "componentConfig": {
     "name": "container",

--- a/react-materials/components/data-binder/package.json
+++ b/react-materials/components/data-binder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/data-binder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ICE 前后端数据绑定、交互方案",
   "main": "lib/index.js",
   "files": [
@@ -36,7 +36,9 @@
     "body-parser": "^1.15.2",
     "cors": "^2.8.1",
     "express": "^4.14.0",
-    "jsonp": "^0.2.1"
+    "jsonp": "^0.2.1",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "componentConfig": {
     "name": "data-binder",

--- a/react-materials/components/dynamic-icon/package.json
+++ b/react-materials/components/dynamic-icon/package.json
@@ -28,9 +28,7 @@
   "devDependencies": {
     "@alifd/next": "^1.x",
     "copy-to-clipboard": "^3.0.8",
-    "react-copy-to-clipboard": "^5.0.1"
-  },
-  "peerDependencies": {
+    "react-copy-to-clipboard": "^5.0.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"
   },

--- a/react-materials/components/ellipsis/package.json
+++ b/react-materials/components/ellipsis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/ellipsis",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "多行文字控制展示组件",
   "main": "lib/index.js",
   "files": [
@@ -29,6 +29,8 @@
     "@alifd/next": "^1.x"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/react-materials/components/form-binder/package.json
+++ b/react-materials/components/form-binder/package.json
@@ -36,7 +36,9 @@
   "devDependencies": {
     "@icedesign/base": "^0.2.0",
     "@alifd/next": "^1.11.8",
-    "moment": "^2.23.0"
+    "moment": "^2.23.0",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "componentConfig": {
     "name": "form-binder",

--- a/react-materials/components/foundation-symbol/package.json
+++ b/react-materials/components/foundation-symbol/package.json
@@ -25,7 +25,9 @@
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
-    "react-copy-to-clipboard": "^5.0.1"
+    "react-copy-to-clipboard": "^5.0.1",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/react-materials/components/img/package.json
+++ b/react-materials/components/img/package.json
@@ -29,7 +29,9 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@alifd/next": "^1.x"
+    "@alifd/next": "^1.x",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0"

--- a/react-materials/components/img/src/index.js
+++ b/react-materials/components/img/src/index.js
@@ -1,1 +1,3 @@
-export default from './Img';
+import Img from './Img';
+
+export default Img;

--- a/react-materials/components/label/package.json
+++ b/react-materials/components/label/package.json
@@ -28,6 +28,8 @@
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/react-materials/components/label/src/index.js
+++ b/react-materials/components/label/src/index.js
@@ -1,1 +1,3 @@
-export default from './Label';
+import Label from './Label';
+
+export default Label;

--- a/react-materials/components/layout/package.json
+++ b/react-materials/components/layout/package.json
@@ -34,6 +34,8 @@
     "react-dom": "^16.5.0"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "componentConfig": {
     "name": "layout",

--- a/react-materials/components/notification/package.json
+++ b/react-materials/components/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/notification",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "全局展示通知提醒信息。",
   "main": "lib/index.js",
   "files": [
@@ -32,7 +32,10 @@
     "@alifd/next": "^1.x",
     "rc-notification": "^1.4.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
+  },
   "componentConfig": {
     "name": "notification",
     "title": "全局展示通知提醒信息"

--- a/react-materials/components/notification/src/index.js
+++ b/react-materials/components/notification/src/index.js
@@ -1,1 +1,3 @@
-export default from './Notification';
+import Notification from './Notification';
+
+export default Notification;

--- a/react-materials/components/panel/package.json
+++ b/react-materials/components/panel/package.json
@@ -29,6 +29,8 @@
     "@alifd/next": "^1.x"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/react-materials/components/panel/src/index.js
+++ b/react-materials/components/panel/src/index.js
@@ -8,3 +8,8 @@ Panel.Body = Body;
 Panel.Footer = Footer;
 
 export default Panel;
+export {
+  Header,
+  Body,
+  Footer,
+};

--- a/react-materials/components/qrcode/package.json
+++ b/react-materials/components/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/qrcode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "飞冰 二维码组件",
   "main": "lib/index.js",
   "files": [
@@ -35,8 +35,9 @@
     "qrcode.react": "^0.8.0"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
-  "typings": "lib/index.d.ts",
   "componentConfig": {
     "name": "qrcode",
     "title": "二维码组件"

--- a/react-materials/components/styled-menu/package.json
+++ b/react-materials/components/styled-menu/package.json
@@ -29,11 +29,13 @@
     "rc-menu": "^5.0.9",
     "@icedesign/foundation-symbol": "^1.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
+  },
   "peerDependencies": {
     "react": "^16.5.0"
   },
-  "typings": "lib/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/react-materials/components/title/package.json
+++ b/react-materials/components/title/package.json
@@ -32,6 +32,8 @@
     "@alifd/next": "^1.x"
   },
   "devDependencies": {
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/react-materials/components/title/src/index.js
+++ b/react-materials/components/title/src/index.js
@@ -1,1 +1,3 @@
-export default from './Title';
+import Title from './Title';
+
+export default Title;


### PR DESCRIPTION

- 修复 `@alifd/next` 依赖构建错误问题（感觉是因为 ice-devtools@1.x 没支持 `@alifd/next`?），此部分需要重新发版本

![image](https://user-images.githubusercontent.com/2505411/53319634-08b64880-390e-11e9-84ea-9c6232486b5f.png)


![image](https://user-images.githubusercontent.com/2505411/53319621-fc31f000-390d-11e9-816a-09a791cbc414.png)

- 所有组件增加 react+react-dom 的 dev 依赖，不需要发版本
- 改变 `export default from` 语法，ice-devtools@2.x 为什么不支持这个语法正在排查，这部分不需要法版本
