### PR TITLE
fix: pro LocaleProvider fallback to en-US (#1716)

### DIFF
--- a/react-materials/scaffolds/ice-design-pro/src/components/LocaleProvider/LocaleProvider.jsx
+++ b/react-materials/scaffolds/ice-design-pro/src/components/LocaleProvider/LocaleProvider.jsx
@@ -36,12 +36,13 @@ class LocaleProvider extends PureComponent {
   render() {
     const { locale, children } = this.props;
 
+    const myLocale = localeInfo[locale]
+      ? localeInfo[locale]
+      : localeInfo['en-US'];
+
     return (
-      <IntlProvider
-        locale={localeInfo[locale].appLocale}
-        messages={localeInfo[locale].appMessages}
-      >
-        <ConfigProvider locale={localeInfo[locale].nextLocale}>
+      <IntlProvider locale={myLocale.appLocale} messages={myLocale.appMessages}>
+        <ConfigProvider locale={myLocale.nextLocale}>
           {React.Children.only(children)}
         </ConfigProvider>
       </IntlProvider>


### PR DESCRIPTION
当前的 localeInfo 是根据 `navigator.language` 来的。

但是如果用户浏览器的语言未在程序中指定，就会抛出错误，页面甚至无法打开。#1716

所以如果监测到用户语言是别的国家的，应该默认回落到更通用的 `en-US` 作为默认值。