### PR TITLE
fix: show message when task process error occur

### DIFF
--- a/packages/iceworks-client/src/hooks/useTask.js
+++ b/packages/iceworks-client/src/hooks/useTask.js
@@ -9,6 +9,7 @@ const useTask = ({ type, writeLog, writeChunk }) => {
   const status = (dataSource[type] && dataSource[type].status) || 'stop';
   const startEventName = `adapter.task.start.data.${type}`;
   const stopEventName = `adapter.task.stop.data.${type}`;
+  const taskErrorEventName = `adapter.task.error`;
 
   async function onStart() {
     try {
@@ -52,6 +53,9 @@ const useTask = ({ type, writeLog, writeChunk }) => {
 
   // listen stop event handle
   useSocket(stopEventName, data => taskEventListener(data), [status]);
+
+  // listen event error
+  useSocket(taskErrorEventName, error => showMessage(error.message));
 
   return {
     isWorking: status === 'working',

--- a/packages/iceworks-server/src/interface/base.ts
+++ b/packages/iceworks-server/src/interface/base.ts
@@ -5,6 +5,7 @@ export interface ISocket {
 export interface IContext {
   socket: ISocket;
   i18n: II18n;
+  logger: any;
 }
 
 export interface IPanel {

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -119,7 +119,11 @@ export default class Task implements ITaskModule {
       const { pid } = this.process[command];
       terminate(pid, (err) => {
         if (err) {
-          throw err;
+          const errMsg = err.toString();
+          ctx.logger.error(errMsg);
+          ctx.socket.emit('adapter.task.error', {
+            message: errMsg,
+          });
         }
 
         this.status[command] = TASK_STATUS_STOP;


### PR DESCRIPTION
## 问题
停止 task 进程是 windows 会抛 ENOENT 异常，导致整个进程错误

## 原因
execa 的 shell 参数设置为true 导致 windows 下的进程不指定 file （可执行文件）
erorr 监听中的异常无法被上层捕获，通过提示输出
