### PR TITLE
fix: alias babel runtime

### DIFF
--- a/tools/ice-scripts/CHANGELOG.md
+++ b/tools/ice-scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.1
+
+- [fix] 修复 @babel/runtime alias 路径错误问题
+
 ## 1.9.0
 
 - [feat] 支持 init 项目

--- a/tools/ice-scripts/lib/config/getResolveAlias.js
+++ b/tools/ice-scripts/lib/config/getResolveAlias.js
@@ -37,7 +37,7 @@ module.exports = function getResolveAlias(buildConfig) {
   }
 
   // 项目不需要单独依赖 @babel/runtime
-  alias['@babel/runtime'] = path.resolve(__dirname, '../../node_modules/@babel/runtime');
+  alias['@babel/runtime'] = path.resolve(require.resolve('@babel/runtime/package.json'), '../');;
 
   return alias;
 };

--- a/tools/ice-scripts/lib/config/getResolveAlias.js
+++ b/tools/ice-scripts/lib/config/getResolveAlias.js
@@ -37,7 +37,7 @@ module.exports = function getResolveAlias(buildConfig) {
   }
 
   // 项目不需要单独依赖 @babel/runtime
-  alias['@babel/runtime'] = path.resolve(require.resolve('@babel/runtime/package.json'), '../');;
+  alias['@babel/runtime'] = path.resolve(require.resolve('@babel/runtime/package.json'), '../');
 
   return alias;
 };

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION

- npm 扁平化之后 @babel/runtime 跟 ice-scripts 同级，于是去 ice-scripts 的 node_modules 下找不到 @babel/runtime，我测试的时候用的 tnpm，扁平规则不一样所以没出现问题
- require.resolve 会递归找可以解决这个问题

Close #1689 