### PR TITLE
fix: 去除 babel-runtime 的 alias & 不锁死 webpack 依赖

### DIFF
--- a/tools/ice-scripts/CHANGELOG.md
+++ b/tools/ice-scripts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.9.2
+
+- [fix] 移除掉 babel-runtime 的 alias，防止项目依赖里有不同版本导致无法构建
+- [chore] 不写死 webpack 的依赖版本，防止多份 webpack 导致构建报错
+
 ## 1.9.1
 
 - [fix] 修复 @babel/runtime alias 路径错误问题

--- a/tools/ice-scripts/lib/config/getResolveAlias.js
+++ b/tools/ice-scripts/lib/config/getResolveAlias.js
@@ -36,8 +36,5 @@ module.exports = function getResolveAlias(buildConfig) {
     alias[pkgData.name] = path.resolve(paths.appDirectory, 'src/index');
   }
 
-  // 项目不需要单独依赖 @babel/runtime
-  alias['@babel/runtime'] = path.resolve(require.resolve('@babel/runtime/package.json'), '../');
-
   return alias;
 };

--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {
@@ -45,7 +45,6 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@babel/runtime": "^7.1.2",
     "address": "1.0.3",
     "autoprefixer": "9.1.5",
     "awesome-typescript-loader": "5.2.1",
@@ -103,7 +102,7 @@
     "uglifyjs-webpack-plugin": "1.3.0",
     "url-loader": "1.1.2",
     "uuid": "^3.3.2",
-    "webpack": "4.20.2",
+    "webpack": "^4.20.2",
     "webpack-bundle-analyzer": "3.0.3",
     "webpack-dev-mock": "0.1.2",
     "webpack-dev-server": "3.1.9",


### PR DESCRIPTION

- 去除 babel-runtime 的 alias
  - 依赖的组件里有可能使用不同 br 版本的 babel-runtime，都 alias 到 ice-scripts 里面会导致构建出错
  - 不 alias 最大的问题，是我们的业务组件构建后依赖了 babel-runtime，但是 dep 里面没声明，但实际上我们大多数业务组件都依赖了 next，next 依赖了 babel-runtime，一般不会有问题，对于有问题的少数用户，让开发自己添加下 babel-runtime 即可
- webpack 版本不固定：这里的版本固定理论上没什么作用，即便写死了直接依赖，间接依赖还是没锁死，后续考虑全部放开，这个版本先放开 webpack，因为这里写死会间接导致一些项目要安装两个版本的 webpack，然后构建报错 tap balabala