### PR TITLE
fix: router sort logic

### DIFF
--- a/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/router/index.ts
@@ -205,15 +205,18 @@ export default class Router implements IRouterModule {
    *  [{path: '/project/abc'}, {path: '/project'}, {path: '/bbc'}, {path: '/'}]
    */
   private sortData(data: IRouter[]): IRouter[] {
-    return data.sort((beforeItem, item) => {
-      if (beforeItem.children) {
-        beforeItem.children = this.sortData(beforeItem.children);
+    data.forEach((item) => {
+      if (item.children) {
+        item.children = this.sortData(item.children);
       }
+    });
+
+    return data.sort((beforeItem, item) => {
       if (!beforeItem.path) {
         return 1;
       }
       if (!item.path) {
-        return 0;
+        return -1;
       }
       if (beforeItem.path.indexOf(item.path) === 0) {
         return -1;


### PR DESCRIPTION
问题: 新建页面时路由加到notFound路由后面，导致访问不到

fix: router adapter中原有的路由排序逻辑有两个问题，一个是路由不存在时未排序，另一个是对于有children的路由只会遍历第一个