### PR TITLE
[iceworks] kill process pid

### DIFF
--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -50,6 +50,7 @@
     "semver": "^6.0.0",
     "simple-git": "^1.113.0",
     "tar": "^4.4.8",
+    "terminate": "^2.1.2",
     "trash": "^5.2.0",
     "uid": "^0.0.2",
     "uppercamelcase": "^3.0.0",

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -1,6 +1,7 @@
 import * as execa from 'execa';
 import * as detectPort from 'detect-port';
 import * as path from 'path';
+import * as terminate from 'terminate';
 import chalk from 'chalk';
 import * as ipc from './ipc';
 import { getCLIConf, setCLIConf, mergeCLIConf } from '../../utils/cliConf';
@@ -104,18 +105,20 @@ export default class Task implements ITaskModule {
       ipc.stop();
     }
 
-    this.process[command].kill();
-    this.process[command].on('exit', (code) => {
-      if (code === 0) {
-        this.status[command] = TASK_STATUS_STOP;
-        ctx.socket.emit(`adapter.task.${eventName}`, {
-          status: this.status[command],
-          chunk: chalk.grey('Task has stopped'),
-        });
+    const { pid } = this.process[command];
+    terminate(pid, (err) => {
+      if (err) {
+        throw err;
       }
-    });
 
-    this.process[command] = null;
+      this.status[command] = TASK_STATUS_STOP;
+      this.process[command] = null;
+
+      ctx.socket.emit(`adapter.task.${eventName}`, {
+        status: this.status[command],
+        chunk: chalk.grey('Task has stopped'),
+      });
+    })
 
     return this;
   }


### PR DESCRIPTION
* 直接调用子进程的 kill() 可以关闭子进程，但是无法关闭子进程打开的其它子进程。需要通过进程 ID 结束进程和子进程。