### PR TITLE
fix: download scaffold error.

### DIFF
--- a/tools/ice-scripts/lib/scaffold/download.js
+++ b/tools/ice-scripts/lib/scaffold/download.js
@@ -58,7 +58,7 @@ function downloadAndFilterNpmFiles(npm, version, destDir, formatFile) {
             entry
               .pipe(fs.createWriteStream(destPath))
               .on('finish', () => {
-                formatFile = formatFile || Promise.resolve;
+                formatFile = formatFile || Promise.resolve.bind(Promise);
                 return formatFile(destPath).then(streamResolve);
               });
           });


### PR DESCRIPTION
`Promise.resolve` can not be called as a function, because there is no context object with 
 `Promise.resolve`.