### PR TITLE
fix: update iceworks failed

### DIFF
--- a/tools/iceworks-cli/CHANGELOG.md
+++ b/tools/iceworks-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.2
+
+- [fix] update iceworks failed #2604
+
 ## 3.0.1
 
 -  [feat] add DAU statistics

--- a/tools/iceworks-cli/lib/downloadServer.js
+++ b/tools/iceworks-cli/lib/downloadServer.js
@@ -1,6 +1,5 @@
 const path = require('path');
-const execa = require('execa');
-const chalk = require('chalk');
+const spawn = require('cross-spawn');
 const { getNpmTarball } = require('ice-npm-utils');
 const extractTarball = require('./extractTarball');
 
@@ -13,27 +12,28 @@ const DEST_DIR = path.join(__dirname, '../', 'server');
  * @param {string} destDir target directory
  */
 function downloadServer(npmName, destDir) {
+  console.log('>>> start downloading code');
   return getNpmTarball(npmName, 'latest')
     .then((url) => {
       return extractTarball(url, destDir);
     })
     .then((res) => {
       if (res.length) {
-        console.log(chalk.green('[download successful]'));
-        return install(destDir);
+        console.log('>>> download completed');
+        console.log('>>> start installing dependencies');
+        install(destDir);
       }
     })
-    .then((res) => {
-      if (res.code === 0) {
-        console.log(chalk.green('[install successful]'));
-      }
-    });
 }
 
 function install(cwd) {
-  return execa.shell('npm install', {
-    stdio: 'inherit',
+  const child = spawn('npm', ['install'], {
+    stdio: ['pipe'],
     cwd,
+  });
+
+  child.on('close', () => {
+    console.log('>>> install completed');
   });
 }
 

--- a/tools/iceworks-cli/package.json
+++ b/tools/iceworks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "a simple CLI for iceworks",
   "main": "bin/iceworks.js",
   "bin": {

--- a/tools/iceworks-cli/package.json
+++ b/tools/iceworks-cli/package.json
@@ -17,7 +17,6 @@
     "chalk": "^2.4.2",
     "commander": "^2.20.0",
     "cross-spawn": "^6.0.5",
-    "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "ice-npm-utils": "^1.1.3",
     "inquirer": "^6.5.0",


### PR DESCRIPTION
## 问题描述
*  https://github.com/alibaba/ice/issues/2604

## 问题原因

* `execa.shell` API 已删除https://github.com/sindresorhus/execa/releases/tag/v2.0.0
*  不推荐使用
![image](https://user-images.githubusercontent.com/3995814/62531477-1c7ab900-b875-11e9-9d59-f9b420976db5.png)
