### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guide/basic/request.md
+++ b/docs/guide/basic/request.md
@@ -7,14 +7,16 @@ order: 4
 
 ## request
 
-request 基于 axios 进行封装，在使用上与 axios 保持一致，使用方式如下：
+request 基于 axios 进行封装，在使用上与 axios 基本保持一致（除不支持 [Request method aliases](https://github.com/axios/axios#request-method-aliases) 之外），使用方式如下：
 
 ```ts
 import { request } from 'ice'
 
 async function getList() {
   try {
-    const data = await request.get('/api/list');
+    const data = await request({
+      url: '/api/list'
+    });
     console.log(data);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
- request 里对 axios 做了一层调用，不支持 [Request method aliases](https://github.com/axios/axios#request-method-aliases) 的写法。
- 因文档示例问题导致用户使用 request aliases 的写法会出现报错产出困惑