### PR TITLE
[iceworks] fix material-panel-styles

### DIFF
--- a/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.js
+++ b/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.js
@@ -25,64 +25,61 @@ const MaterialPanel = ({
   const showCategories = categories.length > 1;
 
   function renderCol(materialType, data, eventHandler) {
-    if (!getMaterialLoading) {
-      if (data.length < 1) {
+    if (data.length < 1) {
+      return (
+        <Col span="24">
+          <NoData />
+        </Col>
+      );
+    }
+
+    return data.map(item => {
+      const key = item.source && item.source.npm ? item.source.npm : item.title;
+
+      if (materialType === 'components') {
         return (
-          <Col span="24">
-            <NoData />
+          <Col l="8" m="8" s="12" xs="24" xxs="24" key={key}>
+            <ComponentCard dataSource={item} onInstall={eventHandler} />
           </Col>
         );
       }
-
-      return data.map(item => {
-        const key =
-          item.source && item.source.npm ? item.source.npm : item.title;
-
-        if (materialType === 'components') {
-          return (
-            <Col l="8" m="8" s="12" xs="24" xxs="24" key={key}>
-              <ComponentCard dataSource={item} onInstall={eventHandler} />
-            </Col>
-          );
-        }
-        if (materialType === 'blocks') {
-          return (
-            <Col l="8" m="8" s="12" xs="24" xxs="24" key={key}>
-              <LazyLoad height={265} resize scrollContainer=".scollContainer">
-                <BlockCard dataSource={item} />
-              </LazyLoad>
-            </Col>
-          );
-        }
-        if (materialType === 'scaffolds') {
-          return (
-            <Col l="12" s="12" xs="24" xxs="24" key={key}>
-              <ScaffoldCard dataSource={item} onDownload={eventHandler} />
-            </Col>
-          );
-        }
-        return null;
-      });
-    }
-
-    return null;
+      if (materialType === 'blocks') {
+        return (
+          <Col l="8" m="8" s="12" xs="24" xxs="24" key={key}>
+            <LazyLoad height={265} resize scrollContainer=".scollContainer">
+              <BlockCard dataSource={item} />
+            </LazyLoad>
+          </Col>
+        );
+      }
+      if (materialType === 'scaffolds') {
+        return (
+          <Col l="12" s="12" xs="24" xxs="24" key={key}>
+            <ScaffoldCard dataSource={item} onDownload={eventHandler} />
+          </Col>
+        );
+      }
+      return null;
+    });
   }
 
   return (
-    <Loading visible={getMaterialLoading} className={styles.main}>
-      <div className={styles.materialsPanel}>
-        {showCategories ? (
-          <MaterialCategories
-            dataSource={categories}
-            current={currentCategory}
-            onChange={onCategoryChange}
-          />
-        ) : null}
+    <div className={styles.materialsPanel}>
+      {showCategories ? (
+        <MaterialCategories
+          dataSource={categories}
+          current={currentCategory}
+          onChange={onCategoryChange}
+        />
+      ) : null}
+      {getMaterialLoading ? (
+        <Loading className={styles.loadingWrap} />
+      ) : (
         <Row wrap gutter="20">
           {renderCol(type, currentMaterials, onUse, getMaterialLoading)}
         </Row>
-      </div>
-    </Loading>
+      )}
+    </div>
   );
 };
 

--- a/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.js
+++ b/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.js
@@ -76,7 +76,7 @@ const MaterialPanel = ({
         <Loading className={styles.loadingWrap} />
       ) : (
         <Row wrap gutter="20">
-          {renderCol(type, currentMaterials, onUse, getMaterialLoading)}
+          {renderCol(type, currentMaterials, onUse)}
         </Row>
       )}
     </div>

--- a/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.module.scss
+++ b/packages/iceworks-client/src/pages/Material/components/MaterialPanel/index.module.scss
@@ -1,16 +1,16 @@
-.main {
-  display: flex;
-  justify-content: center;
-  min-height: 600px;
+.materialsPanel {
+  padding: 0 16px;
+  margin-top: 20px;
 
-  .materialsPanel {
-    padding: 0 16px;
-    margin-top: 20px;
+  .tips {
+    margin: 30px 0;
+    text-align: center;
+    font-size: 14px;
+  }
 
-    .tips {
-      margin: 30px 0;
-      text-align: center;
-      font-size: 14px;
-    }
+  .loadingWrap {
+    display: flex;
+    justify-content: center;
+    min-height: 600px;
   }
 }


### PR DESCRIPTION
### 问题
打开物料面板->其他 样式错乱
![image](https://user-images.githubusercontent.com/44047106/61760091-f4af3e00-adfc-11e9-9d14-18820ad129d6.png)

### 解决
是之前添加的Loading组件导致的样式错乱 修改错误后，样式正常。如下图
![image](https://user-images.githubusercontent.com/44047106/61760138-1e686500-adfd-11e9-86e5-9ec667814ed4.png)
