### PR TITLE
Feat: compile deps to support IE11 

### DIFF
--- a/docs/guide/basic/build.md
+++ b/docs/guide/basic/build.md
@@ -321,7 +321,7 @@ icejs 中一般不允许修改该配置。
 - 类型：`array`
 - 默认值：`[]`
 
-默认情况下 babel-loader 会忽略所有 node_modules 目录下的所有文件。如果需要 babel 去编译 node_modules 下的指定文件，可以在这个配置快捷添加。
+默认情况下 babel-loader 会编译相关模块以兼容 IE11。如果需要 babel 去编译 node_modules 下的指定文件，可以在这个配置快捷添加。
 
 比如想编译 node_modules 下的 @alifd/next 依赖，可以进行如下设置：
 

--- a/packages/plugin-react-app/src/config/default.config.js
+++ b/packages/plugin-react-app/src/config/default.config.js
@@ -54,17 +54,7 @@ module.exports = {
   lessLoaderOptions: {},
   sassLoaderOptions: {},
   postcssrc: false,
-  // default support IE11
-  compileDependencies: [
-    'ansi-regex',
-    'ansi-styles',
-    'chalk',
-    'query-string',
-    'react-dev-utils',
-    'split-on-first',
-    'strict-uri-encode',
-    'strip-ansi'
-  ],
+  compileDependencies: [],
   babelPlugins: [],
   babelPresets: [],
   eslint: false

--- a/packages/plugin-react-app/src/config/default.config.js
+++ b/packages/plugin-react-app/src/config/default.config.js
@@ -54,7 +54,17 @@ module.exports = {
   lessLoaderOptions: {},
   sassLoaderOptions: {},
   postcssrc: false,
-  compileDependencies: [],
+  // default support IE11
+  compileDependencies: [
+    'ansi-regex',
+    'ansi-styles',
+    'chalk',
+    'query-string',
+    'react-dev-utils',
+    'split-on-first',
+    'strict-uri-encode',
+    'strip-ansi'
+  ],
   babelPlugins: [],
   babelPresets: [],
   eslint: false

--- a/packages/plugin-react-app/src/userConfig/compileDependencies.js
+++ b/packages/plugin-react-app/src/userConfig/compileDependencies.js
@@ -1,5 +1,9 @@
 module.exports = (config, compileDependencies) => {
   const matchExclude = (filepath) => {
+    // exclude the core-js for that it will fail to run in IE  
+    if (filepath.match(/core-js/)) {
+      return true;
+    };
     // compile build-plugin module for default
     const deps = [/build-plugin.*module/].concat(compileDependencies).map(dep => {
       if (dep instanceof RegExp) {

--- a/packages/plugin-react-app/src/userConfig/compileDependencies.js
+++ b/packages/plugin-react-app/src/userConfig/compileDependencies.js
@@ -1,11 +1,20 @@
+const defaultCompileDependencies = [
+  'ansi-regex',
+  'ansi-styles',
+  'chalk',
+  'query-string',
+  'react-dev-utils',
+  'split-on-first',
+  'strict-uri-encode',
+  'strip-ansi'
+];
 module.exports = (config, compileDependencies) => {
   const matchExclude = (filepath) => {
     // exclude the core-js for that it will fail to run in IE  
-    if (filepath.match(/core-js/)) {
+    if (filepath.match(/core-js/))
       return true;
-    };
     // compile build-plugin module for default
-    const deps = [/build-plugin.*module/].concat(compileDependencies).map(dep => {
+    const deps = [/build-plugin.*module/].concat(defaultCompileDependencies, compileDependencies).map(dep => {
       if (dep instanceof RegExp) {
         return dep.source;
       } else if (typeof dep === 'string') {


### PR DESCRIPTION
- 默认增加编译相关的模块以支持运行在 IE11 中。
- 禁止 core-js 模块走 babel 编译（会有部分用户会开启全量编译，会把 core-js 也一块编译，会在 IE11 中报错）

Close: #3268 