### PR TITLE
doc: update react-loadable -> React.lazy

### DIFF
--- a/docs/advanced/how-to-dynamic-load.md
+++ b/docs/advanced/how-to-dynamic-load.md
@@ -5,9 +5,11 @@ order: 7
 
 当页面规模、依赖组件达到一定量之后，打包后的文件也会随之增大，但在浏览某个页面的时候并不需要一次性加载所有内容，只需加载当前页面的资源即可，此时可以参考本文档实现静态资源的切割及按需加载。
 
+*提示：React 16.6.0 及以上版本的项目建议使用 [React.lazy](https://reactjs.org/docs/code-splitting.html#reactlazy)，否则建议使用三方组件库 [react-loadable](https://github.com/jamiebuilds/react-loadable)。*
+
 ## React.lazy
 
-React 16.x 版本提供了动态加载组件的标准化能力 —— [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy) API。
+React 16.6.0 及以上版本提供了动态加载组件的标准化能力 —— [React.lazy](https://reactjs.org/docs/code-splitting.html#reactlazy) API。
 
 **正常加载组件**
 ```js
@@ -23,8 +25,9 @@ function MyComponent() {
 ```
 
 **按需动态加载组件**
-```js
-const OtherComponent = React.lazy(() => import('./OtherComponent'));
+```diff
+- import OtherComponent from './OtherComponent';
++ const OtherComponent = React.lazy(() => import('./OtherComponent'));
 
 function MyComponent() {
   return (
@@ -36,8 +39,10 @@ function MyComponent() {
 ```
 
 ## Suspense
+
 由于网络传输原因，加载组件需要花费一定的时间，为了提升用户体验，一般会加一个 loading 组件平滑过渡。
 React 内置的 `<Suspense>` 组件已为我们实现了此功能。
+
 ```js
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import React, { Suspense, lazy } from 'react';
@@ -56,7 +61,5 @@ const App = () => (
   </Router>
 );
 ```
+
 `fallback` 属性值为等待组件加载时你想渲染的任何 React 元素。
-
-
-*提示：React 版本大于 16.x 的项目建议使用 React.lazy，否则的话建议使用三方组件库 [react-loadable](https://github.com/jamiebuilds/react-loadable)。*


### PR DESCRIPTION
更新动态加载组件文档，之前使用 react-loadable 三方库，改为使用官方提供的 `React.lazy`。
fix #1828 