### PR TITLE
fix: 版本自动更新问题

### DIFF
--- a/tools/iceworks/gulpfile.js
+++ b/tools/iceworks/gulpfile.js
@@ -465,7 +465,6 @@ gulp.task('oss', async () => {
     const macDist = [
       `${productName}-${version}.dmg`,
       `${productName}-${version}-mac.zip`,
-      `${channel}-mac.json`,
       `${channel}-mac.yml`,
     ];
 


### PR DESCRIPTION
https://github.com/alibaba/ice/issues/2074

原因：

- 在老版本中使用的 electron-builder 版本是 [20.20.x](https://github.com/alibaba/ice/blob/iceworks/2.18.2/tools/iceworks/package.json#L71)，打包产出 latest-mac.json/latest-mac.yml ，检查更新时会获取 latest-mac.yml 的内容；
- 在新版本中使用的 electron-builder 版本是 20.39.0，打包产出 latest-mac.yml，检查更新时会获取 latest-mac.yml 的内容。

在发布过程中，由于 json 文件不存在，所以上传 `latest-mac.json` 将失败，下面流程不再执行，`latest-mac.yml` 没有上传。导致获取更新时没有更新。