### PR TITLE
fix: use built-in npm client

### DIFF
--- a/tools/iceworks/renderer/src/lib/project-scripts.js
+++ b/tools/iceworks/renderer/src/lib/project-scripts.js
@@ -73,56 +73,42 @@ const doProjectInstall = ({ cwd, env, shell, callback }, reInstall) => {
     shellArgs: ['cache', 'clean', '--force'],
   };
 
-  const npmClientCheckConfig = {
-    cwd,
-    env,
-    shell,
-    shellArgs: ['-v'],
-  };
-
-  sessions.manager.new(npmClientCheckConfig, (status) => {
-    if (status !== 0) {
-      installConfig.shell = 'npm';
-      installConfig.shellArgs.push(`--registry=${env.npm_config_registry}`);
-    }
-
-    sessions.manager.new(installConfig, (code) => {
-      if (code !== 0) {
-        log.error('project-install-failed');
-        log.report('app', { action: 'project-install-failed' });
-        if (reInstall) {
-          log.info('执行 npm cache clean --force 重试');
-          sessions.manager.new(npmCacheCleanConfig, () => {
-            doProjectInstall({ cwd, env, shell, callback });
-          });
-        } else if (shell === 'tnpm' || shell === 'cnpm') {
-          const registryInfo = getRegistryInfo(shell);
-          callback(code, {
-            title: '重装依赖失败',
-            content: (
-              <div>
-                <p>
-                  1. 请检查 {shell} 命令是否安装了，没有请执行 $ [sudo] npm
-                  install --registry={registryInfo.value} -g {shell} 进行安装
-                </p>
-                <p>
-                  2. 已安装 {shell}
-                  ，请检查网络连接是否正常，可展开【运行日志】日志查看详细反馈信息
-                </p>
-              </div>
-            ),
-          });
-        } else {
-          callback(code, {
-            title: '重装依赖失败',
-            content:
-              '请检查网络连接是否正常，可展开【运行日志】日志查看详细反馈信息',
-          });
-        }
+  sessions.manager.new(installConfig, (code) => {
+    if (code !== 0) {
+      log.error('project-install-failed');
+      log.report('app', { action: 'project-install-failed' });
+      if (reInstall) {
+        log.info('执行 npm cache clean --force 重试');
+        sessions.manager.new(npmCacheCleanConfig, () => {
+          doProjectInstall({ cwd, env, shell, callback });
+        });
+      } else if (shell === 'tnpm' || shell === 'cnpm') {
+        const registryInfo = getRegistryInfo(shell);
+        callback(code, {
+          title: '重装依赖失败',
+          content: (
+            <div>
+              <p>
+                1. 请检查 {shell} 命令是否安装了，没有请执行 $ [sudo] npm
+                install --registry={registryInfo.value} -g {shell} 进行安装
+              </p>
+              <p>
+                2. 已安装 {shell}
+                ，请检查网络连接是否正常，可展开【运行日志】日志查看详细反馈信息
+              </p>
+            </div>
+          ),
+        });
       } else {
-        callback(0);
+        callback(code, {
+          title: '重装依赖失败',
+          content:
+            '请检查网络连接是否正常，可展开【运行日志】日志查看详细反馈信息',
+        });
       }
-    });
+    } else {
+      callback(0);
+    }
   });
 };
 
@@ -133,53 +119,39 @@ const doDependenciesInstall = (
   reInstall
 ) => {
   // cwd 项目目录，用于获取对应的 term，term 使用项目路径作为key存储
-  const { cwd, env, shell } = dependenciesInstallConfig;
+  const { cwd, env } = dependenciesInstallConfig;
 
-  const npmClientCheckConfig = {
-    cwd,
-    env,
-    shell,
-    shellArgs: ['-v'],
-  };
-
-  sessions.manager.new(npmClientCheckConfig, (status) => {
-    if (status !== 0) {
-      dependenciesInstallConfig.shell = 'npm';
-      dependenciesInstallConfig.shellArgs.push(`--registry=${env.npm_config_registry}`);
-    }
-
-    sessions.manager.new(dependenciesInstallConfig, (code) => {
-      if (code !== 0) {
-        if (reInstall) {
-          log.info('重试');
-          terms.writeln(cwd, '依赖安装重试');
-          doDependenciesInstall(
-            dependenciesInstallConfig,
-            dependencies,
-            callback
-          );
-        } else {
-          log.error('安装依赖失败', cwd, dependencies);
-          const error = new Error('安装依赖失败');
-          alilog.report(
-            {
-              type: 'install-dependencies-error',
-              msg: error.message,
-              stack: error.stack,
-              data: {
-                dependencies: dependencies.join('; '),
-                env: JSON.stringify(env),
-              },
-            },
-            'error'
-          );
-          callback(1, dependencies);
-        }
+  sessions.manager.new(dependenciesInstallConfig, (code) => {
+    if (code !== 0) {
+      if (reInstall) {
+        log.info('重试');
+        terms.writeln(cwd, '依赖安装重试');
+        doDependenciesInstall(
+          dependenciesInstallConfig,
+          dependencies,
+          callback
+        );
       } else {
-        log.info('安装依赖成功', cwd, dependencies);
-        callback(null, dependencies);
+        log.error('安装依赖失败', cwd, dependencies);
+        const error = new Error('安装依赖失败');
+        alilog.report(
+          {
+            type: 'install-dependencies-error',
+            msg: error.message,
+            stack: error.stack,
+            data: {
+              dependencies: dependencies.join('; '),
+              env: JSON.stringify(env),
+            },
+          },
+          'error'
+        );
+        callback(1, dependencies);
       }
-    });
+    } else {
+      log.info('安装依赖成功', cwd, dependencies);
+      callback(null, dependencies);
+    }
   });
 };
 
@@ -376,14 +348,13 @@ export default {
 
       const cwd = project.fullPath;
       const cwdClient = project.clientPath;
-      const registryInfo = getRegistryInfo(env.npm_config_registry);
       terms.writeln(cwd, '开始安装依赖');
 
       const npmInstallConfig = {
         cwd, // 项目目录，用于获取对应的term，term使用项目路径作为key存储
         cwdClient, // 是否是node模板，如果是node模板，此时安装目录于普通前端模板不同
         env,
-        shell: registryInfo.name || 'npm',
+        shell: 'npm',
         shellArgs: ['install', '--no-package-lock', installPrefix].concat(
           dependencies
         ),
@@ -464,12 +435,11 @@ export default {
       })
       .then(() => {
         const env = getEnvByAli(isAlibaba);
-        const registryInfo = getRegistryInfo(env.npm_config_registry);
         doProjectInstall(
           {
             cwd: project.fullPath,
             env,
-            shell: registryInfo.name || 'npm',
+            shell: 'npm',
             callback,
           },
           true


### PR DESCRIPTION
## 问题：

https://github.com/alibaba/ice/issues/1718

由于目前支持使用系统的 cnpm/npm 以及其他 npm client，因不同系统之间的环境变量配置会有所不一样，iceworks 目前未能读取相关的路径，导致用户安装错误率失败大幅提高

## 现有解决：

降级原因方案使用 npm 结合动态源的方式，保证线上版本正常使用

## 后续方案
支持多 npm client 安装需要研究 windows 设置环境变量的规则以及 Mac 自定义配置的情况，或者提供设置环境变量的入口， 且需要经过充分的 beta 测试