### PR TITLE
[iceworks] fix cli args not working

### DIFF
--- a/packages/iceworks-server/src/lib/adapter/locales/en-US.json
+++ b/packages/iceworks-server/src/lib/adapter/locales/en-US.json
@@ -48,7 +48,7 @@
   "baseAdapter.task.dev.host.label": "Service host name",
   "baseAdapter.task.dev.https.label": "Use https",
   "baseAdapter.task.dev.analyzer.label": "Build analysis",
-  "baseAdapter.task.dev.disabled-reload.label": "Hot update",
+  "baseAdapter.task.dev.disabled-reload.label": "Disable hot reload",
   "vueAdapter.task.dev.port.label": "Service port number",
   "vueAdapter.task.dev.host.label": "Service host name",
   "vueAdapter.task.dev.https.label": "Use https",

--- a/packages/iceworks-server/src/lib/adapter/locales/zh-CN.json
+++ b/packages/iceworks-server/src/lib/adapter/locales/zh-CN.json
@@ -48,7 +48,7 @@
   "baseAdapter.task.dev.host.label": "服务主机名",
   "baseAdapter.task.dev.https.label": "开启 https",
   "baseAdapter.task.dev.analyzer.label": "开启构建分析",
-  "baseAdapter.task.dev.disabled-reload.label": "开启热更新",
+  "baseAdapter.task.dev.disabled-reload.label": "禁止热更新",
   "vueAdapter.task.dev.port.label": "服务端口号",
   "vueAdapter.task.dev.host.label": "服务主机名",
   "vueAdapter.task.dev.https.label": "开启 https",

--- a/packages/iceworks-server/src/lib/adapter/modules/task/getTaskConfig.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/getTaskConfig.ts
@@ -52,7 +52,7 @@ export default (ctx: IContext): ITaskConf => {
       link: '',
       componentName: 'Switch',
       componentProps: {
-        defaultChecked: true,
+        defaultChecked: false,
       },
     },
   ];

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -289,7 +289,9 @@ export default class Task implements ITaskModule {
     const command = devScriptArray[1];
     let newDevScriptContent = `${cli} ${command}`;
     Object.keys(args.options).forEach(key => {
-      newDevScriptContent += ` --${key}=${args.options[key]}`;
+      if(args.options[key]) {
+        newDevScriptContent += ` --${key}=${args.options[key]}`;
+      }
     });
 
     pkgContent.scripts.start = newDevScriptContent;


### PR DESCRIPTION
## 问题

* https://github.com/alibaba/ice/issues/2674
* https://github.com/alibaba/ice/issues/2627

## 原因
修复工程管理的快捷参数不生效问题，主要原因在于透出到 ice-scripts 的 Boolean 值是以字符串的形式，而 ice-scripts 解析字符串用于是当做 true 的形式进行处理，导致不生效

## 解决

* 如果判断是 false 则不写入到 CLI 参数上