### PR TITLE
fix: fix write null file in node 8

### DIFF
--- a/packages/ice-npm-utils/CHANGELOG.md
+++ b/packages/ice-npm-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2
+
+- [fix] 修复getAndExtractTarball写空文件时卡死的问题
+
 ## 1.1.1
 
 - [fix] 用 request-promise 替换 axios 之后的参数变化

--- a/packages/ice-npm-utils/lib/index.js
+++ b/packages/ice-npm-utils/lib/index.js
@@ -65,7 +65,8 @@ function getAndExtractTarball(destDir, tarball, progressFunc = () => {}) {
         allWriteStream.push(new Promise((streamResolve) => {
           entry
             .pipe(fs.createWriteStream(destPath))
-            .on('finish', () => streamResolve());
+            .on('finish', () => streamResolve())
+            .on('close', () => streamResolve()); // resolve when file is empty in node v8
         }));
       })
       .on('end', () => {

--- a/packages/ice-npm-utils/package.json
+++ b/packages/ice-npm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-npm-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "npm utils for ice",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
修复getAndExtractTarball写空文件时卡死的问题

原因： nodev8.14.0环境下，writeStream写空文件时，不会触发finish事件,  node10下没有问题