### PR TITLE
refactor: delete unnecessary file generation and upload logic 

### DIFF
--- a/tools/iceworks-app/README.zh-CN.md
+++ b/tools/iceworks-app/README.zh-CN.md
@@ -40,8 +40,7 @@
 
 ### 编写更新日志
 
-- 编写 /changelog 文件夹下的 ${版本号}.json 和 changelog.json；
-- 使用 `npm run generate-updates` 生成的 updates.js 和 updates.json；
+- 编写 /changelog 文件夹下的 ${版本号}.json
 
 ### 执行发布
 
@@ -52,13 +51,3 @@
 
 > **注意** Mac 打包需要有对应的的开发者证书（否则发布后的软件无法正常更新）证书由管理员管理。
 > **注意** 上传过程中需要输入 OSS 的 Access Key Secret。
-
-### 附加说明
-
-几个文件的作用：
-
-1. change/*
-
-    - changelog.json: ice 站点中的 iceworks 更新日志列表数据来源；
-    - ${版本号}.json: Electron 自动更新时显示给用户的「更新日志」数据；
-2. updates.js/updates.json：ice 站点中「下载按钮」的数据来源。

--- a/tools/iceworks-app/package.json
+++ b/tools/iceworks-app/package.json
@@ -4,7 +4,6 @@
   "main": "app/index.js",
   "scripts": {
     "upload-app": "gulp upload-app",
-    "generate-updates": "gulp generate-updates",
     "upload-logs": "gulp upload-logs",
     "start": "electron app",
     "dist": "cross-env NODE_ENV=production gulp dist",
@@ -20,8 +19,7 @@
     "gulp": "^3.9.1",
     "gulp-util": "^3.0.8",
     "path-exists": "^4.0.0",
-    "inquirer": "^6.5.0",
-    "write": "^1.0.3"
+    "inquirer": "^6.5.0"
   },
   "description": "iceworks desktop app",
   "dependencies": {


### PR DESCRIPTION
No longer need to generate and upload `changelog.json` and `updates.json`,  new sites no longer reveal electronic information.