### PR TITLE
[Iceworks]fix: fix decode for log

### DIFF
--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -27,6 +27,7 @@
     "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "ice-npm-utils": "^1.1.2",
+    "iconv-jschardet": "^1.1.3",
     "iconv-lite": "^0.5.0",
     "isbinaryfile": "^4.0.1",
     "junk": "^3.1.0",

--- a/packages/iceworks-server/package.json
+++ b/packages/iceworks-server/package.json
@@ -27,6 +27,7 @@
     "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "ice-npm-utils": "^1.1.2",
+    "iconv-lite": "^0.5.0",
     "isbinaryfile": "^4.0.1",
     "junk": "^3.1.0",
     "latest-version": "^5.1.0",

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -144,12 +144,7 @@ export default class Task implements ITaskModule {
 
     this.process[command].on('error', error => {
       // emit adapter.task.error to show message
-      let errMsg: string;
-      try {
-        errMsg = iconv.decode(error, 'gbk');
-      } catch {
-        errMsg = error.toString();
-      };
+      const errMsg: string = error.toString();
       logger.error(errMsg);
       ctx.socket.emit('adapter.task.error', {
         message: errMsg,

--- a/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
+++ b/packages/iceworks-server/src/lib/adapter/modules/task/index.ts
@@ -104,12 +104,7 @@ export default class Task implements ITaskModule {
 
     this.process[command].stdout.on('data', buffer => {
       this.status[command] = TASK_STATUS_WORKING;
-      let chunk: string;
-      try {
-        chunk = iconv.decode(buffer, 'gbk');
-      } catch {
-        chunk = buffer.toString();
-      };
+      const chunk: string = iconv.decode(buffer, 'gbk');
       ctx.socket.emit(`adapter.task.${eventName}`, {
         status: this.status[command],
         isStdout: true,
@@ -119,12 +114,7 @@ export default class Task implements ITaskModule {
 
     this.process[command].stderr.on('data', buffer => {
       this.status[command] = TASK_STATUS_WORKING;
-      let chunk: string;
-      try {
-        chunk = iconv.decode(buffer, 'gbk');
-      } catch {
-        chunk = buffer.toString();
-      };
+      const chunk: string = iconv.decode(buffer, 'gbk');
       ctx.socket.emit(`adapter.task.${eventName}`, {
         status: this.status[command],
         isStdout: false,


### PR DESCRIPTION
### 问题描述
- 在windows环境下，启动调试时，如果输出的log是中文的话，会出现乱码。（我身边没有mac，mac我没有测试）
![image](https://user-images.githubusercontent.com/44047106/64124396-84231600-cdd9-11e9-85c5-74a518f9a204.png)

### 原因
- 如果你的windows系统默认的编码方式是gbk的话，那么输出的字符串的编码类型是gbk。当然如果你曾经改过系统的默认的编码方式，则按照你后面改过后的编码方式。
- 如果你是用gbk编码的，就用gbk解码，utf-8也是一样道理。如果你是用utf-8编码的，用gbk解码是会乱码的。
- `buffer.toString()`默认的转换方式为 `utf-8`。

### 解决
引入`iconv-jschardet`和`iconv-lite`: 对`buffer`的编码类型做一个判断，如果是 `GB2312`，则以`GBK`解码。
```
const encodingType = iconvJschardet.detect(buffer);
const chunk: string = encodingType.encoding === 'GB2312' ? iconv.decode(buffer, 'gbk') : buffer.toString();
```
### 解决后：
![image](https://user-images.githubusercontent.com/44047106/64124988-18da4380-cddb-11e9-8ceb-655eef8843cb.png)
