### PR TITLE
Project Page: Use destructured variable from hooks and refactor reloadAdapter

### DIFF
--- a/packages/iceworks-client/src/hooks/useProject.js
+++ b/packages/iceworks-client/src/hooks/useProject.js
@@ -138,6 +138,10 @@ function useProject({ panelStores } = {}) {
     }
   }
 
+  async function reloadAdapter() {
+    await projectStore.reloadAdapter();
+  }
+
   const projectPreDelete =
     projectsStore.dataSource.find(({ path }) => {
       return path === deleteProjectPath;
@@ -180,6 +184,7 @@ function useProject({ panelStores } = {}) {
     onDeleteProject,
     onSwitchProject,
     onChangeProjectPanel,
+    reloadAdapter,
   };
 }
 

--- a/packages/iceworks-client/src/pages/Project/index.js
+++ b/packages/iceworks-client/src/pages/Project/index.js
@@ -74,7 +74,7 @@ const Project = ({ history, intl }) => {
     onResetModal,
     setResetModal,
   } = useDependency();
-  const [ settingPanelStore, taskStore ] = stores.useStores(['settingPanel', 'project', 'task']);
+  const [ settingPanelStore, taskStore ] = stores.useStores(['settingPanel', 'task']);
   const [
     pagesStore, layoutsStore, gitStore, ossStore, menuStore, routesStore, todoStore,
   ] = projectStores.useStores([

--- a/packages/iceworks-client/src/pages/Project/index.js
+++ b/packages/iceworks-client/src/pages/Project/index.js
@@ -134,7 +134,7 @@ const Project = ({ history, intl }) => {
 
   function onResetModalCancel() {
     setResetModal(false);
-    if (isCreatedProject && projectStore.dataSource.adapterName) {
+    if (isCreatedProject && project.adapterName) {
       history.replace({ createdProject: false });
     }
   }
@@ -145,7 +145,7 @@ const Project = ({ history, intl }) => {
 
   async function onResetModalOk() {
     await reset();
-    if (isCreatedProject && projectStore.dataSource.adapterName) {
+    if (isCreatedProject && project.adapterName) {
       history.replace({ createdProject: false });
     }
   }
@@ -153,7 +153,7 @@ const Project = ({ history, intl }) => {
   async function onCreateProjectModalOk(values) {
     await onCreateProject(values);
 
-    if (projectStore.dataSource.adapterName) {
+    if (project.adapterName) {
       setResetModal(true);
     }
   }
@@ -177,7 +177,7 @@ const Project = ({ history, intl }) => {
   async function wrapRefreshProjects() {
     await refreshProjects();
 
-    if (isCreatedProject && projectStore.dataSource.adapterName) {
+    if (isCreatedProject && project.adapterName) {
       setResetModal(true);
     }
   }

--- a/packages/iceworks-client/src/pages/Project/index.js
+++ b/packages/iceworks-client/src/pages/Project/index.js
@@ -74,7 +74,7 @@ const Project = ({ history, intl }) => {
     onResetModal,
     setResetModal,
   } = useDependency();
-  const [ settingPanelStore, projectStore, taskStore ] = stores.useStores(['settingPanel', 'project', 'task']);
+  const [ settingPanelStore, taskStore ] = stores.useStores(['settingPanel', 'project', 'task']);
   const [
     pagesStore, layoutsStore, gitStore, ossStore, menuStore, routesStore, todoStore,
   ] = projectStores.useStores([
@@ -116,6 +116,7 @@ const Project = ({ history, intl }) => {
     onOpenProject,
     onCreateProject,
     onChangeProjectPanel,
+    reloadAdapter,
 
     onOpenProjectModal,
     setOpenProjectModal,
@@ -137,10 +138,6 @@ const Project = ({ history, intl }) => {
     if (isCreatedProject && project.adapterName) {
       history.replace({ createdProject: false });
     }
-  }
-
-  async function reloadAdapter() {
-    await projectStore.reloadAdapter();
   }
 
   async function onResetModalOk() {


### PR DESCRIPTION
1. The `project` variable is destructured from the `useProject` hooks as `projectStore.dataSource`. We can use this variable instead.

2. We can refactor the `reloadAdapter` method to be placed inside `useProject` hooks. That way we don't need to access `projectStore` in `packages/iceworks-client/src/pages/Project/index.js`.