### PR TITLE
Feat support babel config

### DIFF
--- a/tools/ice-scripts/lib/config/getBabelConfig.js
+++ b/tools/ice-scripts/lib/config/getBabelConfig.js
@@ -75,6 +75,10 @@ module.exports = (buildConfig = {}) => {
       ],
       ['babel-plugin-import', { libraryName: '@alife/next' }, '@alife/next'],
       ['babel-plugin-import', { libraryName: '@alifd/next' }, '@alifd/next'],
+
+      buildConfig.babelPluginImportConfig ? [
+        'babel-plugin-import', buildConfig.babelPluginImportConfig
+      ] : null
     ]),
   };
 };

--- a/tools/ice-scripts/lib/config/getRules.js
+++ b/tools/ice-scripts/lib/config/getRules.js
@@ -146,6 +146,8 @@ module.exports = (buildConfig = {}, themeConfig) => {
           loader: LESS_LOADER,
           options: {
             sourceMap: true,
+            // https://github.com/ant-design/ant-motion/issues/44
+            javascriptEnabled: true,
           },
         },
       ]),

--- a/tools/ice-scripts/lib/config/getRules.js
+++ b/tools/ice-scripts/lib/config/getRules.js
@@ -43,6 +43,14 @@ const CSS_MODULE_CONF = {
 module.exports = (buildConfig = {}, themeConfig) => {
   const babelConfig = getBabelConfig(buildConfig);
 
+  let babelExclude = /node_modules/;
+  if (buildConfig.babelExclude) {
+    // 某个依赖包需要 babel 编译（不同 npm 路径可能不同）：babelExclude: "node_modules\\/(?!_@ali_lib-ucc)"
+    // node_modules 都需要编译：babelExclude: "bower_components"，随便配置一个奇怪的地址覆盖默认值即可
+    babelExclude = new RegExp(buildConfig.babelExclude);
+    console.log(colors.green('Info:'), '配置了 babelExclude，new RegExp() 转化后的值：', babelExclude);
+  }
+
   const theme = buildConfig.theme || buildConfig.themePackage;
   if (theme) {
     // eslint-disable-next-line no-console
@@ -161,14 +169,14 @@ module.exports = (buildConfig = {}, themeConfig) => {
     },
     {
       test: /\.jsx?$/,
-      exclude: /node_modules/,
+      exclude: babelExclude,
       loader: BABEL_LOADER,
       options: deepAssign({}, babelConfig, { cacheDirectory: true }),
     },
     // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'
     {
       test: /\.tsx?$/,
-      exclude: /node_modules/,
+      exclude: babelExclude,
       use: [
         {
           loader: BABEL_LOADER,


### PR DESCRIPTION

- 支持 buildConfig.babelExclude
	- 某个依赖包需要 babel 编译（不同 npm 路径可能不同）：babelExclude: "node_modules\\/(?!_@ali_lib-ucc)"
	- node_modules 都需要编译：babelExclude: "bower_components"，随便配置一个奇怪的地址覆盖默认值即可


- 支持 babelPluginImportConfig，比如：

```
// 支持数组
"babelPluginImportConfig": {
  "libraryName": "antd",
  "libraryDirectory": "es",
  "style": true
}
```