### PR TITLE
fix: 主题包 icons.scss 引入失败问题

### DIFF
--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -88,6 +88,7 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
   let iconScssPath;
   let skinOverridePath;
   let variableFilePath;
+  let themeNextVersion;
 
   if (themePackage) {
     variableFilePath = path.resolve(
@@ -103,12 +104,16 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
       themePackage,
       'override.scss'
     );
+
+    themeNextVersion = (/^@alif(e|d)\/theme-/.test(themePackage) || themePackage === '@icedesign/theme') ? '1.x' : '0.x';
   }
   if (iconScssPath && fs.existsSync(iconScssPath)) {
     const appendStylePluginOption = {
       type: 'sass',
       srcFile: iconScssPath,
       variableFile: variableFilePath,
+      compileThemeIcon: true,
+      themeNextVersion,
       distMatch: (chunkName, compilerEntry, compilationPreparedChunks) => {
         const entriesAndPreparedChunkNames = normalizeEntry(
           compilerEntry,
@@ -142,6 +147,8 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
         // type: 'sass', // 不需要指定 type，与 distMatch 互斥
         srcFile: skinOverridePath,
         distMatch: /\.css/,
+        themeNextVersion,
+        compileThemeIcon: false
       })
     );
   }

--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -2,9 +2,9 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const colors = require('chalk');
 const ExtractCssAssetsWebpackPlugin = require('extract-css-assets-webpack-plugin');
 const fs = require('fs');
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
-const path = require('path');
 const SimpleProgressPlugin = require('webpack-simple-progress-plugin');
 const webpack = require('webpack');
 const WebpackPluginImport = require('webpack-plugin-import');
@@ -104,21 +104,20 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry }) => {
       'override.scss'
     );
   }
-
   if (iconScssPath && fs.existsSync(iconScssPath)) {
     const appendStylePluginOption = {
       type: 'sass',
       srcFile: iconScssPath,
       variableFile: variableFilePath,
       distMatch: (chunkName, compilerEntry, compilationPreparedChunks) => {
-        // TODO
         const entriesAndPreparedChunkNames = normalizeEntry(
           compilerEntry,
           compilationPreparedChunks
         );
         // 仅对 css 的 chunk 做 处理
         if (entriesAndPreparedChunkNames.length && /\.css$/.test(chunkName)) {
-          const assetsFromEntry = chunkName.replace(/\.\w+$/, '');
+          // css/index.css -> index
+          const assetsFromEntry = path.basename(chunkName, path.extname(chunkName));
           if (entriesAndPreparedChunkNames.indexOf(assetsFromEntry) !== -1) {
             return true;
           }

--- a/tools/ice-scripts/lib/plugins/append-style-webpack-plugin.js
+++ b/tools/ice-scripts/lib/plugins/append-style-webpack-plugin.js
@@ -14,7 +14,7 @@ function convertCharStr2CSS(ch) {
   return '\\' + code;
 }
 
-function compileSass(srcPath, variableFile) {
+function compileSass(srcPath, variableFile, coreVarCode) {
   srcPath = String(srcPath);
   let scssContent = '';
   const basePath = path.resolve(srcPath, '..');
@@ -27,7 +27,7 @@ function compileSass(srcPath, variableFile) {
     try {
       const variableFileContent = fs.readFileSync(variableFile, 'utf-8');
       if (variableFileContent) {
-        scssContent = variableFileContent + scssContent;
+        scssContent = variableFileContent + coreVarCode + scssContent;
       }
     } catch (err) {
       // do nothing
@@ -73,6 +73,8 @@ module.exports = class AppendStylePlugin {
     this.type = options.type || 'sass'; // 源文件类型
     this.srcFile = options.srcFile; // 源文件
     this.variableFile = options.variableFile; // scss 变量文件
+    this.compileThemeIcon = options.compileThemeIcon; // 是否为主题的 icons.scss
+    this.themeNextVersion = options.themeNextVersion; // 主题包对应基础组件版本
     this.distMatch =
       options.distMatch instanceof RegExp // chunkName 去匹配的逻辑，正则或者函数
         ? (chunkName) => options.distMatch.test(chunkName)
@@ -86,6 +88,16 @@ module.exports = class AppendStylePlugin {
     const compilerEntry = compiler.options.entry;
     if (!srcFile || !distMatch) {
       return;
+    }
+
+    this.projectPath = compiler.context;
+    if (!this.pkgData) {
+      try {
+        this.pkgData = require(path.resolve(compiler.context, 'package.json'));
+      } catch (err) {
+        console.error('append-style: 获取 package.json 出错', err);
+        this.pkgData = {};
+      }
     }
 
     compiler.hooks.compilation.tap('compilation', (compilation) => {
@@ -127,9 +139,19 @@ module.exports = class AppendStylePlugin {
     }
   }
 
-  compileToCSS(srcFile, variableFile) {
+  compileToCSS(srcFile, themeVariableFile, isIconScss) {
     if (this.type === 'sass') {
-      return compileSass(srcFile, variableFile);
+      const themeConfig = this.pkgData.themeConfig || {};
+      let coreVarCode = '';
+
+      if (this.compileThemeIcon && this.themeNextVersion === '1.x') {
+        // 1.x 主题包的 icons.scss 里使用了 css-prefix 变量，因此这里需要手动声明下
+        // 即便不手动声明，这里也需要支持自定义 css-prefix 能力
+        const cssPrefix = themeConfig['css-prefix'] || 'next-';
+        coreVarCode = `$css-prefix: '${themeConfig['css-prefix']}';`;
+      }
+
+      return compileSass(srcFile, themeVariableFile, coreVarCode);
     }
     let css = '';
     try {

--- a/tools/ice-scripts/lib/plugins/append-style-webpack-plugin.js
+++ b/tools/ice-scripts/lib/plugins/append-style-webpack-plugin.js
@@ -93,7 +93,8 @@ module.exports = class AppendStylePlugin {
     this.projectPath = compiler.context;
     if (!this.pkgData) {
       try {
-        this.pkgData = require(path.resolve(compiler.context, 'package.json'));
+        const pkgPath = path.resolve(compiler.context, 'package.json');
+        this.pkgData = JSON.parse(fs.readFileSync(pkgPath));
       } catch (err) {
         console.error('append-style: 获取 package.json 出错', err);
         this.pkgData = {};
@@ -139,7 +140,7 @@ module.exports = class AppendStylePlugin {
     }
   }
 
-  compileToCSS(srcFile, themeVariableFile, isIconScss) {
+  compileToCSS(srcFile, themeVariableFile) {
     if (this.type === 'sass') {
       const themeConfig = this.pkgData.themeConfig || {};
       let coreVarCode = '';
@@ -148,7 +149,7 @@ module.exports = class AppendStylePlugin {
         // 1.x 主题包的 icons.scss 里使用了 css-prefix 变量，因此这里需要手动声明下
         // 即便不手动声明，这里也需要支持自定义 css-prefix 能力
         const cssPrefix = themeConfig['css-prefix'] || 'next-';
-        coreVarCode = `$css-prefix: '${themeConfig['css-prefix']}';`;
+        coreVarCode = `$css-prefix: '${cssPrefix}';`;
       }
 
       return compileSass(srcFile, themeVariableFile, coreVarCode);


### PR DESCRIPTION
- 修复未编译&追加主题包 icons.scss 问题 https://github.com/alibaba/ice/issues/1478 https://github.com/alibaba/ice/issues/1546
- 兼容 1.x 主题包 icons.scss 使用了 css-prefix 变量但未定义问题
- 编译 icons.scss 支持 `themeConfig.css-prefix`