### PR TITLE
fix: compatible with functional plugin

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -24,6 +24,8 @@ export default (api) => {
   const plugins = getAllPlugin();
   // get runtime module
   const runtimeModules = plugins.map(({ pluginPath }) => {
+    // compatible with function plugin
+    if (!pluginPath) return false;
     const modulePath = path.join(path.dirname(pluginPath), 'module.js');
     return fse.existsSync(modulePath) ? formatPath(modulePath) : false;
   })


### PR DESCRIPTION
兼容使用 js 配置时快捷定义 webpack 配置的场景

```js
module.exports = {
  plugins: [
    (api) => {},
  ],
};

```