### PR TITLE
chore: optimize output log

### DIFF
--- a/packages/plugin-react-app/src/index.js
+++ b/packages/plugin-react-app/src/index.js
@@ -64,6 +64,9 @@ module.exports = ({
 
   const mode = command === 'start' ? 'development' : 'production';
   const config = getWebpackConfig(mode);
+  // 1M = 1024 KB = 1048576 B
+  config.performance.maxAssetSize(1048576).maxEntrypointSize(1048576);
+
   // setup DefinePlugin, HtmlWebpackPlugin and  CopyWebpackPlugin out of onGetWebpackConfig
   // in case of registerUserConfig will be excute before onGetWebpackConfig
 


### PR DESCRIPTION
relate to: #3237 
`html-webpack-plugin` 的输出在将在 build-scripts 中处理