### PR TITLE
feat: optimize monentjs with webpack

### DIFF
--- a/docs/advanced/webpackrc.md
+++ b/docs/advanced/webpackrc.md
@@ -293,12 +293,12 @@ favicon, index.html 等。
 // index.js
 import styles from './index.module.scss';
 
-<Button className={styles.btn}>OK</Button>
+<Button className={styles.btn}>OK</Button>;
 ```
 
 ## Moment.js 优化
 
-基础组件包中将 moment 作为自己的 peerDependencies 而非 dependencies，所以用户需要自己在应用中引入 moment 的 cdn 文件 moment-with-locales.js 或者本地安装 moment 打包进自己的应用。对于后者，由于 moment 在引入 locale 文件时存在这样的代码：require('./locale/' + name)，如果用 webpack 构建，会打包进所有的 locale 文件，增加构建后文件的体积，ice-script 1.8.13 版本内置支持了按需加载多语言配置，在使用多语言包时只需要按照以下方式引用即可：
+基础组件包中将 moment 作为自己的 peerDependencies 而非 dependencies，所以用户需要自己在应用中引入 moment 的 cdn 文件 moment-with-locales.js 或者本地安装 moment 打包进自己的应用。对于后者，由于 moment 在引入 locale 文件时存在这样的代码：`require('./locale/' + name)`，如果用 webpack 构建，会打包进所有的 locale 文件，增加构建后文件的体积，ice-script 1.8.13 版本内置支持了按需加载多语言配置，在使用多语言包时只需要按照以下方式引用即可：
 
 ```
 // index.js

--- a/docs/advanced/webpackrc.md
+++ b/docs/advanced/webpackrc.md
@@ -296,6 +296,16 @@ import styles from './index.module.scss';
 <Button className={styles.btn}>OK</Button>
 ```
 
+## Moment.js 优化
+
+基础组件包中将 moment 作为自己的 peerDependencies 而非 dependencies，所以用户需要自己在应用中引入 moment 的 cdn 文件 moment-with-locales.js 或者本地安装 moment 打包进自己的应用。对于后者，由于 moment 在引入 locale 文件时存在这样的代码：require('./locale/' + name)，如果用 webpack 构建，会打包进所有的 locale 文件，增加构建后文件的体积，ice-script 1.8.13 版本内置支持了按需加载多语言配置，在使用多语言包时只需要按照以下方式引用即可：
+
+```
+// index.js
+
+import 'moment/locale/xx.js';
+```
+
 ## 主题配置 - themeConfig
 
 参考 [切换项目主题](#/docs/advanced/use-theme)

--- a/docs/advanced/webpackrc.md
+++ b/docs/advanced/webpackrc.md
@@ -296,9 +296,9 @@ import styles from './index.module.scss';
 <Button className={styles.btn}>OK</Button>;
 ```
 
-## Moment.js 优化
+## Moment.js 按需加载
 
-基础组件包中将 moment 作为自己的 peerDependencies 而非 dependencies，所以用户需要自己在应用中引入 moment 的 cdn 文件 moment-with-locales.js 或者本地安装 moment 打包进自己的应用。对于后者，由于 moment 在引入 locale 文件时存在这样的代码：`require('./locale/' + name)`，如果用 webpack 构建，会打包进所有的 locale 文件，增加构建后文件的体积，ice-script 1.8.13 版本内置支持了按需加载多语言配置，在使用多语言包时只需要按照以下方式引用即可：
+基础组件 `@alifd/next` 里的时间相关组件依赖了 moment，但是为了业务可以优化 moment 的包大小，所以 `@alifd/next` 里将 moment 作为自己的 peerDependencies 而非 dependencies，因此项目使用到时间组件时需要自行引入 moment 依赖。moment 里有针对国际化语言的大量代码，如果不做任何处理的话会导致 bundle 变大，因此 ice-scripts 默认对 moment 文案做了按需加载，只有通过 `import './locale/zh-cn'` 才会引入对应文案代码。
 
 ```
 // index.js

--- a/tools/ice-scripts/CHANGELOG.md
+++ b/tools/ice-scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.13
+
+- [feat] 只打包有过引用的 moment 语言文件
+
 ## 1.8.12
 
 - [fix] 修复 proxy target 语法错误

--- a/tools/ice-scripts/lib/config/getPlugins.js
+++ b/tools/ice-scripts/lib/config/getPlugins.js
@@ -70,6 +70,11 @@ module.exports = ({ buildConfig = {}, themeConfig = {}, entry, pkg = {} }) => {
         stylePath: 'style.js',
       },
     ]),
+    // Moment.js is an extremely popular library that bundles large locale files
+    // by default due to how Webpack interprets its code. This is a practical
+    // solution that requires the user to opt into importing specific locales.
+    // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
   ];
 
   // 增加 html 输出，支持多页面应用

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## 问题
1. 没有使用时间组件的不应该打包 momentjs
2. 使用了时间组件也不应该全量打包 momentjs 的所有 locale

## 方案

1. 没有使用时间组件的模板去掉 moment 依赖，只有在使用时用户按需添加，这个体验能接受，用户可以 CDN 或者本地构建的方式，比较自由，另外组件层面也给出了提示

![image](https://user-images.githubusercontent.com/3995814/54198486-947cc700-4501-11e9-9a30-754a0e5185c8.png)


2. 通过配置 `new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)` 插件可支持按需加载


## 测试

**之前：**
![image](https://user-images.githubusercontent.com/3995814/54198577-cc840a00-4501-11e9-9e2b-0fec83159f95.png)


**现在：**
![image](https://user-images.githubusercontent.com/3995814/54198581-d0b02780-4501-11e9-9816-a6611e07c244.png)

