### PR TITLE
fix: can't instantiate two global terminals

### DIFF
--- a/packages/iceworks-client/ice.config.js
+++ b/packages/iceworks-client/ice.config.js
@@ -32,6 +32,7 @@ module.exports = {
           'material-card-shadow': '0 0px 3px rgba(193, 193, 193, 0.35)',
           'text-color-inverse': '#e4e4e4',
           'tab-bar-bg': '#434557',
+          'tab-bar-color': '#B1B1B8',
           'tab-bar-active': '#fff',
         },
       }, {
@@ -46,7 +47,8 @@ module.exports = {
           'material-card-shadow': '0 8px 24px rgba(193, 193, 193, 0.35)',
           'text-color-inverse': '#fff',
           'tab-bar-bg': '#fff',
-          'tab-bar-active': '#000',
+          'tab-bar-color': '#333',
+          'tab-bar-active': '#5584FF',
         },
       }],
     }],

--- a/packages/iceworks-client/src/components/GlobalBar/index.js
+++ b/packages/iceworks-client/src/components/GlobalBar/index.js
@@ -86,17 +86,11 @@ const GlobalBar = ({ project, intl }) => {
   });
 
   function termHiddenClassName(key) {
-    if (activeKey === key) {
-      return '';
-    }
-    return styles.hidden;
+    return activeKey === key ? '' : styles.hidden;
   };
 
   function tabBarActiveClassName(key) {
-    if (activeKey === key) {
-      return styles.tabActive;
-    }
-    return '';
+    return activeKey === key ? styles.tabActive : '';
   }
 
   const hiddenClassName = show ? '' : styles.hidden;

--- a/packages/iceworks-client/src/components/GlobalBar/index.js
+++ b/packages/iceworks-client/src/components/GlobalBar/index.js
@@ -16,7 +16,7 @@ import styles from './index.module.scss';
 
 const GlobalBar = ({ project, intl }) => {
   const [globalTerminalStore] = stores.useStores(['globalTerminal']);
-  const [activeKey, changeActiveKey] = useState('process');
+  const [activeKey, changeActiveKey] = useState('operation');
   const { theme, setTheme } = useContext(ThemeContext);
   const { themeValue, termTheme } = useTermTheme();
   const projectPath = project.path;
@@ -106,17 +106,17 @@ const GlobalBar = ({ project, intl }) => {
       <div className={`${styles.globalTerminal} ${hiddenClassName}`}>
         <div className={styles.tabsNavScroll}>
           <ul role="tablist" className={styles.tabsNav}>
-            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('process')}`} onClick={() => changeActiveKey('process')}>
-              <div className={styles.tabInner}>
-                {intl.formatMessage({
-                  id: 'iceworks.global.bar.log.process',
-                })}
-              </div>
-            </li>
             <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('operation')}`} onClick={() => changeActiveKey('operation')}>
               <div className={styles.tabInner}>
                 {intl.formatMessage({
                   id: 'iceworks.global.bar.log.operation',
+                })}
+              </div>
+            </li>
+            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('process')}`} onClick={() => changeActiveKey('process')}>
+              <div className={styles.tabInner}>
+                {intl.formatMessage({
+                  id: 'iceworks.global.bar.log.process',
                 })}
               </div>
             </li>
@@ -128,15 +128,15 @@ const GlobalBar = ({ project, intl }) => {
           />
         </div>
         <div className={styles.terminalWrap}>
-          <div className={`${styles.terminal} ${termHiddenClassName('process')}`}>
-            <XtermTerminal
-              id='globalProcessLog'
-              options={{ cols: '100', rows: '17', theme: termTheme }}
-            />
-          </div>
           <div className={`${styles.terminal} ${termHiddenClassName('operation')}`}>
             <XtermTerminal
               id='globalOperationLog'
+              options={{ cols: '100', rows: '17', theme: termTheme }}
+            />
+          </div>
+          <div className={`${styles.terminal} ${termHiddenClassName('process')}`}>
+            <XtermTerminal
+              id='globalProcessLog'
               options={{ cols: '100', rows: '17', theme: termTheme }}
             />
           </div>

--- a/packages/iceworks-client/src/components/GlobalBar/index.js
+++ b/packages/iceworks-client/src/components/GlobalBar/index.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Balloon } from '@alifd/next';
 import { FormattedMessage, injectIntl } from 'react-intl';
@@ -19,6 +19,7 @@ const GlobalBar = ({ project, intl }) => {
   const [activeKey, changeActiveKey] = useState('operation');
   const { theme, setTheme } = useContext(ThemeContext);
   const { themeValue, termTheme } = useTermTheme();
+  const { dataSource: { show, globalTerminalType } } = globalTerminalStore;
   const projectPath = project.path;
 
   function handleTerminal() {
@@ -98,7 +99,7 @@ const GlobalBar = ({ project, intl }) => {
     return '';
   }
 
-  const hiddenClassName = globalTerminalStore.dataSource.show ? '' : styles.hidden;
+  const hiddenClassName = show ? '' : styles.hidden;
   const themeKey = themeValue === 'dark' ? 'light' : 'dark';
 
   const tabs = [
@@ -114,6 +115,10 @@ const GlobalBar = ({ project, intl }) => {
     },
   ];
 
+  useEffect(() => {
+    changeActiveKey(globalTerminalType);
+  }, [globalTerminalType]);
+
   return project.name ? (
     <div className={styles.container}>
       <div className={`${styles.globalTerminal} ${hiddenClassName}`}>
@@ -121,6 +126,7 @@ const GlobalBar = ({ project, intl }) => {
           <ul role="tablist" className={styles.tabsNav}>
             {tabs.map(tab => (
               <li
+                key={tab.key}
                 role="tab"
                 className={`${styles.tab} ${tabBarActiveClassName(tab.key)}`}
                 onClick={() => changeActiveKey(tab.key)}
@@ -141,7 +147,7 @@ const GlobalBar = ({ project, intl }) => {
         </div>
         <div className={styles.terminalWrap}>
           {tabs.map(tab => (
-            <div className={`${styles.terminal} ${termHiddenClassName(tab.key)}`}>
+            <div key={tab.key} className={`${styles.terminal} ${termHiddenClassName(tab.key)}`}>
               <XtermTerminal
                 id={tab.id}
                 options={{ cols: '100', rows: '17', theme: termTheme }}

--- a/packages/iceworks-client/src/components/GlobalBar/index.js
+++ b/packages/iceworks-client/src/components/GlobalBar/index.js
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Balloon, Tab } from '@alifd/next';
+import { Balloon } from '@alifd/next';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Icon from '@components/Icon';
 import XtermTerminal from '@components/XtermTerminal';
@@ -16,7 +16,7 @@ import styles from './index.module.scss';
 
 const GlobalBar = ({ project, intl }) => {
   const [globalTerminalStore] = stores.useStores(['globalTerminal']);
-  const [activeKey, changeActiveKey] = useState('operation');
+  const [activeKey, changeActiveKey] = useState('process');
   const { theme, setTheme } = useContext(ThemeContext);
   const { themeValue, termTheme } = useTermTheme();
   const projectPath = project.path;
@@ -84,44 +84,63 @@ const GlobalBar = ({ project, intl }) => {
     }
   });
 
+  function termHiddenClassName(key) {
+    if (activeKey === key) {
+      return '';
+    }
+    return styles.hidden;
+  };
+
+  function tabBarActiveClassName(key) {
+    if (activeKey === key) {
+      return styles.tabActive;
+    }
+    return '';
+  }
+
   const hiddenClassName = globalTerminalStore.dataSource.show ? '' : styles.hidden;
   const themeKey = themeValue === 'dark' ? 'light' : 'dark';
-  const tabs = [
-    {
-      title: 'iceworks.global.bar.log.operation',
-      key: 'operation',
-      id: 'globalOperationLog',
-    },
-    {
-      title: 'iceworks.global.bar.log.process',
-      key: 'process',
-      id: 'globalProcessLog',
-    },
-  ];
 
   return project.name ? (
     <div className={styles.container}>
       <div className={`${styles.globalTerminal} ${hiddenClassName}`}>
-        <Tab activeKey={activeKey} onChange={key => changeActiveKey(key)}>
-          {tabs.map(tab => (
-            <Tab.Item
-              title={intl.formatMessage({
-                id: tab.title,
-              })}
-              key={tab.key}
-            >
-              <Icon
-                type="close"
-                className={styles.closeIcon}
-                onClick={onClose}
-              />
-              <XtermTerminal
-                id={tab.id}
-                options={{ cols: '100', rows: '17', theme: termTheme }}
-              />
-            </Tab.Item>
-          ))}
-        </Tab>
+        <div className={styles.tabsNavScroll}>
+          <ul role="tablist" className={styles.tabsNav}>
+            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('process')}`} onClick={() => changeActiveKey('process')}>
+              <div className={styles.tabInner}>
+                {intl.formatMessage({
+                  id: 'iceworks.global.bar.log.process',
+                })}
+              </div>
+            </li>
+            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('operation')}`} onClick={() => changeActiveKey('operation')}>
+              <div className={styles.tabInner}>
+                {intl.formatMessage({
+                  id: 'iceworks.global.bar.log.operation',
+                })}
+              </div>
+            </li>
+          </ul>
+          <Icon
+            type="close"
+            className={styles.closeIcon}
+            onClick={onClose}
+          />
+        </div>
+        <div className={styles.terminalWrap}>
+          <div className={`${styles.terminal} ${termHiddenClassName('process')}`}>
+            <XtermTerminal
+              id='globalProcessLog'
+              options={{ cols: '100', rows: '17', theme: termTheme }}
+            />
+          </div>
+          <div className={`${styles.terminal} ${termHiddenClassName('operation')}`}>
+            <XtermTerminal
+              id='globalOperationLog'
+              options={{ cols: '100', rows: '17', theme: termTheme }}
+            />
+          </div>
+        </div>
       </div>
 
       <div className={styles.globalBar}>

--- a/packages/iceworks-client/src/components/GlobalBar/index.js
+++ b/packages/iceworks-client/src/components/GlobalBar/index.js
@@ -101,25 +101,37 @@ const GlobalBar = ({ project, intl }) => {
   const hiddenClassName = globalTerminalStore.dataSource.show ? '' : styles.hidden;
   const themeKey = themeValue === 'dark' ? 'light' : 'dark';
 
+  const tabs = [
+    {
+      title: 'iceworks.global.bar.log.operation',
+      key: 'operation',
+      id: 'globalOperationLog',
+    },
+    {
+      title: 'iceworks.global.bar.log.process',
+      key: 'process',
+      id: 'globalProcessLog',
+    },
+  ];
+
   return project.name ? (
     <div className={styles.container}>
       <div className={`${styles.globalTerminal} ${hiddenClassName}`}>
         <div className={styles.tabsNavScroll}>
           <ul role="tablist" className={styles.tabsNav}>
-            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('operation')}`} onClick={() => changeActiveKey('operation')}>
-              <div className={styles.tabInner}>
-                {intl.formatMessage({
-                  id: 'iceworks.global.bar.log.operation',
-                })}
-              </div>
-            </li>
-            <li role="tab" className={`${styles.tab} ${tabBarActiveClassName('process')}`} onClick={() => changeActiveKey('process')}>
-              <div className={styles.tabInner}>
-                {intl.formatMessage({
-                  id: 'iceworks.global.bar.log.process',
-                })}
-              </div>
-            </li>
+            {tabs.map(tab => (
+              <li
+                role="tab"
+                className={`${styles.tab} ${tabBarActiveClassName(tab.key)}`}
+                onClick={() => changeActiveKey(tab.key)}
+              >
+                <div className={styles.tabInner}>
+                  {intl.formatMessage({
+                    id: tab.title,
+                  })}
+                </div>
+              </li>
+            ))}
           </ul>
           <Icon
             type="close"
@@ -128,18 +140,14 @@ const GlobalBar = ({ project, intl }) => {
           />
         </div>
         <div className={styles.terminalWrap}>
-          <div className={`${styles.terminal} ${termHiddenClassName('operation')}`}>
-            <XtermTerminal
-              id='globalOperationLog'
-              options={{ cols: '100', rows: '17', theme: termTheme }}
-            />
-          </div>
-          <div className={`${styles.terminal} ${termHiddenClassName('process')}`}>
-            <XtermTerminal
-              id='globalProcessLog'
-              options={{ cols: '100', rows: '17', theme: termTheme }}
-            />
-          </div>
+          {tabs.map(tab => (
+            <div className={`${styles.terminal} ${termHiddenClassName(tab.key)}`}>
+              <XtermTerminal
+                id={tab.id}
+                options={{ cols: '100', rows: '17', theme: termTheme }}
+              />
+            </div>
+          ))}
         </div>
       </div>
 

--- a/packages/iceworks-client/src/components/GlobalBar/index.module.scss
+++ b/packages/iceworks-client/src/components/GlobalBar/index.module.scss
@@ -15,19 +15,53 @@
     box-shadow: 0 -2px 10px rgba(51, 51, 51, 0.35);
     visibility: visible;
 
-    :global {
-      .next-tabs {
-        background-color: $tab-bar-bg;
+    .tabsNavScroll {
+      overflow: hidden;
+      white-space: nowrap;
+      background-color: $tab-bar-bg;
 
-        .next-tabs-tab.active {
-          color: $tab-bar-active;
+      .tabsNav {
+        display: inline-block;
+        position: relative;
+        padding: 0;
+        margin: 0;
+
+        .tab {
+          display: inline-block;
+          position: relative;
+          color: $tab-bar-color;
+
+          .tabInner {
+            position: relative;
+            cursor: pointer;
+            text-decoration: none;
+            padding: 12px 16px;
+            font-size: 12px;
+          }
         }
+      }
+    }
+
+    .terminalWrap {
+      position: relative;
+      overflow: hidden;
+      height: 289px;
+
+      .terminal {
+        overflow: hidden;
+        position: absolute;
+        width: 100%;
       }
     }
   }
 
   .hidden {
     visibility: hidden;
+  }
+
+  .tabActive {
+    color: $tab-bar-active !important;
+    border-bottom: 2px solid $tab-bar-active;
   }
 
   .closeIcon {

--- a/packages/iceworks-client/src/hooks/useDependency.js
+++ b/packages/iceworks-client/src/hooks/useDependency.js
@@ -47,14 +47,14 @@ function useDependency(diableUseSocket, showGlobalTerminal = true) {
 
   async function upgrade(packageName, isDev) {
     dependenciesStore.upgrade({ package: packageName, isDev });
-    globalTerminalStore.show();
+    globalTerminalStore.show('process');
   }
 
   async function bulkCreate(values, force) {
     try {
       await dependenciesStore.bulkCreate(values, force);
       setCreateModal(false);
-      globalTerminalStore.show();
+      globalTerminalStore.show('process');
     } catch (error) {
       if (error.code === 'INCOMPATIBLE') {
         setCreateValues({ setDependencies: values, incompatibleDependencies: error.info });
@@ -70,7 +70,7 @@ function useDependency(diableUseSocket, showGlobalTerminal = true) {
     setResetModal(false);
 
     if (showGlobalTerminal) {
-      globalTerminalStore.show();
+      globalTerminalStore.show('process');
     }
   }
 

--- a/packages/iceworks-client/src/pages/Project/components/DEFPanel/index.js
+++ b/packages/iceworks-client/src/pages/Project/components/DEFPanel/index.js
@@ -31,7 +31,7 @@ const DEFPanel = ({ title, description }) => {
       return;
     }
 
-    globalTerminalStore.show();
+    globalTerminalStore.show('process');
 
     if (target === 'daily') {
       await gitStore.push();

--- a/packages/iceworks-client/src/stores/globalTerminal.js
+++ b/packages/iceworks-client/src/stores/globalTerminal.js
@@ -1,9 +1,11 @@
 export default {
   dataSource: {
     show: false,
+    globalTerminalType: 'operation',
   },
-  async show() {
+  async show(globalTerminalType) {
     this.dataSource.show = true;
+    this.dataSource.globalTerminalType = globalTerminalType;
   },
   async hide() {
     this.dataSource.show = false;


### PR DESCRIPTION
### 问题描述
使用fusion的Tab组件时，未被激活的TabItem的css元素为 `display: none`，文档渲染时，该元素如同不存在，开启Tab组件的lazyLoad后也不能实例化未被Tab激活的Term，导致未被实例化。
### 目标
同时实例化两个全局日志（进程日志和操作日志）。不使用fusion的Tab组件。

![image](https://user-images.githubusercontent.com/44047106/62765614-0d894600-bac3-11e9-8ec4-717241aca5bf.png)
![image](https://user-images.githubusercontent.com/44047106/62765757-62c55780-bac3-11e9-9d86-d8e55dfdfd1d.png)

