### PR TITLE
fix: use intl formatMessage api

### DIFF
--- a/packages/iceworks-client/src/pages/Project/components/PagePanel/BuildPageModal.js
+++ b/packages/iceworks-client/src/pages/Project/components/PagePanel/BuildPageModal.js
@@ -351,6 +351,7 @@ const BuildPageModal = ({
         on={onSaveModal}
         onCancel={onCloseSaveModal}
         onOk={onSaveOk}
+        intl={intl}
         key="saveModal"
       />,
     ]

--- a/packages/iceworks-client/src/pages/Project/components/PagePanel/SavePageModal.js
+++ b/packages/iceworks-client/src/pages/Project/components/PagePanel/SavePageModal.js
@@ -19,7 +19,7 @@ const formItemLayout = {
   },
 };
 
-const SavePageModal = ({ on, onCancel, onOk }) => {
+const SavePageModal = ({ on, onCancel, onOk, intl }) => {
   const progress = stores.useStore('progress');
   const routerStore = pageStores.useStore('routes');
   const { dataSource: routes } = routerStore;
@@ -27,7 +27,7 @@ const SavePageModal = ({ on, onCancel, onOk }) => {
 
   async function onSave(values, errors) {
     if (!errors) {
-      await progress.show({ statusText: <FormattedMessage id="iceworks.project.panel.page.create.progress.start" /> });
+      await progress.show({ statusText: intl.formatMessage({ id: 'iceworks.project.panel.page.create.progress.start' }) });
       try {
         await onOk(values);
       } catch (error) {
@@ -161,6 +161,7 @@ SavePageModal.propTypes = {
   on: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   onOk: PropTypes.func.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 export default SavePageModal;


### PR DESCRIPTION
## 问题

新建页面出现堆栈溢出问题

![image](https://user-images.githubusercontent.com/3995814/62047416-03eb1d00-b23d-11e9-87cc-042af631037b.png)

## 原因

1. 新建页面时调用 `progress.show` 传递了一个组件到 icestore：

![image](https://user-images.githubusercontent.com/3995814/62047499-3a289c80-b23d-11e9-8268-ed5f45f80c5c.png)

2. 而这个组件本质解析后是一个递归的对象：

![图片](https://user-images.githubusercontent.com/3995814/62047471-254c0900-b23d-11e9-82f9-2c3cc6e0b91d.png)

3. icestore 中使用 `Object.isFrozen(value)` 进行判断是否要 addProxy：

![image](https://user-images.githubusercontent.com/3995814/62047601-7d830b00-b23d-11e9-8540-8318326c9a5f.png)

4. 由于在开发环境中 react 组件是 Frozen 的而生产环境不是 Frozen 的，因而导致 icestore 判断递归执行了

## 解决

传递一个简单对象到 icestore 中

![image](https://user-images.githubusercontent.com/3995814/62047764-d5217680-b23d-11e9-8478-f79f9a12c8aa.png)

