### PR TITLE
Iceworks/rename adapter

### DIFF
--- a/packages/iceworks-server/src/lib/adapter-ice-scripts-1-kit-2/package.json
+++ b/packages/iceworks-server/src/lib/adapter-ice-scripts-1-kit-2/package.json
@@ -1,3 +1,0 @@
-{
-  "name": "adapter-ice-scripts-1-kit-2"
-}

--- a/packages/iceworks-server/src/lib/adapter-ice-scripts-2-kit-3/package.json
+++ b/packages/iceworks-server/src/lib/adapter-ice-scripts-2-kit-3/package.json
@@ -1,3 +1,0 @@
-{
-  "name": "adapter-ice-scripts-2-kit-3"
-}

--- a/packages/iceworks-server/src/lib/adapter-react-v1/README.md
+++ b/packages/iceworks-server/src/lib/adapter-react-v1/README.md
@@ -1,0 +1,3 @@
+# adapter-react-v1
+
+适用于 ice-scripts@1.x 的工程和 kit@2.x 的项目最佳实践

--- a/packages/iceworks-server/src/lib/adapter-react-v1/package.json
+++ b/packages/iceworks-server/src/lib/adapter-react-v1/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "adapter-react-v2"
+}

--- a/packages/iceworks-server/src/lib/adapter-react-v2/README.md
+++ b/packages/iceworks-server/src/lib/adapter-react-v2/README.md
@@ -1,0 +1,3 @@
+# adapter-react-v2
+
+适用于 ice-scripts@2.x 的工程和 kit@2.x 的项目最佳实践

--- a/packages/iceworks-server/src/lib/adapter-react-v2/package.json
+++ b/packages/iceworks-server/src/lib/adapter-react-v2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "adapter-react-v2"
+}

--- a/packages/iceworks-server/src/lib/adapter/README.md
+++ b/packages/iceworks-server/src/lib/adapter/README.md
@@ -1,0 +1,3 @@
+# adapter-react-v3
+
+适用于 ice-scripts@2.x 的工程和 kit@3.x 的项目最佳实践

--- a/packages/iceworks-server/src/lib/adapter/package.json
+++ b/packages/iceworks-server/src/lib/adapter/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "adapter-ice-scripts-2-kit-2"
+  "name": "adapter-ice-v3"
 }


### PR DESCRIPTION
* issue: https://github.com/alibaba/ice/issues/2249#issuecomment-505744320

考虑到目前有分支基于 iceworks/release-3.x 在修改和未进行合并的分支，故暂时不对现有 adapter 进行命名，防止较大冲突，等功能稳定发布前在修改 `adapter => adapter-react-v3`