### PR TITLE
[iceworks] use midway mirror package

### DIFF
--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -74,10 +74,10 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/install.js",
-    "start": "egg-scripts start --title=egg-server-iceworks-server --framework=midway --sticky",
+    "start": "egg-scripts start --title=egg-server-iceworks-server --framework=midway-mirror --sticky",
     "stop": "egg-scripts stop --title=egg-server-iceworks-server",
     "start_build": "npm run build && NODE_ENV=development midway-bin dev",
-    "dev": "NODE_ENV=local midway-bin dev --ts",
+    "dev": "NODE_ENV=local midway-bin dev --ts --framework=midway-mirror",
     "debug": "NODE_ENV=local midway-bin debug --ts",
     "test": "npm run lint && midway-bin test --ts",
     "cov": "midway-bin cov --ts",

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -34,7 +34,7 @@
     "launch-code-editor": "^0.1.0",
     "line-by-line": "^0.1.6",
     "lodash": "^4.17.11",
-    "midway": "^1.5.6",
+    "midway-mirror": "^1.8.0",
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",
     "node-dir": "^0.1.17",

--- a/packages/iceworks-server/src/app/controller/goldlog.ts
+++ b/packages/iceworks-server/src/app/controller/goldlog.ts
@@ -1,4 +1,4 @@
-import { controller, provide, post } from 'midway';
+import { controller, provide, post } from 'midway-mirror';
 import * as rp from 'request';
 
 @provide()

--- a/packages/iceworks-server/src/app/controller/home.ts
+++ b/packages/iceworks-server/src/app/controller/home.ts
@@ -1,4 +1,4 @@
-import { controller, get, provide } from 'midway';
+import { controller, get, provide } from 'midway-mirror';
 
 @provide()
 @controller('/')

--- a/packages/iceworks-server/src/app/router.ts
+++ b/packages/iceworks-server/src/app/router.ts
@@ -1,4 +1,4 @@
-import { Application } from 'midway';
+import { Application } from 'midway-mirror';
 
 export default (app: Application) => {
   const { controller } = app.io;


### PR DESCRIPTION
- [x] Midway 依赖的命令行工具 `midway-bin` 内置写死了 `context.argv.framework = midway`，如果改用 `midway-mirror` 则 `midway-bin` 需要动态指定 framework 为  `midway` 或 `midway-mirror` 详见 [midway-bin/lib/cmd/dev.js](https://github.com/midwayjs/midway/blob/master/packages/midway-bin/lib/cmd/dev.js#L11)

```js
"scripts" : {
    "dev": "NODE_ENV=local midway-bin dev --ts --framework=midway-mirror"
}
```

![image](https://user-images.githubusercontent.com/3995814/61171740-78239080-a5ae-11e9-925f-805ed2a028d5.png)
