### PR TITLE
[iceworks] fix: xterm style

### DIFF
--- a/packages/iceworks-client/src/components/GlobalBar/index.module.scss
+++ b/packages/iceworks-client/src/components/GlobalBar/index.module.scss
@@ -13,11 +13,11 @@
     height: 300px;
     overflow: hidden;
     box-shadow: 0 -2px 10px rgba(51, 51, 51, 0.35);
-    display: block;
+    visibility: show;
   }
 
   .hidden {
-    display: none;
+    visibility: hidden;
   }
 
   .closeIcon {


### PR DESCRIPTION
fix: xterm样式使用display：none隐藏导致初始化宽度未撑开，改用visibility: hidden隐藏