### PR TITLE
[iceworks] request 的容错

### DIFF
--- a/tools/iceworks/app/main/alilog.js
+++ b/tools/iceworks/app/main/alilog.js
@@ -1,6 +1,6 @@
 const request = require('request');
 const { app } = require('electron');
-
+const log = require('./logger');
 
 /**
  * 阿里云 SLS 服务，日志上报方法
@@ -39,6 +39,10 @@ const report = (data = {}, topic = 'info') => {
   request({
     url,
     timeout: 2000,
+  }, (err) => {
+    if (err) {
+      log.error(err);
+    }
   });
 };
 

--- a/tools/iceworks/app/main/index.js
+++ b/tools/iceworks/app/main/index.js
@@ -59,6 +59,7 @@ process
       type: 'process-uncaught-exception',
       msg: JSON.stringify(error.message),
       stack: error.stack,
+      error: JSON.stringify(error)
     }, 'error');
   });
 

--- a/tools/iceworks/app/main/scaffolder/lib/extractor.js
+++ b/tools/iceworks/app/main/scaffolder/lib/extractor.js
@@ -1,7 +1,0 @@
-exports.extractScaffording = function extractScaffording() {};
-
-exports.extractLayout = function extractScaffording() {};
-
-exports.extractBlock = function extractBlock() {};
-
-exports.extractBlocks = function extractBlocks() {};

--- a/tools/iceworks/app/main/scaffolder/lib/utils.js
+++ b/tools/iceworks/app/main/scaffolder/lib/utils.js
@@ -301,14 +301,11 @@ function extractBlock(
 
 // 超时自动重试
 const retryCount = 2;
-const retryExtractBlock = autoRetry(extractBlock, retryCount, (err) => {
-  if (
-    !err.code ||
-    (err.code !== 'ETIMEDOUT' && err.code !== 'ESOCKETTIMEDOUT')
-  ) {
-    throw err;
-  }
-});
+const retryExtractBlock = autoRetry(
+  extractBlock, 
+  retryCount, 
+  (err) => err.code && (err.code == 'ETIMEDOUT' || err.code == 'ESOCKETTIMEDOUT')
+);
 
 /**
  * 从 registry 获取 npm 包的 tarbal URL

--- a/tools/iceworks/app/main/scaffolder/lib/utils.js
+++ b/tools/iceworks/app/main/scaffolder/lib/utils.js
@@ -435,7 +435,6 @@ function getDependenciesFromCustom(block) {
 exports.extractCustomBlock = extractCustomBlock;
 exports.getDependenciesFromCustom = getDependenciesFromCustom;
 exports.getTarballURL = getTarballURL;
-exports.extractBlock = retryExtractBlock;
 exports.getDependenciesFromNpm = getDependenciesFromNpm;
 exports.getDependenciesFromMaterial = getDependenciesFromMaterial;
 exports.downloadBlockToPage = downloadBlockToPage;

--- a/tools/iceworks/app/main/template/utils/extractTarball.js
+++ b/tools/iceworks/app/main/template/utils/extractTarball.js
@@ -47,8 +47,8 @@ function extractTarball(
         alilog.report(
           {
             type: 'download-tarball-error',
-            msg: err.message,
-            stack: err.stack,
+            msg: error.message,
+            stack: error.stack,
             data: {
               url: tarballURL,
             },

--- a/tools/iceworks/app/main/template/utils/extractTarball.js
+++ b/tools/iceworks/app/main/template/utils/extractTarball.js
@@ -44,6 +44,17 @@ function extractTarball(
         progressFunc(state);
       })
       .on('error', (error = {}) => {
+        alilog.report(
+          {
+            type: 'download-tarball-error',
+            msg: err.message,
+            stack: err.stack,
+            data: {
+              url: tarballURL,
+            },
+          },
+          'error'
+        );
         reject(new DetailError(`链接 ${tarballURL} 请求失败`, {
           message: error.message,
           stack: error.stack,
@@ -117,10 +128,8 @@ function extractTarball(
 
 // 超时自动重试
 const retryCount = 2;
-const retryExtractTarball = autoRetry(extractTarball, retryCount, (err) => {
-  if (err.metadata && err.metadata.message !== 'ETIMEDOUT') {
-    throw (err);
-  }
-});
-
-module.exports = retryExtractTarball;
+module.exports = autoRetry(
+  extractTarball, 
+  retryCount, 
+  (err) => err.metadata && err.metadata.message == 'ETIMEDOUT'
+);

--- a/tools/iceworks/app/main/utils/autoRetry.js
+++ b/tools/iceworks/app/main/utils/autoRetry.js
@@ -2,21 +2,22 @@
  * 自动重试
  * @param {*} fn 被重试的方法
  * @param {*} maxTryTimes 重试次数
- * @param {*} errHandler 被重试方法的错误判断逻辑，用于判断什么样的错误才会进入重试逻辑，返回true则进入重试逻辑
+ * @param {*} retryCondition 返回 true 则进入重试逻辑
  */
-module.exports = function autoRetry(fn, maxTryTimes, errHandler) {
+module.exports = function autoRetry(fn, maxTryTimes, retryCondition) {
   return async function (...args) {
     let tryTimes = 0;
-    async function inner() {
+    return await (async function inner() {
       try {
         tryTimes++;
         return await fn(...args);
       } catch (err) {
-        if (errHandler && errHandler(err)) return inner();
-        if (tryTimes === maxTryTimes) throw err;
-        return inner();
+        if (retryCondition(err) && maxTryTimes > tryTimes) {
+          return await inner();
+        } else {
+          throw err;
+        }
       }
-    }
-    return inner();
+    })();
   };
 };

--- a/tools/iceworks/app/main/utils/npmRequest.js
+++ b/tools/iceworks/app/main/utils/npmRequest.js
@@ -25,15 +25,16 @@ function npmRequest({ name, version = 'latest', registry }) {
       timeout: 5000,
     }, (err, response, json) => {
       if (err || !json) {
+        const error = err || new Error(JSON.stringify(response.body));
         alilog.report({
           type: 'get-tarball-info-error',
-          msg: err.message,
-          stack: err.stack,
+          msg: error.message,
+          stack: error.stack,
           data: {
             url: pkgUrl,
           },
         }, 'error');
-        reject(err || new Error(JSON.stringify(response.body)));
+        reject(error);
       } else {
         if (!semver.valid(version)) {
           version = json['dist-tags'][version];

--- a/tools/iceworks/app/main/utils/npmRequest.js
+++ b/tools/iceworks/app/main/utils/npmRequest.js
@@ -56,10 +56,8 @@ function npmRequest({ name, version = 'latest', registry }) {
 
 // 超时自动重试
 const retryCount = 2;
-const retryNpmRequest = autoRetry(npmRequest, retryCount, (err) => {
-  if (!err.code || (err.code !== 'ETIMEDOUT' && err.code !== 'ESOCKETTIMEDOUT')) {
-    throw (err);
-  }
-});
-
-module.exports = retryNpmRequest;
+module.exports = autoRetry(
+  npmRequest, 
+  retryCount, 
+  (err) => err.code && (err.code == 'ETIMEDOUT' || err.code == 'ESOCKETTIMEDOUT')
+);


### PR DESCRIPTION
## 背景：

Iceworks 在主进程上监听了 `uncaughtException` 事件（[源码](https://github.com/alibaba/ice/blob/iceworks/2.17.1/tools/iceworks/app/main/index.js#L58)），并将错误上传到了 SLS 。当前 SLS 上收到了大量该错误。

Iceworks 版本信息：

- electron: 2.0.1
- Node.js: 8.x

## 问题分析：

- 错误的核心信息：
    - msg: "ETIMEDOUT" ([Node.js@8.x - Error](https://nodejs.org/docs/latest-v8.x/api/errors.html))
    - stack: "...request.js:849:19)"
- 现象：在一次收到该错误后同一客户端短时间内大量产生该错误。

基本定位：

- 由于 request 请求造成的超时错误未被捕获；
- 该请求有重试机制，导致短时间内大量产生该错误。

## 解决方式：

1. 错误采集的接口必须容错，否则该接口的抛错将被抛到主进程，造成死循环；
2. 错误采集的接口上传完整的 error 对象，以便获取更多的信息；
3. 重试逻辑存在隐患，需要重新梳理。因此优化重试的实现逻辑：入参优化，异步处理优化，重试判断逻辑优化；
4. extractTarball 打点（所有 request 的错误都先打点，以便统计 request 错误）。