### PR TITLE
[iceworks ] fix: task status save in global

### DIFF
--- a/packages/iceworks-client/src/pages/Task/index.js
+++ b/packages/iceworks-client/src/pages/Task/index.js
@@ -35,7 +35,7 @@ function getType(pathname) {
 const Task = ({ history, intl }) => {
   const project = stores.useStore('project');
   const task = taskStores.useStore('task');
-  const { dataSource: { status }, setStatus, getStatus } = task;
+  const { dataSource, setStatus, getStatus } = task;
   const { on, toggleModal } = useModal();
   const type = getType(history.location.pathname);
 
@@ -122,21 +122,22 @@ const Task = ({ history, intl }) => {
   const startEventName = `adapter.task.start.data.${type}`;
   const stopEventName = `adapter.task.stop.data.${type}`;
 
+  const conf = (dataSource[type] && dataSource[type].conf) || [];
+  const status = (dataSource[type] && dataSource[type].status) || 'stop';
+
   // listen start event handle
   useSocket(startEventName, (data) => {
-    setStatus(data.status);
+    setStatus(type, data.status);
     const term = termManager.find(id);
     term.writeChunk(data.chunk);
   }, [status]);
 
   // listen stop event handle
   useSocket(stopEventName, (data) => {
-    setStatus(data.status);
+    setStatus(type, data.status);
     const term = termManager.find(id);
     term.writeChunk(data.chunk);
   }, [status]);
-
-  const data = task.dataSource[type] ? task.dataSource[type] : [];
 
   return (
     <Card
@@ -159,7 +160,7 @@ const Task = ({ history, intl }) => {
 
       <TaskModal
         on={on}
-        data={data}
+        data={conf}
         toggleModal={toggleModal}
         onConfirm={onConfirm}
       />

--- a/packages/iceworks-client/src/pages/Task/stores/task.js
+++ b/packages/iceworks-client/src/pages/Task/stores/task.js
@@ -2,11 +2,13 @@ import socket from '@src/socket';
 
 export default {
   dataSource: {
-    status: 'stop',
   },
 
-  setStatus(status) {
-    this.dataSource.status = status;
+  setStatus(type, status) {
+    if (!this.dataSource[type]) {
+      this.dataSource[type] = {};
+    }
+    this.dataSource[type].status = status;
   },
 
   async start(type) {
@@ -18,14 +20,23 @@ export default {
   },
 
   async getStatus(type) {
-    const status = await socket.emit('adapter.task.getStatus', { command: type });
-    this.dataSource.status = status;
+    const status = await socket.emit('adapter.task.getStatus', {
+      command: type,
+    });
+    if (!this.dataSource[type]) {
+      this.dataSource[type] = {};
+    }
+    this.dataSource[type].status = status;
   },
 
   async getConf(type) {
-    this.dataSource[type] = await socket.emit('adapter.task.getConf', {
+    const conf = await socket.emit('adapter.task.getConf', {
       command: type,
     });
+    if (!this.dataSource[type]) {
+      this.dataSource[type] = {};
+    }
+    this.dataSource[type].conf = conf;
   },
 
   async setConf(type, params) {

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -15,7 +15,7 @@ export default class Task implements ITaskModule {
   public project: IProject;
   public storage: any;
 
-  private status: string = TASK_STATUS_STOP;
+  private status: object = {};
 
   public readonly cliConfPath: string;
 
@@ -66,9 +66,9 @@ export default class Task implements ITaskModule {
     );
 
     this.process[command].stdout.on('data', (buffer) => {
-      this.status = TASK_STATUS_WORKING;
+      this.status[command] = TASK_STATUS_WORKING;
       ctx.socket.emit(`adapter.task.${eventName}`, {
-        status: this.status,
+        status: this.status[command],
         chunk: buffer.toString(),
       });
     });
@@ -76,9 +76,9 @@ export default class Task implements ITaskModule {
     this.process[command].on('close', () => {
       if (command === 'build' || command === 'lint') {
         this.process[command] = null;
-        this.status = TASK_STATUS_STOP;
+        this.status[command] = TASK_STATUS_STOP;
         ctx.socket.emit(`adapter.task.${eventName}`, {
-          status: this.status,
+          status: this.status[command],
           chunk: chalk.grey('Task has stopped'),
         });
       }
@@ -107,9 +107,9 @@ export default class Task implements ITaskModule {
     this.process[command].kill();
     this.process[command].on('exit', (code) => {
       if (code === 0) {
-        this.status = TASK_STATUS_STOP;
+        this.status[command] = TASK_STATUS_STOP;
         ctx.socket.emit(`adapter.task.${eventName}`, {
-          status: this.status,
+          status: this.status[command],
           chunk: chalk.grey('Task has stopped'),
         });
       }
@@ -121,7 +121,8 @@ export default class Task implements ITaskModule {
   }
 
   getStatus (args: ITaskParam) {
-    return this.status;
+    const { command } = args;
+    return this.status[command];
   }
 
   /**


### PR DESCRIPTION
fix: 不同的task任务的状态错误地保存在一个变量中导致相互影响