### PR TITLE
[iceworks] default use of system environment

### DIFF
--- a/tools/iceworks/app/main/env.js
+++ b/tools/iceworks/app/main/env.js
@@ -12,13 +12,17 @@ const { APP_BIN_PATH, SASS_BINARY_PATH } = require('./paths');
 exports.SASS_BINARY_PATH = SASS_BINARY_PATH;
 
 exports.getEnv = () => {
+  // https://github.com/sindresorhus/npm-run-path
+  // Returns the augmented process.env object.
   const npmEnv = npmRunPath.env();
+
+  // Merge process.env、npmEnv and custom environment variables
   const env = Object.assign({}, process.env, npmEnv, {
     // eslint-disable-next-line
     npm_config_registry: settings.get('registry'),
     // eslint-disable-next-line
     yarn_registry: settings.get('registry'),
-    SASS_BINARY_PATH,
+    // SASS_BINARY_PATH,
     CLICOLOR: 1,
     FORCE_COLOR: 1,
     COLORTERM: 'truecolor',
@@ -27,7 +31,7 @@ exports.getEnv = () => {
     LANG: `${app.getLocale().replace('-', '_')}.UTF-8`,
   });
 
-  const pathEnv = [APP_BIN_PATH, npmEnv.PATH, process.env.PATH].filter(
+  const pathEnv = [process.env.PATH, npmEnv.PATH, APP_BIN_PATH].filter(
     (p) => !!p
   );
 

--- a/tools/iceworks/app/main/env.js
+++ b/tools/iceworks/app/main/env.js
@@ -7,9 +7,7 @@ const is = require('electron-is');
 
 const isWin = is.windows();
 
-const { APP_BIN_PATH, SASS_BINARY_PATH } = require('./paths');
-
-exports.SASS_BINARY_PATH = SASS_BINARY_PATH;
+const { APP_BIN_PATH } = require('./paths');
 
 exports.getEnv = () => {
   // https://github.com/sindresorhus/npm-run-path
@@ -22,7 +20,6 @@ exports.getEnv = () => {
     npm_config_registry: settings.get('registry'),
     // eslint-disable-next-line
     yarn_registry: settings.get('registry'),
-    // SASS_BINARY_PATH,
     CLICOLOR: 1,
     FORCE_COLOR: 1,
     COLORTERM: 'truecolor',

--- a/tools/iceworks/app/main/paths.js
+++ b/tools/iceworks/app/main/paths.js
@@ -21,29 +21,14 @@ const NPM_CLI = path.join(APP_PATH, 'node_modules', 'npm', 'bin', 'npm-cli.js');
 
 const NRM_CLI = path.join(APP_PATH, 'node_modules', 'nrm', 'cli.js');
 
-const SASS_BINARY_PATH = isDev
-  ? path.join(
-      process.cwd(),
-      'binary',
-      process.platform,
-      'sass',
-      `${process.platform}-x64-57_binding.node`
-    )
-  : path.join(
-      process.resourcesPath,
-      'binary',
-      'sass',
-      `${process.platform}-x64-57_binding.node`
-    );
-
 const NODE_FRAMEWORKS = ['koa2', 'midway', 'midwayAli'];
 
 const getClientPath = (destDir, framework) => {
   if (framework && NODE_FRAMEWORKS.includes(framework)) {
-    return path.join(destDir, 'client'); 
+    return path.join(destDir, 'client');
   } else {
     // 包含两种情况：framework为koa（即老koa项目）、纯前端项目
-    return path.join(destDir); 
+    return path.join(destDir);
   }
 };
 
@@ -78,5 +63,5 @@ module.exports = {
   NODE_FRAMEWORKS,
   getClientPath,
   getClientSrcPath,
-  getServerPath
+  getServerPath,
 };

--- a/tools/iceworks/app/main/shared.js
+++ b/tools/iceworks/app/main/shared.js
@@ -39,8 +39,8 @@ const registries = [
   },
   {
     name: 'tnpm',
-    value: 'http://registry.npm.alibaba-inc.com',
-    label: 'tnpm - http://registry.npm.alibaba-inc.com',
+    value: 'https://registry.npm.alibaba-inc.com',
+    label: 'tnpm - https://registry.npm.alibaba-inc.com',
   },
 ];
 exports.registries = registries;
@@ -56,7 +56,8 @@ const defaultMaterials = [
     description:
       '基于 ICE Design 设计语言，专业视觉设计，每周物料更新，丰富组合区块，不同领域模板',
     source: 'https://ice.alicdn.com/assets/react-materials.json',
-    backupSource: 'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/react-materials.json',
+    backupSource:
+      'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/react-materials.json',
     tags: ['官方', 'React', 'ICE'],
     type: 'react',
   },
@@ -69,7 +70,8 @@ const defaultMaterials = [
     logo: 'https://img.alicdn.com/tfs/TB1_rYRvOAnBKNjSZFvXXaTKXXa-1120-960.png',
     description: '基于 Rax 的小程序应用的物料源集合',
     source: 'https://ice.alicdn.com/assets/rax-materials.json',
-    backupSource: 'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/rax-materials.json',
+    backupSource:
+      'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/rax-materials.json',
     tags: ['官方', 'Rax', 'Miniapp'],
     type: 'rax',
   },
@@ -82,7 +84,8 @@ const defaultMaterials = [
     description:
       '飞冰官方和 Vue 社区贡献者共建的物料源，基于 Element UI 组件库',
     source: 'http://ice.alicdn.com/assets/vue-materials.json',
-    backupSource: 'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/vue-materials.json',
+    backupSource:
+      'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/vue-materials.json',
     tags: ['推荐', 'Vue', 'Element UI'],
     type: 'vue',
   },
@@ -96,10 +99,11 @@ const defaultMaterials = [
     description:
       '飞冰官方和 Angular 社区贡献者共建的物料源，基于 Material UI 组件库',
     source: 'https://ice.alicdn.com/assets/angular-materials.json',
-    backupSource: 'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/angular-materials.json',
+    backupSource:
+      'https://cdn.jsdelivr.net/npm/@icedesign/materails-db@latest/lib/angular-materials.json',
     tags: ['推荐', 'Angular', 'Material UI'],
     type: 'angular',
-  }
+  },
 ];
 exports.defaultMaterials = defaultMaterials;
 


### PR DESCRIPTION
## 问题
1. 因 iceworks 内置 node/npm/node-sass 环境，导致用户在命令行和 iceworks 两者间不能友好的切换出现各种问题，因 node-sass 强依赖 node 的版本
2. 因 iceworks 内置 node/npm/node-sass 环境，用户使用时强依赖 iceworks 对基础环境的升级，不能自由切换 node 等环境的版本
3. 目前下载依赖的方式是通过 `npm install --registry=xxx` 的方式进行安装，虽然支持了动态源的切换，但是只能通过 npm client  进行安装，而不能指定诸如 cnpm  和 tnpm 等 npm client，而 npm 和 cnpm 在依赖安装的策略不同，导致出现安装差异

## 解决

1. 默认优先读取系统的 node/npm/cnpm/tnpm 环境变量，如果系统不存在，则降级兜底使用 iceworks 提供的
2. 支持切换不同的 npm client（npm、cnpm、tnpm）


## TODO
* 完全去掉内置的 node/npm/node-sass，目前维护成本太大收益太小，提供检测 node 环境安装的提示和一键安装功能
* 在设置面板提供当前 iceworks 使用的 node/npm  client 等版本辅助信息（electron 版本和 electron 依赖的 node 版本理论上都可以暴露出来）

## 讨论

#### 问题: 
移除 iceworks 最初版本内置 sass binary ？

#### 现状：
* iceworks 内置了 sass binary 二进制文件 [sass binary](https://github.com/alibaba/ice/tree/master/tools/iceworks/binary)
* ice-scripts 依赖 node-sass  4.9.0 版本 [#L8](https://github.com/alibaba/ice/blob/master/tools/ice-scripts/package.json#L87)

#### node-sass 安装流程

安装 `node-sass` 时会在 [node scripts/install](https://github.com/sass/node-sass/blob/a2ac801e28/package.json#L31) 阶段从 github.com 上下载一个  [xxx-xx_binding.node](https://github.com/sass/node-sass/releases) 文件，因为 GitHub Releases 里的文件都托管在 `s3.amazonaws.com` 上面，而这个网址在国内总是网络不稳定，大部分安装不成功的原因都源自这里，所有通常的做法是通过国内的镜像进行下载。

[#L239](https://github.com/sass/node-sass/blob/a2ac801e28/lib/extensions.js#L239)

```
function getBinaryUrl() {
  var site = getArgument('--sass-binary-site') ||
             process.env.SASS_BINARY_SITE  ||
             process.env.npm_config_sass_binary_site ||
             (pkg.nodeSassConfig && pkg.nodeSassConfig.binarySite) ||
             'https://github.com/sass/node-sass/releases/download';

  return [site, 'v' + pkg.version, getBinaryName()].join('/');
}
```

由以上代码可见通常的做法如下：
```
$ npm i node-sass ---sass-binary-site=https://npm.taobao.org/mirrors/node-sass

// 或者

// linux、mac 下
$ SASS_BINARY_SITE=https://npm.taobao.org/mirrors/node-sass/ npm i node-sass

// window 下
set SASS_BINARY_SITE=https://npm.taobao.org/mirrors/node-sass/ && npm install node-sass

或者
npm config set sass_binary_site https://npm.taobao.org/mirrors/node-sass
```
  
或者读取系统的环境变量，也是 iceworks 最初的设计:

 [iceworks sass binary](https://github.com/alibaba/ice/tree/master/tools/iceworks/binary)

```
// 通过内置 sass binary 环境变量解决网络下载的问题
const SASS_BINARY_PATH = isDev
  ? path.join(
      process.cwd(),
      'binary',
      process.platform,
      'sass',
      `${process.platform}-x64-57_binding.node`
    )
  : path.join(
      process.resourcesPath,
      'binary',
      'sass',
      `${process.platform}-x64-57_binding.node`
    );
```

## 最终结论：

由于现在 node 优先使用的是系统的 node 等环境，而 ice-scripts 也依赖 node-sass 版本，故而 iceworks 可以不用在内置 sass binary 二进制文件。

