### PR TITLE
fix:  not throw an exception

### DIFF
--- a/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
+++ b/packages/iceworks-server/src/lib/plugin/project-manager/app.ts
@@ -281,11 +281,9 @@ class ProjectManager extends EventEmitter {
       (currentItem) => currentItem.path === path
     );
 
-    if (!project) {
-      throw new Error('notfound project');
+    if (project) {
+      return project;
     }
-
-    return project;
   }
 
   /**


### PR DESCRIPTION
新用户首次使用 iceworks 无项目时，控制台抛出错误提示 `notfound project` 不友好

![image](https://user-images.githubusercontent.com/3995814/62126212-c1d7df00-b301-11e9-89f2-a899307f894c.png)
