### PR TITLE
fix: auth template types

### DIFF
--- a/packages/plugin-auth/template/index.tsx
+++ b/packages/plugin-auth/template/index.tsx
@@ -7,7 +7,7 @@ function useAuth() {
   return [
     auth,
     setAuth
-  ];
+  ] as [Record<string, boolean>, typeof setAuth];
 }
 
 // class 组件支持 Hoc 用法

--- a/packages/plugin-auth/template/model.ts
+++ b/packages/plugin-auth/template/model.ts
@@ -1,7 +1,5 @@
 export default {
-  state: {
-    auth: {}
-  },
+  state: {},
 
   reducers: {
     setAuth (state, payload) {


### PR DESCRIPTION
直接在 `function` 中返回 `[A, B]` 时, TS 会推导为 `[A | B]`

close #3294 