### PR TITLE
Fix npm utils extract tarball error

### DIFF
--- a/packages/ice-npm-utils/lib/index.js
+++ b/packages/ice-npm-utils/lib/index.js
@@ -55,7 +55,7 @@ function getAndExtractTarball(destDir, tarball, progressFunc = () => {}) {
         if(entry.type == 'Directory'){
           return;
         }
-	const realPath = entry.path.replace(/^package\//, '');
+        const realPath = entry.path.replace(/^package\//, '');
 
         let filename = path.basename(realPath);
 

--- a/packages/ice-npm-utils/lib/index.js
+++ b/packages/ice-npm-utils/lib/index.js
@@ -53,6 +53,7 @@ function getAndExtractTarball(destDir, tarball, progressFunc = () => {}) {
       .pipe(new tar.Parse())
       .on('entry', (entry) => {
         if (entry.type === 'Directory') {
+          entry.resume();
           return;
         }
         const realPath = entry.path.replace(/^package\//, '');

--- a/packages/ice-npm-utils/lib/index.js
+++ b/packages/ice-npm-utils/lib/index.js
@@ -52,7 +52,10 @@ function getAndExtractTarball(destDir, tarball, progressFunc = () => {}) {
       .pipe(zlib.Unzip())
       .pipe(new tar.Parse())
       .on('entry', (entry) => {
-        const realPath = entry.path.replace(/^package\//, '');
+        if(entry.type == 'Directory'){
+          return;
+        }
+	const realPath = entry.path.replace(/^package\//, '');
 
         let filename = path.basename(realPath);
 

--- a/packages/ice-npm-utils/lib/index.js
+++ b/packages/ice-npm-utils/lib/index.js
@@ -52,7 +52,7 @@ function getAndExtractTarball(destDir, tarball, progressFunc = () => {}) {
       .pipe(zlib.Unzip())
       .pipe(new tar.Parse())
       .on('entry', (entry) => {
-        if(entry.type == 'Directory'){
+        if (entry.type === 'Directory') {
           return;
         }
         const realPath = entry.path.replace(/^package\//, '');

--- a/packages/ice-npm-utils/test/index.test.js
+++ b/packages/ice-npm-utils/test/index.test.js
@@ -154,5 +154,5 @@ test('getAndExtractTarballWithDir', () => {
     })
     .catch(() => {
       rimraf.sync(tempDir);
-    });  
+    });
 });

--- a/packages/ice-npm-utils/test/index.test.js
+++ b/packages/ice-npm-utils/test/index.test.js
@@ -147,5 +147,12 @@ test('getAndExtractTarball', () => {
 
 test('getAndExtractTarballWithDir', () => {
   const tempDir = path.resolve(tmpdir(), 'babel_helper_function_name_tarball');
-  
+  return getAndExtractTarball(tempDir, 'https://registry.npm.taobao.org/@babel/helper-function-name/download/@babel/helper-function-name-7.1.0.tgz')
+    .then((files) => {
+      rimraf.sync(tempDir);
+      expect(files.length > 0).toBe(true);
+    })
+    .catch(() => {
+      rimraf.sync(tempDir);
+    });  
 });

--- a/packages/ice-npm-utils/test/index.test.js
+++ b/packages/ice-npm-utils/test/index.test.js
@@ -145,3 +145,7 @@ test('getAndExtractTarball', () => {
     });
 });
 
+test('getAndExtractTarballWithDir', () => {
+  const tempDir = path.resolve(tmpdir(), 'babel_helper_function_name_tarball');
+  
+});


### PR DESCRIPTION
Fix #2438.
Some packages have directories in the tarball.

The package `split` can be processed by original version of function `getAndExtractTarball`.
```
tar xvzf split-1.0.1.tgz 
x package/package.json
x package/.npmignore
x package/LICENCE
x package/index.js
x package/examples/pretty.js
x package/.travis.yml
x package/readme.markdown
x package/test/options.asynct.js
x package/test/partitioned_unicode.js
x package/test/split.asynct.js
x package/test/try_catch.asynct.js
```
However, the package `@babel/helper-function-name` cannot be processed. The directory `lib` makes it fail.
```
tar xvzf helper-function-name-7.1.0.tgz
x package
x package/LICENSE
x package/README.md
x package/lib
x package/package.json
x package/lib/index.js
```