### PR TITLE
[iceworks] fix: adpater-react-v1 getConfCLI error

### DIFF
--- a/packages/iceworks-client/src/pages/Engineering/index.js
+++ b/packages/iceworks-client/src/pages/Engineering/index.js
@@ -4,18 +4,22 @@ import SubRoutes from '@components/SubRoutes';
 import SubMenu from '@components/SubMenu';
 import SubMenuItem from '@components/SubMenuItem';
 import { getMenuData } from '@utils/getMenuData';
-
-import engineeringStores from './stores';
-
+import stores from '@stores';
 import styles from './index.module.scss';
 
 const Engineering = ({ routes }) => {
-  const conf = engineeringStores.useStore('configuration');
+  const projectStore = stores.useStore('project');
+
+  function isConfExist() {
+    return projectStore.dataSource.panels.some((panel) => {
+      return panel.name === 'Configuration';
+    })
+  }
 
   function getSubMenuData() {
     const hiddenPaths = [];
-    // if ice.config.js not found, hide configuration menu
-    if (!conf.dataSource.cli) {
+    // if configuration panel not found, hide configuration menu
+    if (!isConfExist()) {
       hiddenPaths.push('/task/configuration');
     }
     const menuData = getMenuData(hiddenPaths) || {};
@@ -25,13 +29,8 @@ const Engineering = ({ routes }) => {
 
   const [subMenuData, setSubMenuData] = useState([]);
 
-  async function onGetCLIConf() {
-    await conf.getCLIConf();
-    setSubMenuData(getSubMenuData());
-  }
-
   useEffect(() => {
-    onGetCLIConf();
+    setSubMenuData(getSubMenuData());
   }, []);
 
   return (

--- a/packages/iceworks-client/src/pages/Engineering/index.js
+++ b/packages/iceworks-client/src/pages/Engineering/index.js
@@ -13,7 +13,7 @@ const Engineering = ({ routes }) => {
   function isConfExist() {
     return projectStore.dataSource.panels.some((panel) => {
       return panel.name === 'Configuration';
-    })
+    });
   }
 
   function getSubMenuData() {


### PR DESCRIPTION
问题：现有是通过adpater取ice.config.js配置，进而进行设置菜单的显示隐藏。但是对于adpater-react-v1，由于ice-script v1不支持ice.config.js，adapter中不加载Configuration模块，导致client请求config报错。

fix: 通过Project store中的panels属性来判断Configuration模块是否存在，避免了发请求，不存在的话隐藏设置面板