### PR TITLE
fix:  unnecessary logs

### DIFF
--- a/packages/iceworks-server/src/lib/adapter/modules/dependency/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/dependency/index.ts
@@ -206,8 +206,6 @@ export default class Dependency implements IDependencyModule {
 
     const listenFunc = (buffer) => {
       const chunk = buffer.toString();
-      logger.info('reset.data:', chunk);
-
       socket.emit('adapter.dependency.reset.data', {
         chunk,
         isStdout: true,

--- a/packages/iceworks-server/src/lib/remoteLogger/index.ts
+++ b/packages/iceworks-server/src/lib/remoteLogger/index.ts
@@ -29,10 +29,14 @@ export default class RemoteLogger extends Transport {
       qsData.message = message;
     }
 
-    await request({
-      url: remoteUrl,
-      qs: qsData,
-      timeout: 2000,
-    });
+    try {
+      await request({
+        url: remoteUrl,
+        qs: qsData,
+        timeout: 2000,
+      });
+    } catch (err) {
+      // ignore...
+    }
   }
 }


### PR DESCRIPTION
info log will send to remote in the production environment, installation operations generate a large number of logs which is unnecessary.

