### PR TITLE
[Iceworks]feat: implementation useStore

### DIFF
--- a/packages/iceworks-client/.webpackrc.js
+++ b/packages/iceworks-client/.webpackrc.js
@@ -12,14 +12,16 @@ module.exports = (context) => {
         '@layouts': resolve(__dirname, 'src/layouts/'),
         '@components': resolve(__dirname, 'src/components/'),
         '@utils': resolve(__dirname, 'src/utils/'),
+        '@store': resolve(__dirname, 'src/store/'),
+        '@models': resolve(__dirname, 'src/models/'),
       },
     },
     plugins: [
       new webpack.DefinePlugin({
         'process.env': {
-          NODE_ENV: JSON.stringify(process.env.NODE_ENV)
-        }
+          NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+        },
       }),
-    ]
+    ],
   };
 };

--- a/packages/iceworks-client/src/index.js
+++ b/packages/iceworks-client/src/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
@@ -6,7 +6,7 @@ import MainLayout from '@layouts/MainLayout/index';
 import LocaleProvider from '@components/LocaleProvider';
 import { ThemeProvider } from '@components/ThemeProvider';
 import { getLocale } from '@utils/locale';
-import { StoreContext } from '@store';
+import StoreProvider from '@store/StoreProvider';
 
 import '@utils/logger';
 import '@alifd/next/reset.scss';
@@ -16,10 +16,8 @@ import './variables.scss';
 const locale = getLocale();
 
 const App = () => {
-  const [data, setData] = useState();
-
   return (
-    <StoreContext.Provider value={[data, setData]}>
+    <StoreProvider>
       <LocaleProvider locale={locale}>
         <ThemeProvider>
           <Router>
@@ -27,10 +25,8 @@ const App = () => {
           </Router>
         </ThemeProvider>
       </LocaleProvider>
-    </StoreContext.Provider>
+    </StoreProvider>
   );
 };
 
-const ICE_CONTAINER = document.getElementById('iceworks');
-
-ReactDOM.render(<App />, ICE_CONTAINER);
+ReactDOM.render(<App />, document.getElementById('iceworks'));

--- a/packages/iceworks-client/src/index.js
+++ b/packages/iceworks-client/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
@@ -6,6 +6,7 @@ import MainLayout from '@layouts/MainLayout/index';
 import LocaleProvider from '@components/LocaleProvider';
 import { ThemeProvider } from '@components/ThemeProvider';
 import { getLocale } from '@utils/locale';
+import { StoreContext } from '@store';
 
 import '@utils/logger';
 import '@alifd/next/reset.scss';
@@ -13,15 +14,23 @@ import './global.scss';
 import './variables.scss';
 
 const locale = getLocale();
+
+const App = () => {
+  const [data, setData] = useState();
+
+  return (
+    <StoreContext.Provider value={[data, setData]}>
+      <LocaleProvider locale={locale}>
+        <ThemeProvider>
+          <Router>
+            <Route path="/" component={MainLayout} />
+          </Router>
+        </ThemeProvider>
+      </LocaleProvider>
+    </StoreContext.Provider>
+  );
+};
+
 const ICE_CONTAINER = document.getElementById('iceworks');
 
-ReactDOM.render(
-  <LocaleProvider locale={locale}>
-    <ThemeProvider>
-      <Router>
-        <Route path="/" component={MainLayout} />
-      </Router>
-    </ThemeProvider>
-  </LocaleProvider>,
-  ICE_CONTAINER,
-);
+ReactDOM.render(<App />, ICE_CONTAINER);

--- a/packages/iceworks-client/src/models/material.js
+++ b/packages/iceworks-client/src/models/material.js
@@ -1,0 +1,10 @@
+import { useStore } from '@store';
+
+export function useMaterial() {
+  return useStore((setStore) => {
+    setTimeout(() => {
+      const newData = { name: 'form model' };
+      setStore(newData);
+    }, 100);
+  });
+}

--- a/packages/iceworks-client/src/pages/Material/index.js
+++ b/packages/iceworks-client/src/pages/Material/index.js
@@ -1,9 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useMaterial } from '@models/material';
 
-export default class Material extends Component {
-  state = {};
+const Material = () => {
+  const [data, fetchData] = useMaterial();
 
-  render() {
-    return <div>Material</div>;
-  }
-}
+  const handleClick = () => {
+    fetchData();
+  };
+
+  return (
+    <div onClick={handleClick}>
+      <h2>Material</h2>
+      <p>{data && data.name}</p>
+    </div>
+  );
+};
+
+export default Material;

--- a/packages/iceworks-client/src/store/StoreProvider.js
+++ b/packages/iceworks-client/src/store/StoreProvider.js
@@ -12,6 +12,10 @@ const StoreProvider = ({ initialState, children }) => {
   );
 };
 
+StoreProvider.defaultProps = {
+  initialState: null,
+};
+
 StoreProvider.propTypes = {
   initialState: PropTypes.any,
   children: PropTypes.element.isRequired,

--- a/packages/iceworks-client/src/store/StoreProvider.js
+++ b/packages/iceworks-client/src/store/StoreProvider.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import StoreContext from './StoreContext';
+
+const StoreProvider = ({ initialState, children }) => {
+  const [store, setStore] = useState(initialState);
+
+  return (
+    <StoreContext.Provider value={[store, setStore]}>
+      {children}
+    </StoreContext.Provider>
+  );
+};
+
+StoreProvider.propTypes = {
+  initialState: PropTypes.any,
+  children: PropTypes.element.isRequired,
+};
+
+export default StoreProvider;

--- a/packages/iceworks-client/src/store/index.js
+++ b/packages/iceworks-client/src/store/index.js
@@ -1,0 +1,4 @@
+import StoreContext from './storeContext';
+import useStore from './useStore';
+
+export { StoreContext, useStore };

--- a/packages/iceworks-client/src/store/index.js
+++ b/packages/iceworks-client/src/store/index.js
@@ -1,4 +1,5 @@
-import StoreContext from './storeContext';
+import StoreContext from './StoreContext';
+import StoreProvider from './StoreProvider';
 import useStore from './useStore';
 
-export { StoreContext, useStore };
+export { StoreContext, StoreProvider, useStore };

--- a/packages/iceworks-client/src/store/storeContext.js
+++ b/packages/iceworks-client/src/store/storeContext.js
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+/**
+ * Creates a Context object.
+ * When React renders a component that subscribes to this Context object.
+ * it will read the current context value from the closest matching Provider above it in the tree
+ */
+const StoreContext = createContext();
+
+export default StoreContext;

--- a/packages/iceworks-client/src/store/useStore.js
+++ b/packages/iceworks-client/src/store/useStore.js
@@ -1,0 +1,21 @@
+import { useState, useEffect, useContext } from 'react';
+import StoreContext from './storeContext';
+
+/**
+ * Provide a useStore function to synchronize data to the global store
+ * @param {function} cb callback
+ */
+function useStore(cb) {
+  const [store, setStore] = useContext(StoreContext);
+
+  const [data, setData] = useState(true);
+
+  useEffect(() => {
+    if (data) return;
+    cb(setStore);
+  }, [data]);
+
+  return [store, setData];
+}
+
+export default useStore;

--- a/packages/iceworks-client/src/store/useStore.js
+++ b/packages/iceworks-client/src/store/useStore.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import StoreContext from './storeContext';
+import StoreContext from './StoreContext';
 
 /**
  * Provide a useStore function to synchronize data to the global store
@@ -7,7 +7,6 @@ import StoreContext from './storeContext';
  */
 function useStore(cb) {
   const [store, setStore] = useContext(StoreContext);
-
   const [data, setData] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
## 状态管理方案
> 使用 react hooks 实现 useStore 功能进行全局的状态管理

## Api
`StoreContext`
`StoreProvider`
`useStore()`

## Example

### StoreContext

使用 hooks 之前，需要先使用 `StoreContext.Provider` 在跟路组件上

```
// src/index.js
import React, { useState }  from 'react';
import { StoreContext } from '@store';

const App = () => {
  const [store, setStore] = useState()
   return (
     <StoreContext.Provider value={{ store, setStore }}>
         ...
     </StoreContext.Provider>
   )
}

ReactDOM.render(<App/>, document.getElementById('root'));
```

### StoreProvider
除了使用 `StoreContext.Provider` 还可以使用 `StoreProvider`，本质上对 `StoreContext.Provider`  的一层封装

```
// src/index.js
import React  from 'react';
import { StoreContext } from '@store';

const App = () => {
   return (
     <StoreProvider initialState={xxx}>
         ...
     </StoreProvider>
   )
}
```

### useStore
然后就可以使用 `useStore`  hooks 更新和设置全局的 `store` 数据

```
// models/material.js
import { useStore } from '@store';

export function useMaterial() {
  return useStore((setStore) => {
    setTimeout(() => {
      const newData = { name: 'form model' };
      setStore(newData);
    }, 100);
  });
}
```

### 组件订阅 store 的数据

```
// pages/Material/index.js
import React from 'react';
import { useMaterial } from '@models/material';

const Material = () => {
  const [data, fetchData] = useMaterial();

  const handleClick = () => {
    fetchData();
  };

  return (
    <div onClick={handleClick}>
      <h2>Material</h2>
      <p>{data && data.name}</p>
    </div>
  );
};

export default Material;
```