### PR TITLE
feat: set env for server

### DIFF
--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -42,7 +42,7 @@ export default class Task implements ITaskModule {
    */
   public async start(args: ITaskParam, ctx: IContext) {
     const { i18n, logger } = ctx;
-    const projectEnv = this.propject.getEnv();
+    const projectEnv = this.project.getEnv();
 
     const nodeModulesPath = path.join(this.project.path, 'node_modules')
     const pathExists = await fs.pathExists(nodeModulesPath);
@@ -66,7 +66,7 @@ export default class Task implements ITaskModule {
     const eventName = `start.data.${command}`;
     
     try {
-      const isWindows = os.type === 'Windows_NT';
+      const isWindows = os.type() === 'Windows_NT';
       const findCommand = isWindows ? 'where' : 'which';
       const {stdout: nodePath} = await execa(findCommand, ['node'], { env: projectEnv });
       const {stdout: npmPath} = await execa(findCommand, ['npm'], { env: projectEnv });

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -71,8 +71,8 @@ class Project implements IProject {
   }
 
   public getEnv() {
+    const env = npmRunPath.env();
     const PATH = pathKey();
-    const env = Object.assign({}, npmRunPath.env());
 
     const pathEnv = [
       env[PATH],

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -3,7 +3,9 @@ import * as trash from 'trash';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as util from 'util';
-import * as mv from 'mv';
+import * as os from 'os';
+import * as npmRunPath from 'npm-run-path';
+import * as pathKey from 'path-key';
 import * as _ from 'lodash';
 import * as mkdirp from 'mkdirp';
 import * as pathExists from 'path-exists';
@@ -69,7 +71,26 @@ class Project implements IProject {
   }
 
   public getEnv() {
-    return process.env;
+    const PATH = pathKey();
+    const env = Object.assign({}, npmRunPath.env());
+
+    const pathEnv = [
+      env[PATH],
+    ];
+
+    // for electron 
+    const resourcesPath = process['resourcesPath']; // eslint-disable-line
+    if (resourcesPath) {
+      path.join(resourcesPath, 'bin');
+    }
+
+    if (os.type() === 'Darwin') {
+      pathEnv.push('/usr/local/bin');
+    }
+
+    env[PATH] = pathEnv.join(path.delimiter);
+
+    return env;
   }
 
   private interopRequire(id) {

--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -81,9 +81,10 @@ class Project implements IProject {
     // for electron 
     const resourcesPath = process['resourcesPath']; // eslint-disable-line
     if (resourcesPath) {
-      path.join(resourcesPath, 'bin');
+      pathEnv.push(path.join(resourcesPath, 'bin'));
     }
 
+    // fallback
     if (os.type() === 'Darwin') {
       pathEnv.push('/usr/local/bin');
     }


### PR DESCRIPTION
@chenbin92 

Should we add a method call `execa` for project, then adapter using `project.execa`  to execute command?

Following benefits:

- Developer don't need to declare env explicitly;
- We can do some special processing in this way, such as printing global logs.

