### PR TITLE
[iceworks]fix: copy vue ejs file to dist

### DIFF
--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -89,7 +89,8 @@
   "midway-bin-build": {
     "include": [
       "app/view",
-      "lib/adapter/modules/page/template.jsx.ejs"
+      "lib/adapter/modules/page/template.jsx.ejs",
+      "lib/adapter-vue-v2/modules/page/template.vue.ejs"
     ]
   },
   "author": "chenbin92",


### PR DESCRIPTION
### Problem Description
The template.vue.ejs file is not in the dist.

### fix
copy template.vue.ejs file to the dist
