### PR TITLE
[iceworks] feat error boundary support

### DIFF
--- a/packages/iceworks-client/src/components/ErrorBoundary/FallbackComponent.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/FallbackComponent.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Loading } from '@alifd/next';
+
+const FallbackComponent = () => {
+  return (
+    <div
+      style={{
+        minWidth: '240px',
+        minHeight: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Loading tip="Loading..." />
+    </div>
+  );
+};
+export default FallbackComponent;

--- a/packages/iceworks-client/src/components/ErrorBoundary/FallbackComponent.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/FallbackComponent.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import { Loading } from '@alifd/next';
 
-const FallbackComponent = () => {
+const FallbackComponent = ({ intl }) => {
   return (
     <div
       style={{
@@ -11,8 +13,15 @@ const FallbackComponent = () => {
         justifyContent: 'center',
       }}
     >
-      <Loading tip="Loading..." />
+      <Loading
+        tip={intl.formatMessage({ id: 'iceworks.global.fallback.title' })}
+      />
     </div>
   );
 };
-export default FallbackComponent;
+
+FallbackComponent.propTypes = {
+  intl: PropTypes.object.isRequired,
+};
+
+export default injectIntl(FallbackComponent);

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -22,6 +22,11 @@ class ErrorBoundary extends Component {
     error: null,
   };
 
+  static getDerivedStateFromError() {
+    // Update state so the next render will show the fallback UI.
+    return { error: true };
+  }
+
   componentDidCatch(error, info) {
     const { onError } = this.props;
 
@@ -33,8 +38,6 @@ class ErrorBoundary extends Component {
         console.log(err);
       }
     }
-
-    this.setState({ error });
   }
 
   render() {

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -52,7 +52,7 @@ class ErrorBoundary extends Component {
 export const withErrorBoundary = (
   WrappedComponent,
   FallbackComponent,
-  onError
+  onError,
 ) => {
   const Wrapped = (props) => {
     return (

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -21,6 +21,7 @@ class ErrorBoundary extends Component {
 
   state = {
     error: null,
+    info: null,
   };
 
   static getDerivedStateFromError() {
@@ -37,14 +38,16 @@ class ErrorBoundary extends Component {
     } catch (err) {
       logger.error(error);
     }
+
+    this.setState({ info });
   }
 
   render() {
     const { children, FallbackComponent } = this.props;
-    const { error } = this.state;
+    const { error, info } = this.state;
 
     if (error !== null) {
-      return <FallbackComponent />;
+      return <FallbackComponent error={error} info={info} />;
     }
 
     return children;

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -1,6 +1,7 @@
 /* eslint no-console:0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import logger from '@utils/logger';
 import DefaultFallbackComponent from './FallbackComponent';
 
 // Why not use hooks：
@@ -14,7 +15,7 @@ class ErrorBoundary extends Component {
   };
 
   static defaultProps = {
-    onError: () => {},
+    onError: (error) => logger.error(error),
     FallbackComponent: <DefaultFallbackComponent />,
   };
 
@@ -30,13 +31,11 @@ class ErrorBoundary extends Component {
   componentDidCatch(error, info) {
     const { onError } = this.props;
 
-    if (typeof onError === 'function') {
-      try {
-        // can also log the error to an error reporting service
-        onError.call(this, error, info ? info.componentStack : '');
-      } catch (err) {
-        console.log(err);
-      }
+    try {
+      // can also log the error to an error reporting service
+      onError.call(this, error, info ? info.componentStack : '');
+    } catch (err) {
+      logger.error(error);
     }
   }
 

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -24,22 +24,12 @@ class ErrorBoundary extends Component {
     info: null,
   };
 
-  static getDerivedStateFromError() {
-    // Update state so the next render will show the fallback UI.
-    return { error: true };
-  }
-
   componentDidCatch(error, info) {
     const { onError } = this.props;
 
-    try {
-      // can also log the error to an error reporting service
-      onError.call(this, error, info ? info.componentStack : '');
-    } catch (err) {
-      logger.error(error);
-    }
-
-    this.setState({ info });
+    this.setState({ error, info }, () => {
+      onError(error, info);
+    });
   }
 
   render() {
@@ -61,10 +51,7 @@ export const withErrorBoundary = (
 ) => {
   const Wrapped = (props) => {
     return (
-      <ErrorBoundary
-        FallbackComponent={FallbackComponent}
-        onError={onError}
-      >
+      <ErrorBoundary FallbackComponent={FallbackComponent} onError={onError}>
         <WrappedComponent {...props} />
       </ErrorBoundary>
     );

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -1,0 +1,78 @@
+/* eslint no-console:0 */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import DefaultFallbackComponent from './FallbackComponent';
+
+// Why not use hooks：
+// docs: https://reactjs.org/docs/hooks-faq.html#do-hooks-work-with-static-typing
+// issue:  https://github.com/facebook/react/issues/14347
+class ErrorBoundary extends Component {
+  static propTypes = {
+    onError: PropTypes.func,
+    FallbackComponent: PropTypes.any,
+    children: PropTypes.node.isRequired,
+  };
+
+  static defaultProps = {
+    onError: () => {},
+    FallbackComponent: <DefaultFallbackComponent />,
+  };
+
+  state = {
+    error: null,
+  };
+
+  componentDidCatch(error, info) {
+    const { onError } = this.props;
+
+    if (typeof onError === 'function') {
+      try {
+        // can also log the error to an error reporting service
+        onError.call(this, error, info ? info.componentStack : '');
+      } catch (err) {
+        console.log(err);
+      }
+    }
+
+    this.setState({ error });
+  }
+
+  render() {
+    const { children, FallbackComponent } = this.props;
+    const { error } = this.state;
+
+    if (error !== null) {
+      return <FallbackComponent />;
+    }
+
+    return children;
+  }
+}
+
+export const withErrorBoundary = (
+  WrappedComponent,
+  FallbackComponent,
+  onError
+) => {
+  const Wrapped = (props) => {
+    return (
+      <ErrorBoundary
+        FallbackComponent={FallbackComponent || DefaultFallbackComponent}
+        onError={onError}
+      >
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    );
+  };
+
+  // Give this component a more helpful display name in DevTools.
+  // docs: https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
+  const ComponentName = WrappedComponent.displayName || WrappedComponent.name;
+  Wrapped.displayName = ComponentName
+    ? `WithErrorBoundary(${ComponentName})`
+    : 'WithErrorBoundary';
+
+  return Wrapped;
+};
+
+export default ErrorBoundary;

--- a/packages/iceworks-client/src/components/ErrorBoundary/index.js
+++ b/packages/iceworks-client/src/components/ErrorBoundary/index.js
@@ -59,7 +59,7 @@ export const withErrorBoundary = (
   const Wrapped = (props) => {
     return (
       <ErrorBoundary
-        FallbackComponent={FallbackComponent || DefaultFallbackComponent}
+        FallbackComponent={FallbackComponent}
         onError={onError}
       >
         <WrappedComponent {...props} />

--- a/packages/iceworks-client/src/locales/en-US/index.js
+++ b/packages/iceworks-client/src/locales/en-US/index.js
@@ -4,6 +4,7 @@ export default {
   'iceworks.global.disconnect': 'Disconnect',
   'iceworks.global.button.yes': 'Yes',
   'iceworks.global.button.no': 'No',
+  'iceworks.global.fallback.title': 'Loading',
 
   // menu
   'iceworks.menu.project': 'Project',
@@ -32,6 +33,8 @@ export default {
 
   // project panel
   'iceworks.project.panel.page.title': 'Page',
+  'iceworks.project.panel.fallback.title': 'Panel',
+  'iceworks.project.panel.fallback.desc': 'Panel loading error',
 
   // project dependency
   'iceworks.project.panel.dependency.title': 'Dependency',

--- a/packages/iceworks-client/src/locales/zh-CN/index.js
+++ b/packages/iceworks-client/src/locales/zh-CN/index.js
@@ -4,6 +4,7 @@ export default {
   'iceworks.global.disconnect': '断开连接',
   'iceworks.global.button.yes': '确定',
   'iceworks.global.button.no': '取消',
+  'iceworks.global.fallback.title': '加载错误',
 
   // menu
   'iceworks.menu.project': '项目',
@@ -31,9 +32,11 @@ export default {
   'iceworks.project.submenu.opts.createProject': '创建项目',
 
   // project panel
+  'iceworks.project.panel.page.title': '页面管理',
+  'iceworks.project.panel.fallback.title': '面板',
+  'iceworks.project.panel.fallback.desc': '面板加载出错',
 
   // project page
-  'iceworks.project.panel.page.title': '页面管理',
   'iceworks.project.panel.page.create.title': '创建页面',
   'iceworks.project.panel.page.create.progress.start': '开始创建页面...',
   'iceworks.project.panel.page.delete.title': '删除页面',

--- a/packages/iceworks-client/src/pages/Project/components/FallbackPanel/index.js
+++ b/packages/iceworks-client/src/pages/Project/components/FallbackPanel/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Loading } from '@alifd/next';
+import Panel from '../Panel';
+
+const FallbackPanel = () => {
+  return (
+    <Panel header={<h3>Loading Error</h3>}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+        }}
+      >
+        <Loading tip="Loading..." />
+      </div>
+    </Panel>
+  );
+};
+
+export default FallbackPanel;

--- a/packages/iceworks-client/src/pages/Project/components/FallbackPanel/index.js
+++ b/packages/iceworks-client/src/pages/Project/components/FallbackPanel/index.js
@@ -1,10 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import { Loading } from '@alifd/next';
 import Panel from '../Panel';
 
-const FallbackPanel = () => {
+const FallbackPanel = ({ intl }) => {
   return (
-    <Panel header={<h3>Loading Error</h3>}>
+    <Panel
+      header={
+        <h3>
+          {intl.formatMessage({ id: 'iceworks.project.panel.fallback.title' })}
+        </h3>
+      }
+    >
       <div
         style={{
           display: 'flex',
@@ -13,10 +21,24 @@ const FallbackPanel = () => {
           height: '100%',
         }}
       >
-        <Loading tip="Loading..." />
+        <Loading
+          inline={false}
+          tip={
+            <div style={{ minWidth: '100px' }}>
+              {intl.formatMessage({
+                id: 'iceworks.project.panel.fallback.desc',
+              })}
+              ...
+            </div>
+          }
+        />
       </div>
     </Panel>
   );
 };
 
-export default FallbackPanel;
+FallbackPanel.propTypes = {
+  intl: PropTypes.object.isRequired,
+};
+
+export default injectIntl(FallbackPanel);

--- a/packages/iceworks-client/src/pages/Project/components/LayoutPanel/index.js
+++ b/packages/iceworks-client/src/pages/Project/components/LayoutPanel/index.js
@@ -17,7 +17,6 @@ const LayoutPanel = () => {
         </h3>
       }
     >
-      {AST_Await.ccc}
       {dataSource.length ? (
         <div className={styles.main}>
           {dataSource.map(({ name, title }) => {

--- a/packages/iceworks-client/src/pages/Project/components/LayoutPanel/index.js
+++ b/packages/iceworks-client/src/pages/Project/components/LayoutPanel/index.js
@@ -10,25 +10,31 @@ const LayoutPanel = () => {
   const { dataSource } = layouts;
 
   return (
-    <Panel header={<h3><FormattedMessage id="iceworks.project.panel.layout.title" /></h3>}>
-      {
-        dataSource.length ?
-          <div className={styles.main}>
-            {dataSource.map(({ name, title }) => {
-              return (
-                <div key={name} className={styles.item}>
-                  <strong>
-                    {name}
-                  </strong>
-                  <span>
-                    {title}
-                  </span>
-                </div>
-              );
-            })}
-          </div> :
-          <Message title={<FormattedMessage id="iceworks.project.panel.layout.none" />} type="help" />
+    <Panel
+      header={
+        <h3>
+          <FormattedMessage id="iceworks.project.panel.layout.title" />
+        </h3>
       }
+    >
+      {AST_Await.ccc}
+      {dataSource.length ? (
+        <div className={styles.main}>
+          {dataSource.map(({ name, title }) => {
+            return (
+              <div key={name} className={styles.item}>
+                <strong>{name}</strong>
+                <span>{title}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <Message
+          title={<FormattedMessage id="iceworks.project.panel.layout.none" />}
+          type="help"
+        />
+      )}
     </Panel>
   );
 };

--- a/packages/iceworks-client/src/pages/Project/index.js
+++ b/packages/iceworks-client/src/pages/Project/index.js
@@ -4,6 +4,8 @@ import stores from '@stores';
 import logger from '@utils/logger';
 import useModal from '@hooks/useModal';
 import mockData from '@src/mock';
+import ErrorBoundary from '@components/ErrorBoundary';
+import FallbackPanel from './components/FallbackPanel';
 import SubMenu from './components/SubMenu';
 import OpenProjectModal from './components/OpenProjectModal';
 import DeleteProjectModal from './components/DeleteProjectModal';
@@ -32,10 +34,7 @@ const panels = {
 };
 
 const Project = () => {
-  const {
-    on: onOpenProjectModal,
-    setModal: setOpenProjectModal,
-  } = useModal();
+  const { on: onOpenProjectModal, setModal: setOpenProjectModal } = useModal();
   const {
     on: onDeleteProjectModal,
     toggleModal: toggleDeleteProjectModal,
@@ -99,7 +98,6 @@ const Project = () => {
     await refreshProjects();
     toggleDeleteProjectModal();
   }
-
 
   async function createProject(data) {
     await projects.create(data);
@@ -182,25 +180,23 @@ const Project = () => {
         onCancel={toggleCreateProjectModal}
         onOk={onCreateProject}
       />
-      {
-        projects.dataSource.length && project.dataSource.panels.length ?
-          (
-            <div className={styles.main}>
-              {
-                project.dataSource.panels.map(name => {
-                  const Panel = panels[name];
-                  return Panel ? <Panel /> : null;
-                })
-              }
-            </div>
-          ) :
-          (
-            <Guide
-              onOpenProject={onOpenProject}
-              onCreateProject={onCreateProject}
-            />
-          )
-      }
+      {projects.dataSource.length && project.dataSource.panels.length ? (
+        <div className={styles.main}>
+          {project.dataSource.panels.map((name) => {
+            const Panel = panels[name];
+            return Panel ? (
+              <ErrorBoundary FallbackComponent={<FallbackPanel />}>
+                <Panel />
+              </ErrorBoundary>
+            ) : null;
+          })}
+        </div>
+      ) : (
+        <Guide
+          onOpenProject={onOpenProject}
+          onCreateProject={onCreateProject}
+        />
+      )}
     </div>
   );
 };

--- a/packages/iceworks-client/src/pages/Project/index.js
+++ b/packages/iceworks-client/src/pages/Project/index.js
@@ -185,7 +185,7 @@ const Project = () => {
           {project.dataSource.panels.map((name, index) => {
             const Panel = panels[name];
             return Panel ? (
-              <ErrorBoundary key={index} FallbackComponent={<FallbackPanel />}>
+              <ErrorBoundary key={index} FallbackComponent={FallbackPanel}>
                 <Panel />
               </ErrorBoundary>
             ) : null;

--- a/packages/iceworks-client/src/pages/Task/index.js
+++ b/packages/iceworks-client/src/pages/Task/index.js
@@ -7,6 +7,7 @@ import useModal from '@hooks/useModal';
 import Card from '@components/Card';
 import TaskBar from '@components/TaskBar';
 import XtermTerminal from '@components/XtermTerminal';
+import { withErrorBoundary } from '@components/ErrorBoundary';
 import stores from '@stores';
 import termManager from '@utils/termManager';
 import taskStores from './stores';
@@ -110,4 +111,4 @@ Task.propTypes = {
   intl: PropTypes.object.isRequired,
 };
 
-export default injectIntl(Task);
+export default injectIntl(withErrorBoundary(Task));


### PR DESCRIPTION
## 背景

> 问题：部分 UI 的 JavaScript 错误不应该导致整个应用崩溃

* 详见 https://github.com/alibaba/ice/pull/2036 由于未补获的错误导致整个应用 crash，对用户体验及其不好
* 在当前 iceworks 架构下是按照功能模块进行设计的，由此引申模块之间的功能是相互独立的，即使某个模块出错，也只会对当前功能模块有影响

## 方案

> 解决：使用 React 提供的 `Error Boundaries` 进行错误处理和兜底的 UI 展示

封装 `<ErrorBoundary>` 组件处理错误边界，提供两种使用方式：

#### 组件方式

```jsx
import ErrorBoundary from '@components/ErrorBoundary';

<ErrorBoundary>
  <WrappedComponent />
</ErrorBoundary>
```


#### HOC 方式

```jsx
import {  withErrorBoundary } from '@components/ErrorBoundary';

const WrappedComponent = () => {
   // some code
}

export default withErrorBoundary(WrappedComponent)

```

## 其他

自定义 `Fallback Component` 组件和 `onError` 错误处理

```jsx
// Component
<ErrorBoundary FallbackComponent={  } onError={  }>
    <WrappedComponent />
<ErrorBoundary />

or

// HOC
withErrorBoundary(
  WrappedComponent,
  FallbackComponent,  // Or pass in your own fallback component
  onErrorHandler: (error, componentStack) => {
    // Do something with the error
    // Can also log the error to an error reporting service
  },
);

```

## 效果图

![image](https://user-images.githubusercontent.com/3995814/58525158-407aa800-81fd-11e9-88c9-b16352c97c13.png)



