### PR TITLE
fix: add file-loader dep

### DIFF
--- a/tools/ice-scripts/package.json
+++ b/tools/ice-scripts/package.json
@@ -62,6 +62,7 @@
     "detect-port": "^1.2.3",
     "ejs": "^2.6.1",
     "extract-css-assets-webpack-plugin": "^0.2.5",
+    "file-loader": "^3.0.1",
     "find-root": "^1.1.0",
     "fs-extra": "^7.0.1",
     "html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
url-loader will specifies an alternative loader to use when a target file's size exceeds the limi, default is file-loader

https://github.com/webpack-contrib/url-loader/#fallback
https://github.com/webpack-contrib/url-loader/blob/a6705ccf419c6a1240c4ae13c4e19cc0d1360c07/src/utils/normalizeFallback.js#L3