### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guide/advance/proxy.md
+++ b/docs/guide/advance/proxy.md
@@ -25,9 +25,9 @@ order: 2
 ```js
 {
   "proxy": {
-	'/**': {
+	  "/**": {
       "enable": true,
-      "target": 'http://127.0.0.1:6001'
+      "target": "http://127.0.0.1:6001"
     }
   }
 }


### PR DESCRIPTION
- 用户反馈的 JSON 格式的引号问题