### PR TITLE
fix: exit process when installation dependencies fail

### DIFF
--- a/tools/iceworks-cli/lib/downloadServer.js
+++ b/tools/iceworks-cli/lib/downloadServer.js
@@ -32,6 +32,11 @@ function install(cwd) {
     cwd,
   });
 
+  child.on('error', error => {
+    console.log(error);
+    process.exit(1);
+  });
+
   child.on('close', () => {
     console.log('>>> install completed');
   });


### PR DESCRIPTION
* 安装 iceworks 时安装依赖失败就退出进程 https://github.com/alibaba/ice/issues/2626