### PR TITLE
fix: compatible when the project is deleted

### DIFF
--- a/tools/iceworks/renderer/src/stores/extensions.js
+++ b/tools/iceworks/renderer/src/stores/extensions.js
@@ -98,10 +98,10 @@ class Extensions {
       }, gitConfig);
     }
 
-    if (projects.currentProject) {
+    if (projects && projects.currentProject && projects.currentProject.pkgData) {
       const { pkgData = {} } = projects.currentProject;
-      const { devDependencies = {} } = pkgData;
-      if (/^\^1\./.test(devDependencies['ice-scripts'])) {
+      const { devDependencies } = pkgData;
+      if (devDependencies && /^\^1\./.test(devDependencies['ice-scripts'])) {
         this.list.push({
           name: 'proxies',
           cover: require('../static/prories@3x.png'), // 1x1 的封面图


### PR DESCRIPTION
## 问题
issue: https://github.com/alibaba/ice/issues/2117

用户创建项目，iceworks 会将对应的项目路径缓存到系统的某个文件中，当用户在命令行或者文件夹中把项目删除，在重新打开 iceworks 时会从缓存路径读取对应的项目信息，但是项目已经不存在了，读取失败导致引用到了 pkgData 的代码挂掉了

## 解决
![image](https://user-images.githubusercontent.com/3995814/59812093-53d1ec80-933f-11e9-9d7a-73edfcbc372c.png)
