### PR TITLE
fix: bind this to prevent context change

### DIFF
--- a/tools/ice-scripts/lib/core/Plugin.js
+++ b/tools/ice-scripts/lib/core/Plugin.js
@@ -3,6 +3,10 @@ const processEntry = require('../config/processEntry');
 module.exports = class PluginAPI {
   constructor(service) {
     this.service = service;
+
+    this.chainWebpack = this.chainWebpack.bind(this);
+    this.processEntry = this.processEntry.bind(this);
+    this.getWebpackConfig = this.getWebpackConfig.bind(this);
   }
 
   chainWebpack(fn) {


### PR DESCRIPTION
const { processEntry } = api;

processEntry({ entry }) 
// <- Uncaught TypeError: Cannot read property 'service' of undefined