### PR TITLE
fix: fix compile dependencies path in windows

### DIFF
--- a/packages/plugin-react-app/src/userConfig/compileDependencies.js
+++ b/packages/plugin-react-app/src/userConfig/compileDependencies.js
@@ -7,7 +7,7 @@ module.exports = (config, compileDependencies) => {
       } else if (typeof dep === 'string') {
         // add default node_modules
         const matchStr = `node_modules/?.+${dep}/`;
-        return process.platform === 'win32' ? matchStr.replace(/\\/g, '\\\\') : matchStr;
+        return process.platform === 'win32' ? matchStr.replace(/\//g, '\\\\') : matchStr;
       }
       return false;
     }).filter(Boolean);


### PR DESCRIPTION
修复在 win32 系统 下配置 compileDependencies 字段后，找不到对应的依赖的路径