### PR TITLE
[iceworks] publish flow

### DIFF
--- a/packages/iceworks-client/ice.config.js
+++ b/packages/iceworks-client/ice.config.js
@@ -1,6 +1,8 @@
 const { resolve } = require('path');
 
 module.exports = {
+  publicPath: 'https://unpkg.com/iceworks-client@latest/build/',
+
   alias: {
     '@src': resolve(__dirname, 'src/'),
     '@layouts': resolve(__dirname, 'src/layouts/'),

--- a/packages/iceworks-client/package.json
+++ b/packages/iceworks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks-client",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "",
   "files": [
     "build"

--- a/packages/iceworks-client/package.json
+++ b/packages/iceworks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks-client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "",
   "files": [
     "build"

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/install.js",
-    "start": "egg-scripts start --title=egg-server-iceworks-server --framework=midway",
+    "start": "egg-scripts start --title=egg-server-iceworks-server --framework=midway --sticky",
     "stop": "egg-scripts stop --title=egg-server-iceworks-server",
     "start_build": "npm run build && NODE_ENV=development midway-bin dev",
     "dev": "NODE_ENV=local midway-bin dev --ts",

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -4,7 +4,6 @@
   "description": "iceworks server",
   "files": [
     "dist/",
-    "data/",
     "scripts/"
   ],
   "dependencies": {

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks-server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "iceworks server",
   "files": [
     "dist/",

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -1,10 +1,11 @@
 {
   "name": "iceworks-server",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.5",
   "description": "iceworks server",
   "files": [
     "dist/",
-    "data/"
+    "data/",
+    "scripts/"
   ],
   "dependencies": {
     "@babel/generator": "^7.4.4",
@@ -73,7 +74,7 @@
     "node": ">=8.9.0"
   },
   "scripts": {
-    "postinstall": "node scripts/install.js",
+    "postinstall": "node ./scripts/install.js",
     "start": "egg-scripts start --title=egg-server-iceworks-server --framework=midway",
     "stop": "egg-scripts stop --title=egg-server-iceworks-server",
     "start_build": "npm run build && NODE_ENV=development midway-bin dev",

--- a/packages/iceworks-server/src/app/middleware/client.ts
+++ b/packages/iceworks-server/src/app/middleware/client.ts
@@ -10,9 +10,9 @@ export default function() {
     ctx.clientConfig = {
       // TODO: 区分环境和端口检测
       // default use iceworks-client@latest
-      clientPath: '//unpkg.com/iceworks-client@latest/build/',
-      socketUrl: '//127.0.0.1:7001/',
-      apiUrl: '//127.0.0.1:7001/api/',
+      clientPath: 'https://unpkg.com/iceworks-client@1.0.0-beta.3/build/',
+      socketUrl: `//127.0.0.1:${process.env.PORT}/`,
+      apiUrl: `//127.0.0.1:${process.env.PORT}/api/`,
       isAliInternal: await checkAliInternal(),
     };
 

--- a/packages/iceworks-server/src/app/middleware/client.ts
+++ b/packages/iceworks-server/src/app/middleware/client.ts
@@ -8,9 +8,8 @@ export default function() {
     }
 
     ctx.clientConfig = {
-      // TODO: 区分环境和端口检测
       // default use iceworks-client@latest
-      clientPath: 'https://unpkg.com/iceworks-client@1.0.0-beta.3/build/',
+      clientPath: 'https://unpkg.com/iceworks-client@latest/build/',
       socketUrl: `//127.0.0.1:${process.env.PORT}/`,
       apiUrl: `//127.0.0.1:${process.env.PORT}/api/`,
       isAliInternal: await checkAliInternal(),


### PR DESCRIPTION
* 动态端口获取，端口逻辑 iceworks CLI => Server Middleware => Client Socket
* 由于 socket.io 的设计，在多进程中服务器必须在 sticky 模式下工作，故需要给 startCluster 传递 sticky 参数。
* 前端资源按需加载需要指定 publicPath 路径