### PR TITLE
[iceworks]builtin-materials-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tools/extract-css-assets-webpack-plugin/lib/
 !tools/iceworks/build
 tools/iceworks/out
 tools/iceworks/dist
+tools/iceworks/renderer/src/datacenter/data

--- a/tools/iceworks/gulpfile.js
+++ b/tools/iceworks/gulpfile.js
@@ -14,6 +14,7 @@ const shelljs = require('shelljs');
 const spawn = require('cross-spawn');
 const UglifyJS = require('uglify-es');
 const writeFile = require('write');
+const request = require('request');
 
 const colors = gutil.colors;
 const isMac = process.platform === 'darwin';
@@ -138,22 +139,21 @@ async function getUpload2oss() {
       '=>',
       paths.join('/')
     );
-  
+
     return co(iceworksStore.put(paths.join('/'), file))
       .then((object = {}) => {
         if (object.res && object.res.status == 200) {
           gutil.log(colors.green('上传成功'), object.url);
           return 0;
-        } else {
-          gutil.log(colors.red('上传失败'), file);
-          return 1;
         }
+        gutil.log(colors.red('上传失败'), file);
+        return 1;
       })
       .catch(() => {
         gutil.log(colors.red('上传失败'), file);
         return 1;
       });
-  }
+  };
 }
 
 gulp.task('compile:after:css', ['compile:prod'], () => {
@@ -290,7 +290,7 @@ gulp.task('dist:win', (done) => {
     }
   );
   ls.on('close', (code) => {
-    if (code == 0) {
+    if (code === 0) {
       gutil.log(colors.green('exe 打包完成'));
     } else {
       gutil.log(colors.red('exe 打包失败'));
@@ -448,7 +448,7 @@ gulp.task('dist', () => {
   }
 });
 
-gulp.task('oss', async function() {
+gulp.task('oss', async () => {
   const upload2oss = await getUpload2oss();
 
   const version = require('./out/package.json').version;
@@ -517,33 +517,66 @@ gulp.task('oss-log', async () => {
   const upload2oss = await getUpload2oss();
   const version = require('./out/package.json').version;
   const productNameLowCase = productName.toLowerCase();
-  const filepaths = [{
-    from: 'dist/updates.json', // iceworks 下的相对路径
-    to: ['updates.json'] // oss 对应 bucket 下的相对路径
-  }, {
-    from: 'changelog/changelog.json',
-    to: ['changelog.json']
-  }, {
-    from: `changelog/${version}.json`,
-    to: [`changelog/${version}.json`]
-  }, {
-    from: 'dist/updates.json',
-    to: ['assets', `${productNameLowCase}-updates.json`]
-  }, {
-    from: 'changelog/changelog.json',
-    to: ['assets', `${productNameLowCase}-changelog.json`]
-  }];
+  const filepaths = [
+    {
+      from: 'dist/updates.json', // iceworks 下的相对路径
+      to: ['updates.json'], // oss 对应 bucket 下的相对路径
+    },
+    {
+      from: 'changelog/changelog.json',
+      to: ['changelog.json'],
+    },
+    {
+      from: `changelog/${version}.json`,
+      to: [`changelog/${version}.json`],
+    },
+    {
+      from: 'dist/updates.json',
+      to: ['assets', `${productNameLowCase}-updates.json`],
+    },
+    {
+      from: 'changelog/changelog.json',
+      to: ['assets', `${productNameLowCase}-changelog.json`],
+    },
+  ];
   // 上传
-  filepaths.forEach( async filepath => {
+  filepaths.forEach(async (filepath) => {
     const fromDir = path.join(__dirname, filepath.from);
     const code = await upload2oss(filepath.to, fromDir);
     if (code !== 0) {
-      gutil.log( colors.red(`${fromDir} => ${filepath.to.join('/')} error`) );
+      gutil.log(colors.red(`${fromDir} => ${filepath.to.join('/')} error`));
     }
   });
-
-})
+});
 
 gulp.task('build-dist', ['build'], () => {
   gulp.start(['dist']);
+});
+
+// 同步官网物料数据
+gulp.task('sync-db', () => {
+  request(
+    {
+      url: 'https://ice.alicdn.com/assets/react-materials.json',
+      json: true,
+    },
+    (error, response, body) => {
+      if (body) {
+        const distDir = path.join(
+          __dirname,
+          'renderer',
+          'src',
+          'datacenter',
+          'react-materials.json'
+        );
+        writeFile(distDir, JSON.stringify(body, null, 2))
+          .then(() => {
+            console.log('同步物料 db 数据完成');
+          })
+          .catch((err) => {
+            console.log('同步物料 db 数据出错:', err);
+          });
+      }
+    }
+  );
 });

--- a/tools/iceworks/package.json
+++ b/tools/iceworks/package.json
@@ -16,6 +16,7 @@
     "updates": "gulp publish",
     "upload": "gulp oss",
     "upload-log": "gulp oss-log",
+    "sync-db": "gulp sync-db",
     "lint": "npm run lint:render && npm run lint:main",
     "lint:render": "eslint -c ./.eslintrc ./renderer/src --fix",
     "lint:main": "eslint -c ./.eslintrc ./app/main --fix",

--- a/tools/iceworks/package.json
+++ b/tools/iceworks/package.json
@@ -93,6 +93,8 @@
     "postcss-loader": "^2.1.5",
     "react-dev-utils": "^5.0.1",
     "react-hot-loader": "^4.3.2",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.0.3",
     "shelljs": "^0.8.1",

--- a/tools/iceworks/renderer/src/stores/materials.js
+++ b/tools/iceworks/renderer/src/stores/materials.js
@@ -11,8 +11,11 @@ import AdditionalComponents from './additional-components';
 import filterMaterial from '../lib/filter-material';
 import { isIceMaterial } from '../lib/utils';
 import services from '../services';
-import history from '../history';
 import projects from './projects';
+
+const BUILTIN_DATA = require('../datacenter/react-materials');
+
+console.log('BUILT_IN_DATA:', BUILTIN_DATA);
 
 const { settings, shared } = services;
 
@@ -29,6 +32,9 @@ class Materials {
   tabComponentActiveKey = '';
   @observable
   startRecommendMaterials = {};
+
+  // 是否启用内置的物料数据
+  useBuiltinData = false;
 
   constructor() {
     // 加载物料数据
@@ -126,112 +132,111 @@ class Materials {
   @action
   loadStartRecommendMaterials() {
     const recommendMaterialSource = settings.get('materials')[0];
-    const isMaterialsBackup = settings.get('isMaterialsBackup');
     const startRecommendMaterials = this.startRecommendMaterials;
-    const source = isMaterialsBackup ? recommendMaterialSource.backupSource : recommendMaterialSource.source;
+    const fn = (data) => {
+      const scaffolds = data.scaffolds || [];
+      const { startRecommendScaffolds } = new AdditionalScaffolds(scaffolds);
+      startRecommendMaterials.scaffolds = startRecommendScaffolds || [];
+      startRecommendMaterials.loaded = true;
+      startRecommendMaterials.error = null;
+    };
 
-    this.fetchByMaterial(source)
-      .then((body = {}) => {
-        const scaffolds = body.scaffolds || [];
-        const { startRecommendScaffolds } = new AdditionalScaffolds(scaffolds);
-
-        startRecommendMaterials.scaffolds = startRecommendScaffolds || [];
-        startRecommendMaterials.loaded = true;
-        startRecommendMaterials.error = null;
-      })
-      .catch((error) => {
-        // 如果alicdn物料源访问超时 切换备份物料源
-        if (
-          error.code &&
-          (error.code === 'ETIMEDOUT' || error.code === 'ESOCKETTIMEDOUT')
-        ) {
-          if (!isMaterialsBackup) {
-            settings.set('isMaterialsBackup', true);
+    if (!this.useBuiltinData) {
+      this.fetchByMaterial(recommendMaterialSource.source)
+        .then((body = {}) => {
+          fn(body);
+        })
+        .catch(() => {
+          if (!this.useBuiltinData) {
+            this.useBuiltinData = true;
             this.loadStartRecommendMaterials();
           } else {
             startRecommendMaterials.loaded = true;
-            startRecommendMaterials.error = `物料源加载失败，请确认网络是否能直接访问此链接 ${source}，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题`;
+            startRecommendMaterials.error =
+              '物料源加载失败，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题';
           }
-        } else {
-          startRecommendMaterials.loaded = true;
-          startRecommendMaterials.error = '物料源加载失败，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题';
-        }
-      });
-  }
-
-  switchToBackupMaterials(fn = () => {}) {
-    settings.set('isMaterialsBackup', true);
-    fn();
+        });
+    } else {
+      fn(BUILTIN_DATA);
+    }
   }
 
   @action
   loaderMaterial(index) {
     const material = this.materials[index];
     if (!material) return;
-    const isMaterialsBackup = settings.get('isMaterialsBackup');
-    const source = (isMaterialsBackup && material.backupSource) ? material.backupSource : material.source;
+    const source = material.source;
+    const fn = (data, iceBaseComponents) => {
+      const {
+        blocks = [],
+        scaffolds = [],
+        components = [],
+        name,
+        ...attrs
+      } = data;
 
-    if (material && !material.loaded) {
-      let promiseAll;
-      if (isIceMaterial(material.source)) {
-        // HACK: 获取 ICE 物料源时一同获取基础组件数据
-        const { currentProject } = projects;
-        const iceVersion = currentProject ? currentProject.iceVersion : '1.x';
-        const { iceBaseMaterials } = shared;
-        const iceBaseMaterial = iceVersion === '0.x' ? iceBaseMaterials[0] : iceBaseMaterials[1];
-
-        promiseAll = Promise.all([
-          this.fetchByMaterial(source),
-          this.fetchByMaterial(iceBaseMaterial.source).catch((err) => {
-            // 获取基础组件列表失败，不终止流程
-            material.componentsError = `基础组件列表加载失败，请确认网络是否能直接访问此链接 ${iceBaseMaterial.source}，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题`;
-            return null;
-          }),
-        ]);
-      } else {
-        promiseAll = Promise.all([
-          this.fetchByMaterial(source),
-        ]);
-      }
-
-      promiseAll.then(([
-        body = {},
-        iceBaseComponents,
-      ]) => {
-        const {
-          blocks = [],
-          scaffolds = [],
-          components = [],
-          name,
-          ...attrs
-        } = body;
-
-        Object.keys(attrs).forEach((key) => {
-          material[key] = attrs[key];
-        })
-
-        // 双向绑定数据
-        material.blocks = new AdditionalBlocks(blocks);
-        material.scaffolds = new AdditionalScaffolds(scaffolds, material);
-
-        // if (iceBaseComponents) {
-          material.components = new AdditionalComponents(components, material, iceBaseComponents);
-        // }
-
-        material.loaded = true;
-        material.data = body;
-        material.error = null;
-      }).catch((error) => {
-        console.error('promiseAll.then error', error);
-        if (!isMaterialsBackup) {
-          settings.set('isMaterialsBackup', true);
-          this.loaderMaterial(index);
-        } else {
-          material.loaded = true;
-          const errMsg = `物料源加载失败，请确认网络是否能直接访问此链接 ${source}，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题`;
-          material.error = errMsg;
-        }
+      Object.keys(attrs).forEach((key) => {
+        material[key] = attrs[key];
       });
+
+      // 双向绑定数据
+      material.blocks = new AdditionalBlocks(blocks);
+      material.scaffolds = new AdditionalScaffolds(scaffolds, material);
+      material.components = new AdditionalComponents(
+        components,
+        material,
+        iceBaseComponents
+      );
+
+      material.loaded = true;
+      material.data = data;
+      material.error = null;
+    };
+
+    if (!this.useBuiltinData) {
+      if (material && !material.loaded) {
+        let promiseAll;
+        if (isIceMaterial(material.source)) {
+          // HACK: 获取 ICE 物料源时一同获取基础组件数据
+          // 因为 ICE 物料源会有一份单独的基础组件数据，其他的没有？
+          const { currentProject } = projects;
+          const iceVersion = currentProject ? currentProject.iceVersion : '1.x';
+          const { iceBaseMaterials } = shared;
+          const iceBaseMaterial =
+            iceVersion === '0.x' ? iceBaseMaterials[0] : iceBaseMaterials[1];
+
+          promiseAll = Promise.all([
+            this.fetchByMaterial(source),
+            this.fetchByMaterial(iceBaseMaterial.source).catch(() => {
+              // 获取基础组件列表失败，不终止流程
+              material.componentsError = `基础组件列表加载失败，请确认网络是否能直接访问此链接 ${
+                iceBaseMaterial.source
+              }，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题`;
+              return null;
+            }),
+          ]);
+        } else {
+          promiseAll = Promise.all([this.fetchByMaterial(source)]);
+        }
+
+        promiseAll
+          .then(([body = {}, iceBaseComponents]) => {
+            fn(body, iceBaseComponents);
+          })
+          .catch((error) => {
+            console.error('promiseAll.then error', error);
+            if (!this.useBuiltinData && isIceMaterial(material.source)) {
+              this.useBuiltinData = true;
+              this.loaderMaterial(index);
+            } else {
+              material.loaded = true;
+              const errMsg = `物料源加载失败，请确认网络是否能直接访问此链接 ${source}，建议将此问题反馈给飞冰（ICE）团队，在菜单中点击: 帮助 => 反馈问题`;
+              material.error = errMsg;
+            }
+          });
+      }
+    } else {
+      fn(BUILTIN_DATA);
     }
   }
 
@@ -272,7 +277,11 @@ class Materials {
       const material = this.materials[index];
       const components = material.components.iceBusinessComponents;
       const iceBaseComponents = material.components.iceBaseComponents;
-      material.components = new AdditionalComponents(components, material, iceBaseComponents);
+      material.components = new AdditionalComponents(
+        components,
+        material,
+        iceBaseComponents
+      );
     }
   }
 }


### PR DESCRIPTION
## iceworks 物料数据源问题
目前官方物料源都托管在 `ice.alicdn.com` 下，很多用户特定网络会屏蔽这个域名导致物料源加载失败，因此整个 Iceworks 对用户不可用

## 数据同步 jsdelivr 方案
对官方物料源加了一个 backup 的 url，backup url 来自于：通过 npm 包将物料源数据同步发包，然后访问 `https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/react-materials.json"`，结合日志发现部分用户这个地址还是无法访问

## 内置数据源兜底方案（最终方案）
将所有官方维护的数据源（oss 上）添加到 Iceworks 代码里作为终极兜底方案。缺点是数据可能不是最新的，但一定能保证 Iceworks 的可用性。通过构建命令触发同步所有 oss 上的数据到指定代码文件夹，保证每次发版时会更新一次数据，获取数据的逻辑：`ice.alicdn.com`  -> `iceworks builtin data`