### PR TITLE
fix: show message when installation dependencies fail

### DIFF
--- a/tools/iceworks-cli/CHANGELOG.md
+++ b/tools/iceworks-cli/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-## 3.1.0
+## 3.1.1
+- [fix] show message when installation dependencies fail
+
+## 3.1.0 
 
 - [feat] support develop materials(ice-devtools)
 - [feat] support `iceworks config`

--- a/tools/iceworks-cli/command/start/downloadServer.js
+++ b/tools/iceworks-cli/command/start/downloadServer.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const spawn = require('cross-spawn');
 const userHome = require('user-home');
+const chalk = require('chalk');
+const qrcode = require('qrcode-terminal');
 const getNpmTarball = require('../../lib/getNpmTarball');
 const extractTarball = require('../../lib/extractTarball');
 
@@ -50,8 +52,21 @@ function install(cwd) {
     process.exit(1);
   });
 
-  child.on('close', () => {
-    console.log('>>> install completed');
+  child.on('close', (code) => {
+    if (code === 0) {
+      console.log('>>> install completed');
+    } else {
+      console.log();
+      console.log(chalk.red('提示：安装依赖失败，可通过以下步骤进行修复。'));
+      console.log();
+      console.log(chalk.green(`   1. cd ${DEST_DIR}`));
+      console.log(chalk.green('   2. npm install --registry=https://registry.npm.taobao.org'));
+      console.log();
+      console.log(chalk.green('   确保依赖正常安装，然后重新启动 iceworks，如还不能正常启动，请通过钉钉群联系我们'));
+      qrcode.generate('https://ice.alicdn.com/assets/images/qrcode.png', {small: true});
+      console.log();
+      process.exit(1);
+    }
   });
 }
 

--- a/tools/iceworks-cli/package.json
+++ b/tools/iceworks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "a simple CLI for iceworks",
   "main": "bin/iceworks.js",
   "bin": {


### PR DESCRIPTION
## 问题

目前收到不少因为依赖安装失败导致 iceworks 启动失败的问题，报 `egg-scripts:command not found` 错误。如下截图所示：
![image](https://user-images.githubusercontent.com/3995814/66630153-31d5e000-ec36-11e9-8e4d-c9c08b99f747.png)

![image](https://user-images.githubusercontent.com/3995814/66630191-50d47200-ec36-11e9-8db4-25c04392bce3.png)

## 排查

通过与相关用户联系发现问题，主要原因在于 **依赖没有正常安装**，由于网络，权限等某些特定环境因素，安装依赖存在一定程度上的偶发性报错的可能，如以排查过程中用户出现下错误：

#### 安装出现 `npm install: "cb() never called`  错误
![image](https://user-images.githubusercontent.com/3995814/66630604-33ec6e80-ec37-11e9-808f-8952707804c4.png)

#### 权限问题导致依赖无法正常安装
![image](https://user-images.githubusercontent.com/3995814/66631612-1b7d5380-ec39-11e9-8c6c-bfe2cc23760d.png)

继续排查发现，目前 npm 官方也没能很好的解决，以及一些社区的解决方式，大多数是本地 npm 的环境导致，通过清楚本地 npm cache 缓存或者重新安装进行解决。

* [npm install: "cb() never called" #17839](https://github.com/npm/npm/issues/17839)
* [npm ERR cb() never called](https://stackoverflow.com/questions/15393821/npm-err-cb-never-called)
* 权限问题解决：[Resolving EACCES permissions errors when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)


## 解决

现状：目前的实现在安装依赖失败后没能退出进程，而是继续执行 iceworks 进行启动，导致用户困扰。

方案：在安装依赖失败后退出进程，并给出通过提示引导用户进行解决。

![image](https://user-images.githubusercontent.com/3995814/66632131-5fbd2380-ec3a-11e9-8063-e80ef3e67564.png)

