### PR TITLE
fix: broken links in website

### DIFF
--- a/docs/materials/init-dev.md
+++ b/docs/materials/init-dev.md
@@ -38,9 +38,9 @@ my-materials/
 
 不同物料体系可能使用不同的框架或工具，实际开发方式也会有所差异，此处根据选择的前端方案参考不同文档即可：
 
-- [开发 React 物料](./react.md)
-- [开发 Vue 物料](./vue.md)
-- [开发 Angular 物料](./angular.md)
+- [开发 React 物料](https://ice.work/docs/materials/react)
+- [开发 Vue 物料](https://ice.work/docs/materials/vue)
+- [开发 Angular 物料](https://ice.work/docs/materials/angular)
 
 如有其他框架/工具的需求，欢迎反馈给飞冰（ICE）团队。
 

--- a/docs/materials/init-dev.md
+++ b/docs/materials/init-dev.md
@@ -72,6 +72,6 @@ $ ls build/
 materials.json
 ```
 
-这份物料数据时一份标准协议，可以在 iceworks, fusion.design 以及其他各种端使用，具体协议规范请参考 [物料数据协议](./schema.md)。
+这份物料数据时一份标准协议，可以在 iceworks, fusion.design 以及其他各种端使用，具体协议规范请参考 [物料数据协议](https://ice.work/docs/materials/schema)。
 
 目前这只是一份静态数据，想要在 iceworks 里使用这份物料的话需要参考下文将其托管到某些服务上生成一个 url。

--- a/docs/materials/schema.md
+++ b/docs/materials/schema.md
@@ -104,6 +104,6 @@ order: 4
 }
 ```
 
-如果模版需要接入 iceworks 体系，还需要关注 iceworks 代码生成规则。iceworks 默认会在 `/src/routerConfig.js` 和 `/src/menuConfig.js` 两个文件中注入代码，用于添加路由及添加菜单项。因此，在模版的路由配置及菜单配置中，需引入这两个文件，ice-devtools 初始化的模版中已包含这两个文件，切勿删除或修改它们。更多细节，可查看 [iceworks 文档](../iceworks/marterial-scaffold.md)。
+如果模版需要接入 iceworks 体系，还需要关注 iceworks 代码生成规则。iceworks 默认会在 `/src/routerConfig.js` 和 `/src/menuConfig.js` 两个文件中注入代码，用于添加路由及添加菜单项。因此，在模版的路由配置及菜单配置中，需引入这两个文件，ice-devtools 初始化的模版中已包含这两个文件，切勿删除或修改它们。更多细节，可查看 [iceworks 文档](https://ice.work/docs/guide/about)。
 
 至此，我们对飞冰的设计思想和物料数据规范有了大概的了解。如果你看完还是不知道如何开始动手，可以通过飞冰钉钉群联系我们。


### PR DESCRIPTION
1. `init-dev.md`:

The link of `material data protocol` is broken when viewed from the [website](https://ice.work/docs/materials/init-dev).

2. `schema.md`:

The file `iceworks/marterial-scaffold.md` is not present in the current directory anymore. Replaced it with a general link to reflect the correct meaning.