### PR TITLE
fix: 修复 angular 模版资源 404 的问题

### DIFF
--- a/templates/ice-angular-material-template/template/block/demo/index.html
+++ b/templates/ice-angular-material-template/template/block/demo/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title><%= name %></title>
-  <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/templates/ice-angular-material-template/template/scaffold/src/index.html
+++ b/templates/ice-angular-material-template/template/scaffold/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title><%= npmName %></title>
-  <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
html 中有 <base href="/"> 标签导致所有资源从跟路径请求。