### PR TITLE
fix: socket compatible with different system platforms

### DIFF
--- a/packages/iceworks-client/src/socket.js
+++ b/packages/iceworks-client/src/socket.js
@@ -7,6 +7,10 @@ import appConfig from './appConfig';
 const socket = io(appConfig.socketUrl, {
   // number of reconnection attempts before giving up
   reconnectionAttempts: 3,
+
+  // Note: Why set up websocket
+  // MR：https://github.com/alibaba/ice/pull/2450
+  // Refs：https://socket.io/docs/client-api/#With-websocket-transport-only
   transports: ['websocket'],
 });
 

--- a/packages/iceworks-client/src/socket.js
+++ b/packages/iceworks-client/src/socket.js
@@ -7,6 +7,7 @@ import appConfig from './appConfig';
 const socket = io(appConfig.socketUrl, {
   // number of reconnection attempts before giving up
   reconnectionAttempts: 3,
+  transports: ['websocket'],
 });
 
 socket.on('error', error => {


### PR DESCRIPTION
## 问题

socket 在不同的 Node 版本上出现以下 Error 导致页面白屏

![image](https://user-images.githubusercontent.com/3995814/61198551-0f9ef580-a70d-11e9-96b0-f51903bd73da.png)


## 解决

Refs: https://socket.io/docs/client-api/#With-websocket-transport-only

```js
const socket = io({  transports: ['websocket']});
```