### PR TITLE
Iceworks cli/log install info

### DIFF
--- a/tools/iceworks-cli/lib/downloadServer.js
+++ b/tools/iceworks-cli/lib/downloadServer.js
@@ -27,9 +27,17 @@ function downloadServer(npmName, destDir) {
 }
 
 function install(cwd) {
-  const child = spawn('npm', ['install'], {
+  const child = spawn('npm', ['install', '--loglevel', 'silly'], {
     stdio: ['pipe'],
     cwd,
+  });
+
+  child.stdout.on('data', data => {
+    console.log(data.toString())
+  });
+
+  child.stderr.on('data', data => {
+    console.log(data.toString())
   });
 
   child.on('error', error => {


### PR DESCRIPTION
* 在下载 iceworks-core 之后安装依赖可能非常慢，目前只打印了一个提示，给用户的感觉以为是卡死，因此输出安装的详细日志流

![image](https://user-images.githubusercontent.com/3995814/62703059-e0815880-ba1a-11e9-818f-f2bc7ade53f7.png)
