### PR TITLE
feat: lint for iceworks-server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@ build/
 test/
 tests/
 node_modules/
+dist/
 
 # node 覆盖率文件
 coverage/
@@ -34,4 +35,4 @@ tools/iceworks
 tools/iceworks-cli
 tools/ice-devtools
 packages/iceworks-client
-packages/iceworks-server
+# packages/iceworks-server

--- a/.eslintignore
+++ b/.eslintignore
@@ -35,4 +35,3 @@ tools/iceworks
 tools/iceworks-cli
 tools/ice-devtools
 packages/iceworks-client
-# packages/iceworks-server

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ const { eslintTS, deepmerge } = require('@ice/spec');
 
 module.exports = deepmerge(eslintTS, {
   rules: {
-    // 禁止用var引入模块：取消
-    "@typescript-eslint/no-var-requires": 0
+    "@typescript-eslint/no-var-requires": 0,
+    "class-methods-use-this": 1,
   }
 });

--- a/packages/iceworks-server/src/app.ts
+++ b/packages/iceworks-server/src/app.ts
@@ -1,13 +1,13 @@
 import RemoteLogger from './lib/remoteLogger';
 
 export default class AppBootHook {
-  app: any;
+  public app: any;
 
   constructor(app) {
     this.app = app;
   }
 
-  async didLoad() {
+  public async didLoad() {
     // send server log to remote in production
     if (this.app.config.env === 'prod') {
       this.app.getLogger().set('remote', new RemoteLogger({ level: 'INFO' }));

--- a/packages/iceworks-server/src/app/controller/goldlog.ts
+++ b/packages/iceworks-server/src/app/controller/goldlog.ts
@@ -5,8 +5,8 @@ import * as rp from 'request';
 @controller('/api/goldlog')
 export class GoldlogController {
 
-    @post('/record')
-  async record(ctx) {
+  @post('/record')
+  public async record(ctx) {
     if (ctx.request.body) {
       const data = ctx.request.body;
       const dataKeyArray = Object.keys(data);

--- a/packages/iceworks-server/src/app/controller/goldlog.ts
+++ b/packages/iceworks-server/src/app/controller/goldlog.ts
@@ -6,37 +6,37 @@ import * as rp from 'request';
 export class GoldlogController {
 
     @post('/record')
-    async record(ctx) {
-      if (ctx.request.body) {
-        const data = ctx.request.body;
-        const dataKeyArray = Object.keys(data);
-        const gokey = dataKeyArray.reduce((finnalStr, currentKey, index) => {
-          const currentData =
+  async record(ctx) {
+    if (ctx.request.body) {
+      const data = ctx.request.body;
+      const dataKeyArray = Object.keys(data);
+      const gokey = dataKeyArray.reduce((finnalStr, currentKey, index) => {
+        const currentData =
             typeof data[currentKey] === 'string'
               ? data[currentKey]
               : JSON.stringify(data[currentKey]);
-          return `${finnalStr}${currentKey}=${currentData}${
-            dataKeyArray.length - 1 === index ? '' : '&'
-          }`;
-        }, '');
+        return `${finnalStr}${currentKey}=${currentData}${
+          dataKeyArray.length - 1 === index ? '' : '&'
+        }`;
+      }, '');
 
-        await rp({
-          method: 'post',
-          url: 'http://gm.mmstat.com/iceteam.iceworks.log3',
-          data: {
-            cache: Math.random(),
-            gmkey: 'CLK',
-            gokey: encodeURIComponent(gokey),
-            logtype: '2',
-          },
-        });
-        ctx.body = {
-          success: true
-        };
-      } else {
-        ctx.body = {
-          success: false,
-        };
-      }
+      await rp({
+        method: 'post',
+        url: 'http://gm.mmstat.com/iceteam.iceworks.log3',
+        data: {
+          cache: Math.random(),
+          gmkey: 'CLK',
+          gokey: encodeURIComponent(gokey),
+          logtype: '2',
+        },
+      });
+      ctx.body = {
+        success: true,
+      };
+    } else {
+      ctx.body = {
+        success: false,
+      };
     }
-  };
+  }
+};

--- a/packages/iceworks-server/src/app/controller/home.ts
+++ b/packages/iceworks-server/src/app/controller/home.ts
@@ -5,7 +5,7 @@ import { controller, get, provide } from 'midway';
 export class HomeController {
 
   @get('*')
-  async render(ctx) {
+  public async render(ctx) {
     await ctx.render('index.html');
     await ctx.render('index.html', ctx.clientConfig);
   }

--- a/packages/iceworks-server/src/app/io/controller/home/project.ts
+++ b/packages/iceworks-server/src/app/io/controller/home/project.ts
@@ -2,41 +2,41 @@ export default (app) => {
   const { Controller } = app;
 
   return class ProjectController extends Controller {
-    async list() {
+    public async list() {
       const { projectManager } = app;
       const projects = await projectManager.getProjects();
       return projects.map((project) => project.toJSON());
     }
 
-    async create(ctx) {
+    public async create(ctx) {
       const { projectManager } = app;
       const { args } = ctx;
 
       await projectManager.createProject(args);
     }
 
-    async delete(ctx) {
+    public async delete(ctx) {
       const { projectManager } = app;
       const { args } = ctx;
 
       await projectManager.deleteProject(args);
     }
 
-    async add(ctx) {
+    public async add(ctx) {
       const { projectManager } = app;
       const { args } = ctx;
       const { projectPath } = args;
       await projectManager.addProject(projectPath);
     }
 
-    async getCurrent() {
+    public async getCurrent() {
       const { projectManager } = app;
       const project = await projectManager.getCurrent();
 
       return project.toJSON();
     }
 
-    async setCurrent(ctx) {
+    public async setCurrent(ctx) {
       const { projectManager } = app;
       const { args } = ctx;
       const { path } = args;
@@ -45,21 +45,21 @@ export default (app) => {
       return project.toJSON();
     }
 
-    async setPanel(ctx) {
+    public async setPanel(ctx) {
       const { args } = ctx;
       const { projectManager } = app;
       const project = await projectManager.getCurrent();
       return project.setPanel(args);
     }
 
-    async sortPanels(ctx) {
+    public async sortPanels(ctx) {
       const { args } = ctx;
       const { projectManager } = app;
       const project = await projectManager.getCurrent();
       return project.sortPanels(args);
     }
 
-    async reloadAdapter() {
+    public async reloadAdapter() {
       const { projectManager, i18n } = app;
       const project = await projectManager.getCurrent();
       const result = await project.reloadAdapter(i18n);

--- a/packages/iceworks-server/src/app/io/controller/home/setting.ts
+++ b/packages/iceworks-server/src/app/io/controller/home/setting.ts
@@ -7,7 +7,7 @@ export default (app) => {
   const { Controller, i18n } = app;
 
   return class HomeController extends Controller {
-    async getWorkFolder() {
+    public async getWorkFolder() {
       const workFolder = storage.get('workFolder');
       const directories = await scanDirectory(workFolder);
       return {
@@ -16,7 +16,7 @@ export default (app) => {
       };
     }
 
-    async setWorkFolder(ctx) {
+    public async setWorkFolder(ctx) {
       const { args } = ctx;
       const { path: setPath } = args;
 
@@ -31,7 +31,7 @@ export default (app) => {
       };
     }
 
-    async setLocale(ctx) {
+    public async setLocale(ctx) {
       const { projectManager, i18n } = app;
       const project = await projectManager.getCurrent();
 
@@ -40,27 +40,27 @@ export default (app) => {
       storage.set('locale', ctx.args.locale);
     }
 
-    async getLocale() {
+    public async getLocale() {
       return storage.get('locale');
     }
 
-    async setTheme(ctx) {
+    public async setTheme(ctx) {
       storage.set('theme', ctx.args.theme);
     }
 
-    async getTheme() {
+    public async getTheme() {
       return storage.get('theme');
     }
 
-    async setEditor(ctx) {
+    public async setEditor(ctx) {
       storage.set('editor', ctx.args.editor);
     }
 
-    async getEditor() {
+    public async getEditor() {
       return storage.get('editor');
     }
 
-    async setUser({ args }) {
+    public async setUser({ args }) {
       const { name, workId, avatarUrl } = args;
       if (workId && name && avatarUrl) {
         storage.set('user', { name, workId, avatarUrl, isLogin: true });
@@ -71,7 +71,7 @@ export default (app) => {
       return storage.get('user');
     }
 
-    async getUser() {
+    public async getUser() {
       return storage.get('user');
     }
   };

--- a/packages/iceworks-server/src/app/io/controller/home/system.ts
+++ b/packages/iceworks-server/src/app/io/controller/home/system.ts
@@ -8,16 +8,16 @@ export default (app) => {
 
   // System capability
   return class SystemController extends Controller {
-    async getPath({ args }) {
+    public async getPath({ args }) {
       return path.join(...args);
     }
 
-    async openFolder(ctx) {
+    public async openFolder(ctx) {
       const { args: { path } } = ctx;
       return await openFolder(path);
     }
 
-    openEditor(ctx) {
+    public openEditor(ctx) {
       const { args: { path }, logger, socket } = ctx;
       const editor = storage.get('editor');
       logger.info('open editor:', path, editor);

--- a/packages/iceworks-server/src/app/io/controller/material/index.ts
+++ b/packages/iceworks-server/src/app/io/controller/material/index.ts
@@ -97,7 +97,7 @@ export default (app) => {
 
       const material = storage.get('material');
       const currentItem = {
-        official: false, name, description, homepage, logo, type, source
+        official: false, name, description, homepage, logo, type, source,
       };
       const newMaterials = material.filter((item) => item.name !== currentItem.name);
       newMaterials.unshift(currentItem)
@@ -199,6 +199,6 @@ const updateArrayItem = (array, item, itemIdx) => {
   return [
     ...array.slice(0, itemIdx),
     item,
-    ...array.slice(itemIdx + 1)
+    ...array.slice(itemIdx + 1),
   ];
 };

--- a/packages/iceworks-server/src/app/io/controller/material/index.ts
+++ b/packages/iceworks-server/src/app/io/controller/material/index.ts
@@ -12,7 +12,7 @@ const CATEGORY_ALL = '全部';
 
 export default (app) => {
   return class MaterialController extends app.Controller {
-    async getResources({ args }) {
+    public async getResources({ args }) {
       const resources = storage.get('material');
 
       if (args && args.type) {
@@ -22,7 +22,7 @@ export default (app) => {
       return resources;
     }
 
-    async getOne(ctx) {
+    public async getOne(ctx) {
       const { args: { url }, logger } = ctx;
 
       logger.info(`get material by url, url: ${url}`);
@@ -64,13 +64,13 @@ export default (app) => {
       return {...formatMaterialData(data), name: currentItem.name };
     }
 
-    async getRecommendScaffolds() {
+    public async getRecommendScaffolds() {
       const material = storage.get('material')[0];
       const { scaffolds = [] } = await request(material.source);
       return scaffolds.filter(({ name }) => RECOMMEND_SCAFFOLDS.includes(name));
     }
 
-    async add(ctx) {
+    public async add(ctx) {
       const { args: { url, name }, logger } = ctx;
       const allMaterials = storage.get('material');
       const existed = allMaterials.some(m => m.source === url);
@@ -108,7 +108,7 @@ export default (app) => {
       return { resource: storage.get('material'), current: { ...materialData, name } };
     }
 
-    async delete(ctx) {
+    public async delete(ctx) {
       const { args: { url }, logger } = ctx;
       logger.info(`delete material, source URL: ${url}`);
 

--- a/packages/iceworks-server/src/config/config.default.ts
+++ b/packages/iceworks-server/src/config/config.default.ts
@@ -2,7 +2,7 @@ export = (appInfo: any) => {
   const config: any = (exports = {});
 
   // use for cookie sign key, should change to your own and keep security
-  config.keys = appInfo.name + '_1555062042825_9790';
+  config.keys = `${appInfo.name  }_1555062042825_9790`;
 
   // middleware config
   config.middleware = ['client'];

--- a/packages/iceworks-server/src/config/config.default.ts
+++ b/packages/iceworks-server/src/config/config.default.ts
@@ -1,5 +1,5 @@
 export = (appInfo: any) => {
-  const config: any = (exports = {});
+  const config: any = {};
 
   // use for cookie sign key, should change to your own and keep security
   config.keys = `${appInfo.name  }_1555062042825_9790`;

--- a/packages/iceworks-server/src/config/plugin.ts
+++ b/packages/iceworks-server/src/config/plugin.ts
@@ -24,5 +24,5 @@ export = {
   i18n: {
     enable: true,
     path: path.join(__dirname, '../lib/plugin/i18n'),
-  }
+  },
 };

--- a/packages/iceworks-server/src/interface/dependency.ts
+++ b/packages/iceworks-server/src/interface/dependency.ts
@@ -45,21 +45,21 @@ export interface IDependencyModule extends IBaseModule {
   /**
    * 获取项目内的依赖
    */
-  getAll(): Promise<{ dependencies: IDependency[], devDependencies: IDependency[] }>;
+  getAll(): Promise<{ dependencies: IDependency[]; devDependencies: IDependency[] }>;
 
   /**
    * 添加依赖到项目
    *
    * @param dependency 依赖信息
    */
-  create(params: {dependency: ICreateDependencyParam, isDev?: boolean; }, ctx: IContext): Promise<void>;
+  create(params: {dependency: ICreateDependencyParam; isDev?: boolean }, ctx: IContext): Promise<void>;
 
   /**
    * 添加多个依赖到项目
    *
    * @param dependencies 依赖列表
    */
-  bulkCreate(params: {dependencies: ICreateDependencyParam[], isDev?: boolean; }, ctx: IContext): Promise<void>;
+  bulkCreate(params: {dependencies: ICreateDependencyParam[]; isDev?: boolean }, ctx: IContext): Promise<void>;
 
   /**
    * 重装依赖

--- a/packages/iceworks-server/src/interface/menu.ts
+++ b/packages/iceworks-server/src/interface/menu.ts
@@ -54,5 +54,5 @@ export interface IMenuModule extends IBaseModule {
   /**
    * bulk create menus
    */
-  bulkCreate(params: {data: IMenu[], options: IMenuOptions}): Promise<void>;
+  bulkCreate(params: {data: IMenu[]; options: IMenuOptions}): Promise<void>;
 }

--- a/packages/iceworks-server/src/interface/page.ts
+++ b/packages/iceworks-server/src/interface/page.ts
@@ -85,12 +85,6 @@ export interface ICreatePageParam {
 }
 
 export interface IPageModule extends IBaseModule {
-  /**
-   * 获取单个页面的信息
-   *
-   * @param name 页面名
-   */
-  getOne(name): Promise<IPage>;
 
   /**
    * 获取项目内的页面信息
@@ -109,25 +103,11 @@ export interface IPageModule extends IBaseModule {
   create(page: ICreatePageParam, ctx: IContext): Promise<IPage>;
 
   /**
-   * 添加多个页面到项目
-   *
-   * @param pages 页面配置信息
-   */
-  bulkCreate(pages: ICreatePageParam[]): Promise<IPage[]>;
-
-  /**
    * 删除项目内的页面
    *
    * @param name 页面名
    */
   delete(params: {name: string}): Promise<void>;
-
-  /**
-   * 更新页面
-   *
-   * @param page 页面信息
-   */
-  update(page: IPage): Promise<IPage>;
 
   /**
    * 获取区块列表

--- a/packages/iceworks-server/src/interface/page.ts
+++ b/packages/iceworks-server/src/interface/page.ts
@@ -142,7 +142,7 @@ export interface IPageModule extends IBaseModule {
    * @param block 区块信息
    * @param name 页面名称，如果无则添加区块的项目
    */
-  addBlock(params: {block: IMaterialBlock, name?: string; }, ctx: IContext): Promise<void>;
+  addBlock(params: {block: IMaterialBlock; name?: string }, ctx: IContext): Promise<void>;
 
   /**
    * 添加区块列表
@@ -150,5 +150,5 @@ export interface IPageModule extends IBaseModule {
    * @param blocks 区块列表
    * @param name 页面名称，如果无则添加区块列表到项目
    */
-  addBlocks(params: {blocks: IMaterialBlock[]; name?: string; }, ctx: IContext): Promise<void>;
+  addBlocks(params: {blocks: IMaterialBlock[]; name?: string }, ctx: IContext): Promise<void>;
 }

--- a/packages/iceworks-server/src/interface/router.ts
+++ b/packages/iceworks-server/src/interface/router.ts
@@ -40,7 +40,7 @@ export interface IRouterModule extends IBaseModule {
   /**
    * set routers
    */
-  bulkCreate(params: {data: IRouter[], options?: IRouterOptions}): Promise<void>;
+  bulkCreate(params: {data: IRouter[]; options?: IRouterOptions}): Promise<void>;
 
   /**
    * delete router by component name

--- a/packages/iceworks-server/src/lib/adapter-react-v1/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v1/index.ts
@@ -22,11 +22,11 @@ export default async (i18n) => {
     Task: baseAdapter.Task,
     Router: {
       ...baseAdapter.Router,
-      module: Router
+      module: Router,
     },
     Menu: {
       ...baseAdapter.Menu,
-      module: Menu
+      module: Menu,
     },
   };
 

--- a/packages/iceworks-server/src/lib/adapter-react-v1/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v1/modules/menu/index.ts
@@ -4,9 +4,10 @@ import { IProject } from '../../../../interface';
 
 export default class Menu extends baseModules.Menu {
   public readonly path: string;
+
   public configFilePath = 'menuConfig.js';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     super(params);
     this.path = path.join(this.project.path, 'src', this.configFilePath);
   }

--- a/packages/iceworks-server/src/lib/adapter-react-v1/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v1/modules/router/index.ts
@@ -4,9 +4,10 @@ import { IProject } from '../../../../interface';
 
 export default class Router extends baseModules.Router {
   public readonly path: string;
+
   public configFilePath = 'routerConfig.js';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     super(params);
     this.path = path.join(this.project.path, 'src', this.configFilePath);
   }

--- a/packages/iceworks-server/src/lib/adapter-react-v2/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v2/index.ts
@@ -13,11 +13,11 @@ export default async (i18n) => {
     ...baseAdapter,
     Router: {
       ...baseAdapter.Router,
-      module: Router
+      module: Router,
     },
     Menu: {
       ...baseAdapter.Menu,
-      module: Menu
+      module: Menu,
     },
   };
 

--- a/packages/iceworks-server/src/lib/adapter-react-v2/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v2/modules/menu/index.ts
@@ -4,9 +4,10 @@ import { IProject } from '../../../../interface';
 
 export default class Menu extends baseModules.Menu {
   public readonly path: string;
+
   public configFilePath = 'menuConfig.js';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     super(params);
     this.path = path.join(this.project.path, 'src', this.configFilePath);
   }

--- a/packages/iceworks-server/src/lib/adapter-react-v2/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v2/modules/router/index.ts
@@ -4,9 +4,10 @@ import { IProject } from '../../../../interface';
 
 export default class Router extends baseModules.Router {
   public readonly path: string;
+
   public configFilePath = 'routerConfig.js';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     super(params);
     this.path = path.join(this.project.path, 'src', this.configFilePath);
   }

--- a/packages/iceworks-server/src/lib/adapter-react-v3/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-react-v3/index.ts
@@ -7,7 +7,7 @@ import getBaseAdapter from '../adapter';
 export default async (i18n) => {
   const baseAdapter = await getBaseAdapter(i18n);
   const adapter = {
-    ...baseAdapter
+    ...baseAdapter,
   };
 
   const isAliInternal = await checkAliInternal();

--- a/packages/iceworks-server/src/lib/adapter-vue-v1/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-vue-v1/index.ts
@@ -14,12 +14,12 @@ export default async (i18n) => {
     Dependency: baseAdapter.Dependency,
     Task: {
       ...baseAdapter.Task,
-      module: Task
+      module: Task,
     },
     Configuration: {
       ...baseAdapter.Configuration,
-      module: Configuration
-    }
+      module: Configuration,
+    },
   };
 
   const isAliInternal = await checkAliInternal();

--- a/packages/iceworks-server/src/lib/adapter-vue-v1/modules/configuration/getConfigSchema.ts
+++ b/packages/iceworks-server/src/lib/adapter-vue-v1/modules/configuration/getConfigSchema.ts
@@ -27,8 +27,8 @@ export default () => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: true
+        defaultChecked: true,
       },
-    }
+    },
   ];
 };

--- a/packages/iceworks-server/src/lib/adapter-vue-v1/modules/configuration/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-vue-v1/modules/configuration/index.ts
@@ -4,6 +4,7 @@ import getConfigSchema from './getConfigSchema';
 
 export default class Configuration extends baseModules.Configuration {
   public cliConfFilename = 'vue.config.js';
+
   public getConfigSchema = getConfigSchema;
 
   public cliConfPath: string;

--- a/packages/iceworks-server/src/lib/adapter-vue-v1/modules/task/getTaskConfig.ts
+++ b/packages/iceworks-server/src/lib/adapter-vue-v1/modules/task/getTaskConfig.ts
@@ -29,7 +29,7 @@ export default () => {
       componentProps: {
         defaultChecked: false,
       },
-    }
+    },
   ];
 
   const build = [
@@ -57,9 +57,9 @@ export default () => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: true
+        defaultChecked: true,
       },
-    }
+    },
   ];
 
   const lint = [];

--- a/packages/iceworks-server/src/lib/adapter-vue-v1/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter-vue-v1/modules/task/index.ts
@@ -4,6 +4,7 @@ import getTaskConfig from './getTaskConfig';
 
 export default class Task extends baseModules.Task {
   public cliConfFilename = 'vue.config.js';
+
   public cliConfPath: string;
 
   public getTaskConfig = getTaskConfig;

--- a/packages/iceworks-server/src/lib/adapter/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/index.ts
@@ -39,7 +39,7 @@ export default async (i18n: II18n) => {
     Guide: {
       cover: 'https://img.alicdn.com/tfs/TB1CDlTdEKF3KVjSZFEXXXExFXa-300-300.png',
       isAvailable: true,
-      module: null
+      module: null,
     },
     QuickDev: {
       cover: 'https://img.alicdn.com/tfs/TB1hcJCe.uF3KVjSZK9XXbVtXXa-300-300.png',
@@ -49,27 +49,27 @@ export default async (i18n: II18n) => {
     Dependency: {
       cover: 'https://img.alicdn.com/tfs/TB1nPY8c21H3KVjSZFBXXbSMXXa-300-300.png',
       isAvailable: true,
-      module: Dependency
+      module: Dependency,
     },
     Page: {
       cover: 'https://img.alicdn.com/tfs/TB1Vl4javBj_uVjSZFpXXc0SXXa-300-300.png',
       isAvailable: true,
-      module: Page
+      module: Page,
     },
     Layout: {
       cover: 'https://img.alicdn.com/tfs/TB1KUD8c4iH3KVjSZPfXXXBiVXa-300-300.png',
       isAvailable: false,
-      module: Layout
+      module: Layout,
     },
     Router: {
       cover: 'https://img.alicdn.com/tfs/TB1mZ.Xc8GE3KVjSZFhXXckaFXa-300-300.png',
       isAvailable: false,
-      module: Router
+      module: Router,
     },
     Menu: {
       cover: 'https://img.alicdn.com/tfs/TB1mZ.Xc8GE3KVjSZFhXXckaFXa-300-300.png',
       isAvailable: false,
-      module: Menu
+      module: Menu,
     },
     QuickBuild: {
       cover: 'https://img.alicdn.com/tfs/TB1P8pAe79E3KVjSZFGXXc19XXa-300-300.png',
@@ -79,32 +79,32 @@ export default async (i18n: II18n) => {
     Git: {
       cover: 'https://img.alicdn.com/tfs/TB1GVb_c79E3KVjSZFGXXc19XXa-300-300.png',
       isAvailable: false,
-      module: Git
+      module: Git,
     },
     OSS: {
       cover: 'https://img.alicdn.com/tfs/TB1mZ.Xc8GE3KVjSZFhXXckaFXa-300-300.png',
       isAvailable: false,
-      module: OSS
+      module: OSS,
     },
     DEF: {
       cover: 'https://img.alicdn.com/tfs/TB1qDkAXMFY.1VjSZFnXXcFHXXa-300-300.png',
       isAvailable: false,
-      module: DEF
+      module: DEF,
     },
     Todo: {
       cover: 'https://img.alicdn.com/tfs/TB1zZJKdEGF3KVjSZFmXXbqPXXa-300-300.png',
       isAvailable: false,
-      module: Todo
+      module: Todo,
     },
     Task: {
       cover: '',
       isAvailable: true,
-      module: Task
+      module: Task,
     },
     Configuration: {
       cover: '',
       isAvailable: true,
-      module: Configuration
+      module: Configuration,
     },
   };
 

--- a/packages/iceworks-server/src/lib/adapter/modules/configuration/getConfigSchema.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/configuration/getConfigSchema.ts
@@ -53,7 +53,7 @@ export default (ctx: IContext): IConfSchema[] => {
       link: 'https://ice.work/docs/cli/config/config#hash',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: false
+        defaultChecked: false,
       },
     },
     {
@@ -61,7 +61,7 @@ export default (ctx: IContext): IConfSchema[] => {
       link: 'https://ice.work/docs/cli/config/config#minify',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: false
+        defaultChecked: false,
       },
     },
     {
@@ -69,7 +69,7 @@ export default (ctx: IContext): IConfSchema[] => {
       link: 'https://ice.work/docs/cli/config/config#vendor',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: false
+        defaultChecked: false,
       },
     },
   ];

--- a/packages/iceworks-server/src/lib/adapter/modules/configuration/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/configuration/index.ts
@@ -21,11 +21,11 @@ export default class Configuration implements IConfigurationModule {
     this.cliConfPath = path.join(this.project.path, this.cliConfFilename);
   }
 
-  async getCLIConf(args, ctx): Promise<IConfSchema[]> {
+  public async getCLIConf(args, ctx): Promise<IConfSchema[]> {
     return getCLIConf(this.cliConfPath, this.getConfigSchema(ctx));
   }
 
-  async setCLIConf(args: IConfParam) {
+  public async setCLIConf(args: IConfParam) {
     return setCLIConf(this.cliConfPath, args.options);
   }
 }

--- a/packages/iceworks-server/src/lib/adapter/modules/configuration/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/configuration/index.ts
@@ -5,12 +5,16 @@ import getConfigSchema from './getConfigSchema';
 
 export default class Configuration implements IConfigurationModule {
   public project: IProject;
+
   public storage: any;
+
   public readonly cliConfPath: string;
+
   public cliConfFilename = 'ice.config.js';
+
   public getConfigSchema: (ctx: IContext) => IConfSchema[] = getConfigSchema;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;

--- a/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
@@ -5,7 +5,7 @@ try {
 } catch (e) {
   Client = {
     Client: class C {
-      run() {
+      public run() {
         throw new Error('缺少 DEF 客户端依赖');
       }
     },

--- a/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
@@ -1,9 +1,11 @@
-let Client;
+/* eslint import/no-mutable-exports: 0, global-require: 0 */
+
+let ClientWrap;
 
 try {
-  Client = require('@ali/def-pub-client');
+  ClientWrap = require('@ali/def-pub-client');
 } catch (e) {
-  Client = {
+  ClientWrap = {
     Client: class C {
       public run() {
         throw new Error('缺少 DEF 客户端依赖');
@@ -12,4 +14,4 @@ try {
   };
 }
 
-export default Client;
+export default ClientWrap;

--- a/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/client.ts
@@ -8,7 +8,7 @@ try {
       run() {
         throw new Error('缺少 DEF 客户端依赖');
       }
-    }
+    },
   };
 }
 

--- a/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
@@ -13,9 +13,10 @@ const env = isDev ? 'daily' : 'prod';
 
 export default class DEF implements IDEFModule {
   public project: IProject;
+
   public storage: any;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;

--- a/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
@@ -1,4 +1,4 @@
-/** eslint camelcase:0 */
+/* eslint @typescript-eslint/camelcase: 0 */
 
 import Client from './client';
 import { IProject, IDEFModule, IDEFPushParams, IContext } from '../../../../interface';

--- a/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/def/index.ts
@@ -22,7 +22,7 @@ export default class DEF implements IDEFModule {
     this.storage = storage;
   }
 
-  async push(params: IDEFPushParams, ctx: IContext): Promise<void> {
+  public async push(params: IDEFPushParams, ctx: IContext): Promise<void> {
     const { target, commitId, branch, repository, empId } = params;
     const client = new Client.Client();
     client.run({

--- a/packages/iceworks-server/src/lib/adapter/modules/dependency/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/dependency/index.ts
@@ -44,15 +44,16 @@ export const install = async (
   });
 };
 
-export interface INpmOutdatedData { package: string; current: string; wanted: string; latest: string; location: string; }
+export interface INpmOutdatedData { package: string; current: string; wanted: string; latest: string; location: string }
 
 export default class Dependency implements IDependencyModule {
   public project: IProject;
+
   public storage: any;
 
   public readonly path: string;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;
@@ -76,20 +77,20 @@ export default class Dependency implements IDependencyModule {
       npmOutdated = JSON.parse(error.stdout);
     }
 
-    return Object.entries(npmOutdated).map(([key, value]: [string, { current: string; wanted: string; latest: string; location: string; }]) => ({ package: key, ...value }));
+    return Object.entries(npmOutdated).map(([key, value]: [string, { current: string; wanted: string; latest: string; location: string }]) => ({ package: key, ...value }));
   }
 
-  public async create(params: {dependency: ICreateDependencyParam, idDev?: boolean}, ctx: IContext): Promise<void> {
+  public async create(params: {dependency: ICreateDependencyParam; idDev?: boolean}, ctx: IContext): Promise<void> {
     const { dependency, idDev } = params;
     return (await install([dependency], idDev, this.project, ctx.socket, 'dependency'))[0];
   }
 
-  public async bulkCreate(params: {dependencies: ICreateDependencyParam[], idDev?: boolean}, ctx: IContext): Promise<void> {
+  public async bulkCreate(params: {dependencies: ICreateDependencyParam[]; idDev?: boolean}, ctx: IContext): Promise<void> {
     const { dependencies, idDev } = params;
     return await install(dependencies, idDev, this.project, ctx.socket, 'dependency');
   }
 
-  public async getAll(): Promise<{ dependencies: IDependency[], devDependencies: IDependency[] }> {
+  public async getAll(): Promise<{ dependencies: IDependency[]; devDependencies: IDependency[] }> {
     const { dependencies: packageDependencies, devDependencies: packageDevDependencies } = this.project.getPackageJSON();
 
     const getAll = async (list, dev) => {
@@ -105,7 +106,7 @@ export default class Dependency implements IDependencyModule {
           specifyVersion,
           dev,
           localVersion,
-          latestVersion: await latestVersion(packageName)
+          latestVersion: await latestVersion(packageName),
         };
       }));
     };
@@ -135,7 +136,7 @@ export default class Dependency implements IDependencyModule {
 
     return {
       dependencies,
-      devDependencies
+      devDependencies,
     };
   }
 

--- a/packages/iceworks-server/src/lib/adapter/modules/git/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/git/index.ts
@@ -1,13 +1,14 @@
-import { IProject, IGitModule, IGitBranchs, IGitGetLog, IGitGetStatus, IUnstagedFile, IGitSwitchBranchParams, IGitAddAndCommitParams } from '../../../../interface';
 import * as gitPromie from 'simple-git/promise';
+import { IProject, IGitModule, IGitBranchs, IGitGetLog, IGitGetStatus, IUnstagedFile, IGitSwitchBranchParams, IGitAddAndCommitParams } from '../../../../interface';
 
 export default class Git implements IGitModule {
   public readonly project: IProject;
+
   public storage: any;
 
   private gitTools: any;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;
@@ -112,7 +113,7 @@ export default class Git implements IGitModule {
     const localBranches = await this.gitTools.branchLocal();
     return {
       localBranches: localBranches.all,
-      originBranches: originBranches.all
+      originBranches: originBranches.all,
     };
   }
 

--- a/packages/iceworks-server/src/lib/adapter/modules/layout/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/layout/index.ts
@@ -6,10 +6,12 @@ const DEFAULT_IMAGE = 'https://gw.alicdn.com/tfs/TB1Qby8ex9YBuNjy0FfXXXIsVXa-976
 
 export default class Layout implements ILayoutModule {
   public readonly project: IProject;
+
   public readonly path: string;
+
   public storage: any;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;

--- a/packages/iceworks-server/src/lib/adapter/modules/layout/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/layout/index.ts
@@ -35,11 +35,11 @@ export default class Layout implements ILayoutModule {
     );
   }
 
-  async getAll(args, ctx: IContext): Promise<IProjectLayout[]> {
+  public async getAll(args, ctx: IContext): Promise<IProjectLayout[]> {
     return await this.scanLayout(ctx);
   }
 
-  async getOne(layoutName: string, ctx: IContext): Promise<IProjectLayout> {
+  public async getOne(layoutName: string, ctx: IContext): Promise<IProjectLayout> {
     const layouts = await this.getAll(null, ctx);
     const layout = layouts.find(({name}) => name === layoutName);
     return layout;

--- a/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
@@ -49,7 +49,7 @@ export default class Menu implements IMenuModule {
     return code;
   }
 
-  async getAll(): Promise<{ asideMenuConfig: IMenu[]; headerMenuConfig: IMenu[] }> {
+  public async getAll(): Promise<{ asideMenuConfig: IMenu[]; headerMenuConfig: IMenu[] }> {
     let asideMenuConfig = [];
     let headerMenuConfig = [];
     const menuFileAST = this.getFileAST();
@@ -74,7 +74,7 @@ export default class Menu implements IMenuModule {
     };
   }
 
-  async bulkCreate(params: {data: IMenu[]; options: IMenuOptions}): Promise<void> {
+  public async bulkCreate(params: {data: IMenu[]; options: IMenuOptions}): Promise<void> {
     let {
       data = [],
       options = {},
@@ -94,7 +94,7 @@ export default class Menu implements IMenuModule {
     this.setData(data, menuFileAST, name);
   }
 
-  async delete(params: {paths: string[]}) {
+  public async delete(params: {paths: string[]}) {
     const { paths } = params;
     const menuFileAST = this.getFileAST();
     const { asideMenuConfig, headerMenuConfig } = await this.getAll();
@@ -103,7 +103,7 @@ export default class Menu implements IMenuModule {
     this.setData(this.removeItemByPaths(headerMenuConfig, paths), menuFileAST, HEADER_CONFIG_VARIABLE);
   }
 
-  removeItemByPaths(data: IMenu[], paths: string[]) {
+  private removeItemByPaths(data: IMenu[], paths: string[]) {
     const removeIndex = [];
     data.forEach((item, index) => {
       if (paths.indexOf(item.path) > -1) {

--- a/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
@@ -14,11 +14,14 @@ const HEADER_CONFIG_VARIABLE = 'headerMenuConfig';
 
 export default class Menu implements IMenuModule {
   public readonly project: IProject;
+
   public readonly storage: any;
+
   public readonly path: string;
+
   public configFilePath = 'config/menu.js';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.storage = storage;
     this.project = project;
@@ -46,7 +49,7 @@ export default class Menu implements IMenuModule {
     return code;
   }
 
-  async getAll(): Promise<{ asideMenuConfig: IMenu[], headerMenuConfig: IMenu[] }> {
+  async getAll(): Promise<{ asideMenuConfig: IMenu[]; headerMenuConfig: IMenu[] }> {
     let asideMenuConfig = [];
     let headerMenuConfig = [];
     const menuFileAST = this.getFileAST();
@@ -62,7 +65,7 @@ export default class Menu implements IMenuModule {
         if (headerMenuCode) {
           headerMenuConfig = eval(headerMenuCode);
         }
-      }
+      },
     });
 
     return {
@@ -71,10 +74,10 @@ export default class Menu implements IMenuModule {
     };
   }
 
-  async bulkCreate(params: {data: IMenu[], options: IMenuOptions}): Promise<void> {
+  async bulkCreate(params: {data: IMenu[]; options: IMenuOptions}): Promise<void> {
     let {
       data = [],
-      options = {}
+      options = {},
     } = params;
     const { replacement = false, type = 'aside' } = options;
     const { asideMenuConfig, headerMenuConfig } = await this.getAll();
@@ -131,7 +134,7 @@ export default class Menu implements IMenuModule {
         ) {
           node.init = arrayAST;
         }
-      }
+      },
     });
 
     fs.writeFileSync(

--- a/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
@@ -1,4 +1,3 @@
-/* eslint no-eval: 0 */
 import * as path from 'path';
 import * as fs from 'fs';
 import * as parser from '@babel/parser';
@@ -61,10 +60,10 @@ export default class Menu implements IMenuModule {
         const asideMenuCode = getMenuCode(node, ASIDE_CONFIG_VARIABLE);
         const headerMenuCode = getMenuCode(node, HEADER_CONFIG_VARIABLE);
         if (asideMenuCode) {
-          asideMenuConfig = eval(asideMenuCode);
+          asideMenuConfig = eval(asideMenuCode); // eslint-disable-line
         }
         if (headerMenuCode) {
-          headerMenuConfig = eval(headerMenuCode);
+          headerMenuConfig = eval(headerMenuCode); // eslint-disable-line
         }
       },
     });

--- a/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/menu/index.ts
@@ -1,3 +1,4 @@
+/* eslint no-eval: 0 */
 import * as path from 'path';
 import * as fs from 'fs';
 import * as parser from '@babel/parser';
@@ -75,10 +76,8 @@ export default class Menu implements IMenuModule {
   }
 
   public async bulkCreate(params: {data: IMenu[]; options: IMenuOptions}): Promise<void> {
-    let {
-      data = [],
-      options = {},
-    } = params;
+    let { data = [] } = params;
+    const {options = {} } = params;
     const { replacement = false, type = 'aside' } = options;
     const { asideMenuConfig, headerMenuConfig } = await this.getAll();
     const menuFileAST = this.getFileAST();

--- a/packages/iceworks-server/src/lib/adapter/modules/oss/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/oss/index.ts
@@ -19,7 +19,7 @@ export default class OSS implements IOSSModule {
     this.storage = storage;
   }
 
-  async getBuckets(): Promise<IOSSBucket[]> {
+  public async getBuckets(): Promise<IOSSBucket[]> {
     const oss = this.storage.get('oss');
     const params: IOSSGetBucketsParams = oss.find(({ project }) => project === this.project.path);
     const { region } = params;
@@ -29,12 +29,12 @@ export default class OSS implements IOSSModule {
     return buckets;
   }
 
-  async getConfig() {
+  public async getConfig() {
     const oss = this.storage.get('oss');
     return oss.find(({ project }) => project === this.project.path) || {};
   }
 
-  async setConfig(args) {
+  public async setConfig(args) {
     const oss = this.storage.get('oss');
 
     let newConfig;
@@ -52,7 +52,7 @@ export default class OSS implements IOSSModule {
     return newConfig;
   }
 
-  async upload(args, ctx: IContext): Promise<IUploadResult[]> {
+  public async upload(args, ctx: IContext): Promise<IUploadResult[]> {
     const { i18n } = ctx;
     const oss = this.storage.get('oss');
     const params: IOSSUploadParams = oss.find(({ project }) => project === this.project.path);

--- a/packages/iceworks-server/src/lib/adapter/modules/oss/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/oss/index.ts
@@ -1,18 +1,19 @@
-import { IContext, IProject, IOSSModule, IOSSUploadParams, IUploadResult, IOSSGetBucketsParams, IOSSBucket } from '../../../../interface';
 import * as AliOSS from 'ali-oss';
 import * as pathExists from 'path-exists';
 import * as path from 'path';
 import * as dir from 'node-dir';
+import { IContext, IProject, IOSSModule, IOSSUploadParams, IUploadResult, IOSSGetBucketsParams, IOSSBucket } from '../../../../interface';
 
 const DOMAIN = 'aliyuncs.com';
 
 export default class OSS implements IOSSModule {
   public project: IProject;
+
   public storage: any;
 
   public readonly buildDir: string = 'build';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;

--- a/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
@@ -38,12 +38,14 @@ const loadTemplate = async () => {
 
 export default class Page implements IPageModule {
   public readonly project: IProject;
+
   public readonly storage: any;
 
   public readonly path: string;
+
   private readonly componentDirName: string = 'components';
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;
@@ -86,7 +88,7 @@ export default class Page implements IPageModule {
     Object.keys(blocksDependencies).forEach((packageName) => {
       if (!projectPackageJSON.dependencies.hasOwnProperty(packageName)) {
         filterDependencies.push({
-          [packageName]: blocksDependencies[packageName]
+          [packageName]: blocksDependencies[packageName],
         });
       }
     });
@@ -220,12 +222,12 @@ export default class Page implements IPageModule {
     return blocks;
   }
 
-  async addBlocks(params: {blocks: IMaterialBlock[]; name?: string; }, ctx: IContext): Promise<void> {
+  async addBlocks(params: {blocks: IMaterialBlock[]; name?: string }, ctx: IContext): Promise<void> {
     const {blocks, name} = params;
     await this.downloadBlocksToPage(blocks, name, ctx);
   }
 
-  async addBlock(params: {block: IMaterialBlock, name?: string; }, ctx: IContext): Promise<void> {
+  async addBlock(params: {block: IMaterialBlock; name?: string }, ctx: IContext): Promise<void> {
     const {block, name} = params;
     await this.downloadBlockToPage(block, name, ctx);
   }

--- a/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
@@ -1,5 +1,3 @@
-/* eslint no-empty-function: 0 */
-
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -146,8 +144,6 @@ export default class Page implements IPageModule {
     return _.orderBy(pages, 'name', 'asc');
   }
 
-  public async getOne(): Promise<any> { }
-
   public async create(page: ICreatePageParam, ctx: IContext): Promise<any> {
     const { name, blocks } = page;
     const { socket, i18n } = ctx;
@@ -204,8 +200,6 @@ export default class Page implements IPageModule {
     return pageFolderName;
   }
 
-  public async bulkCreate(): Promise<any> { }
-
   public async delete(params: {name: string}): Promise<any> {
     const { name } = params;
     await rimrafAsync(path.join(this.path, name));
@@ -233,6 +227,4 @@ export default class Page implements IPageModule {
     const {block, name} = params;
     await this.downloadBlockToPage(block, name, ctx);
   }
-
-  public async update(): Promise<any> { }
 }

--- a/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
@@ -1,3 +1,5 @@
+/* eslint no-empty-function: 0 */
+
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/page/index.ts
@@ -139,14 +139,14 @@ export default class Page implements IPageModule {
     }
   }
 
-  async getAll(): Promise<IPage[]> {
+  public async getAll(): Promise<IPage[]> {
     const pages = await this.scanPages(this.path);
     return _.orderBy(pages, 'name', 'asc');
   }
 
-  async getOne(): Promise<any> { }
+  public async getOne(): Promise<any> { }
 
-  async create(page: ICreatePageParam, ctx: IContext): Promise<any> {
+  public async create(page: ICreatePageParam, ctx: IContext): Promise<any> {
     const { name, blocks } = page;
     const { socket, i18n } = ctx;
 
@@ -202,9 +202,9 @@ export default class Page implements IPageModule {
     return pageFolderName;
   }
 
-  async bulkCreate(): Promise<any> { }
+  public async bulkCreate(): Promise<any> { }
 
-  async delete(params: {name: string}): Promise<any> {
+  public async delete(params: {name: string}): Promise<any> {
     const { name } = params;
     await rimrafAsync(path.join(this.path, name));
   }
@@ -222,15 +222,15 @@ export default class Page implements IPageModule {
     return blocks;
   }
 
-  async addBlocks(params: {blocks: IMaterialBlock[]; name?: string }, ctx: IContext): Promise<void> {
+  public async addBlocks(params: {blocks: IMaterialBlock[]; name?: string }, ctx: IContext): Promise<void> {
     const {blocks, name} = params;
     await this.downloadBlocksToPage(blocks, name, ctx);
   }
 
-  async addBlock(params: {block: IMaterialBlock; name?: string }, ctx: IContext): Promise<void> {
+  public async addBlock(params: {block: IMaterialBlock; name?: string }, ctx: IContext): Promise<void> {
     const {block, name} = params;
     await this.downloadBlockToPage(block, name, ctx);
   }
 
-  async update(): Promise<any> { }
+  public async update(): Promise<any> { }
 }

--- a/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
@@ -102,7 +102,8 @@ export default class Router implements IRouterModule {
 
   // bulk create routers
   public async bulkCreate(params: {data: IRouter[]; options: IRouterOptions}): Promise<void>  {
-    let { data, options = {} } = params;
+    let { data } = params;
+    const { options = {} } = params;
     const { replacement = false, parent } = options;
     const routerConfigAST = this.getRouterConfigAST();
     const currentData = await this.getAll();
@@ -256,7 +257,7 @@ export default class Router implements IRouterModule {
       // parse eg. `const Forbidden = React.lazy(() => import('./pages/Exception/Forbidden'));`
       VariableDeclaration: ({ node, key }) => {
         const code = generate(node.declarations[0]).code;
-        const matchLazyReg = /(\w+)\s=\sReact\.lazy(.+)import\(['|"]((\.|\@)\/(\w+)\/.+)['|"]\)/;
+        const matchLazyReg = /(\w+)\s=\sReact\.lazy(.+)import\(['|"]((\.|@)\/(\w+)\/.+)['|"]\)/;
         const match = code.match(matchLazyReg);
 
         if (match && match.length > 5) {

--- a/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
@@ -16,14 +16,18 @@ const ROUTE_PROP_WHITELIST = ['component', 'path', 'exact', 'strict', 'sensitive
 
 export default class Router implements IRouterModule {
   public readonly project: IProject;
+
   public readonly storage: any;
 
   public readonly path: string;
+
   public existLazy: boolean;
+
   public configFilePath = 'config/routes.js';
+
   public removePaths: string[];
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;
@@ -60,7 +64,7 @@ export default class Router implements IRouterModule {
           ) {
             config = this.parseRoute(node.init.elements);
           }
-        }
+        },
       });
     } catch (error) {
       console.log(error);
@@ -97,7 +101,7 @@ export default class Router implements IRouterModule {
   }
 
   // bulk create routers
-  async bulkCreate(params: {data: IRouter[], options: IRouterOptions}): Promise<void>  {
+  async bulkCreate(params: {data: IRouter[]; options: IRouterOptions}): Promise<void>  {
     let { data, options = {} } = params;
     const { replacement = false, parent } = options;
     const routerConfigAST = this.getRouterConfigAST();
@@ -173,7 +177,7 @@ export default class Router implements IRouterModule {
         if (['component'].indexOf(node.key.value) > -1) {
           node.value = t.identifier(node.value.value);
         }
-      }
+      },
     });
     traverse(routerConfigAST, {
       VariableDeclarator({ node }) {

--- a/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
@@ -51,7 +51,7 @@ export default class Router implements IRouterModule {
     return routerConfigAST;
   }
 
-  async getAll(): Promise<IRouter[]> {
+  public async getAll(): Promise<IRouter[]> {
     let config = [];
     const routerConfigAST = this.getRouterConfigAST();
 
@@ -72,7 +72,7 @@ export default class Router implements IRouterModule {
     return config;
   }
 
-  parseRoute(elements) {
+  private parseRoute(elements) {
     const config = [];
     elements.forEach((element) => {
       // { path: '/home', component: Home, children: [] }
@@ -101,7 +101,7 @@ export default class Router implements IRouterModule {
   }
 
   // bulk create routers
-  async bulkCreate(params: {data: IRouter[]; options: IRouterOptions}): Promise<void>  {
+  public async bulkCreate(params: {data: IRouter[]; options: IRouterOptions}): Promise<void>  {
     let { data, options = {} } = params;
     const { replacement = false, parent } = options;
     const routerConfigAST = this.getRouterConfigAST();
@@ -126,7 +126,7 @@ export default class Router implements IRouterModule {
     this.setData(data, routerConfigAST);
   }
 
-  async delete(params: {componentName: string}): Promise<string[]> {
+  public async delete(params: {componentName: string}): Promise<string[]> {
     const { componentName } = params;
     const routerConfigAST = this.getRouterConfigAST();
     const data = await this.getAll();
@@ -136,7 +136,7 @@ export default class Router implements IRouterModule {
     return this.removePaths;
   }
 
-  removeItemByComponent(data: IRouter[], componentName: string, parent?: IRouter) {
+  private removeItemByComponent(data: IRouter[], componentName: string, parent?: IRouter) {
     const removeIndex = [];
     data.forEach((item, index) => {
       if (!item.children) {

--- a/packages/iceworks-server/src/lib/adapter/modules/task/getTaskConfig.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/getTaskConfig.ts
@@ -43,7 +43,7 @@ export default (ctx: IContext): ITaskConf => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: false
+        defaultChecked: false,
       },
     },
     {
@@ -52,7 +52,7 @@ export default (ctx: IContext): ITaskConf => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: true
+        defaultChecked: true,
       },
     },
   ];
@@ -64,7 +64,7 @@ export default (ctx: IContext): ITaskConf => {
       link: '',
       componentName: 'Input',
       componentProps: {
-        placeholder: '/dist'
+        placeholder: '/dist',
       },
     },
     {
@@ -73,7 +73,7 @@ export default (ctx: IContext): ITaskConf => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: true
+        defaultChecked: true,
       },
     },
     {

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -15,6 +15,7 @@ const TASK_STATUS_STOP = 'stop';
 
 export default class Task implements ITaskModule {
   public project: IProject;
+
   public storage: any;
 
   private status: object = {};
@@ -27,7 +28,7 @@ export default class Task implements ITaskModule {
 
   public getTaskConfig: (ctx: IContext) => ITaskConf = getTaskConfig;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     const { project, storage } = params;
     this.project = project;
     this.storage = storage;
@@ -144,7 +145,7 @@ export default class Task implements ITaskModule {
       case 'dev':
         return this.getDevConf(taskConfig);
       case 'build':
-       return getCLIConf(this.cliConfPath, taskConfig.build);
+        return getCLIConf(this.cliConfPath, taskConfig.build);
       case 'lint':
         // @TODO support lint configuration
         return null;
@@ -168,7 +169,7 @@ export default class Task implements ITaskModule {
     }
   }
 
-/**
+  /**
  * get dev configuration
  * merge the user configuration to return to the new configuration
  * @param projectPath
@@ -202,7 +203,7 @@ export default class Task implements ITaskModule {
 
     let newDevScriptContent =  `${cli} ${command}`;
     Object.keys(args.options).forEach((key) => {
-      newDevScriptContent = newDevScriptContent + ` --${key}=${args.options[key]}`;
+      newDevScriptContent += ` --${key}=${args.options[key]}`;
     });
 
     pkgContent.scripts.start = newDevScriptContent;

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -39,7 +39,7 @@ export default class Task implements ITaskModule {
    * run start task
    * @param args
    */
-  async start(args: ITaskParam, ctx: IContext) {
+  public async start(args: ITaskParam, ctx: IContext) {
     const { i18n } = ctx;
 
     const nodeModulesPath = path.join(this.project.path, 'node_modules')
@@ -103,7 +103,7 @@ export default class Task implements ITaskModule {
    * run stop task
    * @param args
    */
-  async stop(args: ITaskParam, ctx: IContext) {
+  public async stop(args: ITaskParam, ctx: IContext) {
     const { command } = args;
     const eventName = `stop.data.${command}`;
 
@@ -130,7 +130,7 @@ export default class Task implements ITaskModule {
     return this;
   }
 
-  getStatus (args: ITaskParam) {
+  public getStatus (args: ITaskParam) {
     const { command } = args;
     return this.status[command];
   }
@@ -139,7 +139,7 @@ export default class Task implements ITaskModule {
    * get the conf of the current task
    * @param args
    */
-  async getConf(args: ITaskParam, ctx: IContext) {
+  public async getConf(args: ITaskParam, ctx: IContext) {
     const taskConfig = this.getTaskConfig(ctx);
     switch (args.command) {
       case 'dev':
@@ -158,7 +158,7 @@ export default class Task implements ITaskModule {
    * set the conf of the current task
    * @param args
    */
-  async setConf(args: ITaskParam) {
+  public async setConf(args: ITaskParam) {
     switch (args.command) {
       case 'dev':
         return this.setDevConf(args);
@@ -170,10 +170,10 @@ export default class Task implements ITaskModule {
   }
 
   /**
- * get dev configuration
- * merge the user configuration to return to the new configuration
- * @param projectPath
- */
+   * get dev configuration
+   * merge the user configuration to return to the new configuration
+   * @param projectPath
+   */
   private getDevConf(taskConfig: ITaskConf) {
     const pkgContent = this.project.getPackageJSON();
     const devScriptContent = pkgContent.scripts.start;

--- a/packages/iceworks-server/src/lib/adapter/modules/todo/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/todo/index.ts
@@ -53,9 +53,10 @@ function retrieveMessagesFromLine(lineString, lineNumber): ITodoMsg[] {
 
 export default class Todo implements ITodoModule {
   public readonly project: IProject;
+
   public readonly storage: any;
 
-  constructor(params: {project: IProject; storage: any; }) {
+  constructor(params: {project: IProject; storage: any }) {
     this.project = params.project;
   }
 
@@ -70,7 +71,7 @@ export default class Todo implements ITodoModule {
         if (messages.length) {
           result.push({
             messages,
-            path: path.relative(this.project.path, filePath)
+            path: path.relative(this.project.path, filePath),
           });
         }
       }

--- a/packages/iceworks-server/src/lib/adapter/modules/todo/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/todo/index.ts
@@ -64,18 +64,15 @@ export default class Todo implements ITodoModule {
     const files: string[] = await recursiveReaddir(this.project.path);
 
     const result: ITodo[] = [];
-
-    if (files.length) {
-      for (const filePath of files) {
-        const messages: ITodoMsg[] = await matchFileContent(filePath);
-        if (messages.length) {
-          result.push({
-            messages,
-            path: path.relative(this.project.path, filePath),
-          });
-        }
+    await Promise.all(files.map(async (filePath) => {
+      const messages: ITodoMsg[] = await matchFileContent(filePath);
+      if (messages.length) {
+        result.push({
+          messages,
+          path: path.relative(this.project.path, filePath),
+        });
       }
-    }
+    }));
 
     return result;
   }

--- a/packages/iceworks-server/src/lib/adapter/utils/cliConf.ts
+++ b/packages/iceworks-server/src/lib/adapter/utils/cliConf.ts
@@ -24,7 +24,7 @@ function getCLIConf(path: string, defaultConf) {
         if (defaultConfKeys.includes(path.node.name)) {
           userConf[path.node.name] = path.container.value.value;
         }
-      }
+      },
     };
 
     traverse(ast, visitor);
@@ -56,7 +56,7 @@ function setCLIConf(path: string, conf: object) {
         properties = node.properties;
         flag = true;
       }
-    }
+    },
   };
 
   // traverse ast
@@ -96,16 +96,16 @@ function setCLIConf(path: string, conf: object) {
  */
 function mergeCLIConf(defaultConf: any, userConf: any) {
   return _.cloneDeepWith(defaultConf).map((item) => {
-     if (Object.keys(userConf).includes(item.name)) {
-       if (item.componentName === 'Switch') {
-         item.componentProps.defaultChecked = JSON.parse(userConf[item.name]);
-       } else {
-         item.componentProps.placeholder = userConf[item.name].toString();
-       }
-     }
-     return item;
-   });
- }
+    if (Object.keys(userConf).includes(item.name)) {
+      if (item.componentName === 'Switch') {
+        item.componentProps.defaultChecked = JSON.parse(userConf[item.name]);
+      } else {
+        item.componentProps.placeholder = userConf[item.name].toString();
+      }
+    }
+    return item;
+  });
+}
 
 export {
   getCLIConf,

--- a/packages/iceworks-server/src/lib/plugin/i18n/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/i18n/app.ts
@@ -15,7 +15,7 @@ function ignoreFile(filePath: string) {
 }
 
 class I18n implements II18n {
-  localeMap: {
+  private localeMap: {
     [key: string]: object;
   };
 

--- a/packages/iceworks-server/src/lib/plugin/i18n/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/i18n/app.ts
@@ -16,12 +16,13 @@ function ignoreFile(filePath: string) {
 
 class I18n implements II18n {
   localeMap: {
-    [key: string]: object
+    [key: string]: object;
   };
+
   constructor() {
     this.localeMap = {
       'zh-CN': zhCNGlobal,
-      'en-US': enUSGlobal
+      'en-US': enUSGlobal,
     };
   }
 

--- a/packages/iceworks-server/src/lib/plugin/i18n/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/i18n/app.ts
@@ -34,12 +34,12 @@ class I18n implements II18n {
       return _.includes(file, 'locales') && path.extname(file) === '.json';
     });
 
-    for (const file of localeFiles) {
+    await Promise.all(localeFiles.map(async (file) => {
       const name = path.basename(file, '.json');
       const content = await fs.readJSON(file);
 
       this.localeMap[name] = Object.assign({}, this.localeMap[name], content);
-    }
+    }));
   }
 
   public format(localeKey: string, args?: object): string {

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -75,12 +75,12 @@ class Project implements IProject {
   private interopRequire(id) {
     let mod;
     try {
-      mod = require(id);
+      mod = require(id); // eslint-disable-line
     } catch (error) {
       throw error;
     }
 
-    return mod && mod.__esModule ? mod.default : mod;
+    return mod && mod.__esModule ? mod.default : mod; // eslint-disable-line
   }
 
   public async loadAdapter(i18n: II18n) {
@@ -290,7 +290,7 @@ class ProjectManager extends EventEmitter {
 
     // check read and write
     try {
-      await accessAsync(targetPath, fs.constants.R_OK | fs.constants.W_OK); // tslint:disable-line
+      await accessAsync(targetPath, fs.constants.R_OK | fs.constants.W_OK); // eslint-disable-line  
     } catch (error) {
       error.message = '当前路径没有读写权限，请更换项目路径';
       throw error;
@@ -370,7 +370,7 @@ class ProjectManager extends EventEmitter {
    */
   public async createProject(params: ICreateParams): Promise<void> {
     if (params.appId) {
-      const generate = require('@ali/stark-biz-generator');
+      const generate = require('@ali/stark-biz-generator'); // eslint-disable-line
       generate({ appId: params.appId, changeId: params.changeId, targetDir: params.path })
     } else {
       await this.createProjectFolder(params);

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -29,7 +29,7 @@ const DEFAULT_ADAPTER = [
   'adapter-react-v1',
   'adapter-react-v2',
   'adapter-react-v3',
-  'adapter-vue-v1'
+  'adapter-vue-v1',
 ];
 
 class Project implements IProject {
@@ -108,7 +108,7 @@ class Project implements IProject {
 
         this.panels.push({
           name,
-          ..._.omit(config, 'module')
+          ..._.omit(config, 'module'),
         });
       });
 
@@ -167,7 +167,7 @@ class Project implements IProject {
     storage.set('panelSettings', panelSettings);
   }
 
-  public setPanel(params: {name: string; isAvailable: boolean; }): IPanel[] {
+  public setPanel(params: {name: string; isAvailable: boolean }): IPanel[] {
     const {name, isAvailable} = params;
     const panel = this.panels.find(({ name: settingName }) => settingName === name);
     if (panel) {
@@ -177,7 +177,7 @@ class Project implements IProject {
     return this.panels;
   }
 
-  public sortPanels(params: { oldIndex: number; newIndex: number; }): IPanel[] {
+  public sortPanels(params: { oldIndex: number; newIndex: number }): IPanel[] {
     const { oldIndex, newIndex } = params;
     this.panels = arrayMove(this.panels, oldIndex, newIndex);
     this.savePanels();
@@ -201,12 +201,13 @@ interface ICreateParams {
   path: string;
   scaffold: IMaterialScaffold;
   forceCover?: boolean;
-  appId?: string,
-  changeId?: string,
+  appId?: string;
+  changeId?: string;
 }
 
 class ProjectManager extends EventEmitter {
   private projects;
+
   private i18n: II18n;
 
   constructor(i18n: II18n) {
@@ -280,7 +281,7 @@ class ProjectManager extends EventEmitter {
   /**
    * Create folder for project
    */
-  private async createProjectFolder(params: { path: string; forceCover?: boolean; }) {
+  private async createProjectFolder(params: { path: string; forceCover?: boolean }) {
     const { path: targetPath, forceCover } = params;
 
     if (!await pathExists(targetPath)) {
@@ -381,7 +382,7 @@ class ProjectManager extends EventEmitter {
   /**
    * Delete a project in project list
    */
-  public async deleteProject(params: { projectPath: string, deleteFiles?: boolean }): Promise<void> {
+  public async deleteProject(params: { projectPath: string; deleteFiles?: boolean }): Promise<void> {
     const { projectPath, deleteFiles } = params;
     this.projects = this.projects.filter(({ path }) => path !== projectPath);
     const newProjects = storage.get('projects').filter((path) => path !== projectPath);

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -225,7 +225,7 @@ class ProjectManager extends EventEmitter {
     );
   }
 
-  async ready() {
+  public async ready() {
     await this.i18n.readLocales();
     this.projects = await this.refresh();
   }

--- a/packages/iceworks-server/src/lib/remoteLogger/index.ts
+++ b/packages/iceworks-server/src/lib/remoteLogger/index.ts
@@ -10,7 +10,7 @@ export default class RemoteLogger extends Transport {
     const qsData = {
       APIVersion: '0.6.0', // sls required
       __topic__: level, // log type
-      node_version: process.version,
+      node_version: process.version, // eslint-disable-line
 
       message: '',
       name: '',

--- a/packages/iceworks-server/src/lib/remoteLogger/index.ts
+++ b/packages/iceworks-server/src/lib/remoteLogger/index.ts
@@ -6,7 +6,7 @@ const remoteUrl = `http://iceworks.cn-hangzhou.log.aliyuncs.com/logstores/icewor
 
 export default class RemoteLogger extends Transport {
   // send to remote
-  async log(level, args) {
+  public async log(level, args) {
     const qsData = {
       APIVersion: '0.6.0', // sls required
       __topic__: level, // log type

--- a/packages/iceworks-server/src/lib/remoteLogger/index.ts
+++ b/packages/iceworks-server/src/lib/remoteLogger/index.ts
@@ -32,7 +32,7 @@ export default class RemoteLogger extends Transport {
     await request({
       url: remoteUrl,
       qs: qsData,
-      timeout: 2000
+      timeout: 2000,
     });
   }
 }

--- a/packages/iceworks-server/src/lib/scanDirectory.ts
+++ b/packages/iceworks-server/src/lib/scanDirectory.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as pathExists from 'path-exists';
 import * as util from 'util';
 import * as junk from 'junk';
+
 const readdirAsync = util.promisify(fs.readdir);
 const lstatAsync = util.promisify(fs.lstat);
 const accessAsync = util.promisify(fs.access);

--- a/packages/iceworks-server/src/lib/storage.ts
+++ b/packages/iceworks-server/src/lib/storage.ts
@@ -6,6 +6,7 @@ import * as userHome from 'user-home';
 // Note: why not use `import`
 // ref: https://github.com/sindresorhus/conf
 const Conf = require('conf');
+
 const confPath = path.join(userHome, '.iceworks');
 
 if (!fs.existsSync(confPath)) {
@@ -53,8 +54,8 @@ const schema = {
         official: true,
         name: '飞冰物料',
         type: 'react',
-        source: 'http://ice.alicdn.com/assets/materials/react-materials.json'
-      }
+        source: 'http://ice.alicdn.com/assets/materials/react-materials.json',
+      },
     ],
   },
   oss: {


### PR DESCRIPTION
## Background

- Open lint for iceworks-server;
- Fixed some irregular code with auto-fix function;
- Manually fix some irregular code.

## Notes

- Add `dist/` to .eslintignore, this is the directory of the build results of typescript;
- set `class-methods-use-this` to warning, I think this is a very controversial rule, `this` is not used in many controllers;
- I used `/* eslint */` to ignore some rules for file and `// eslint-disable-line` for line, please check the specific scenario.

