### PR TITLE
fix: src name change

### DIFF
--- a/packages/plugin-app-core/src/config/setAlias.ts
+++ b/packages/plugin-app-core/src/config/setAlias.ts
@@ -9,11 +9,16 @@ export default (api, options) => {
   const aliasMap = [
     [`${aliasKey}$`, path.join(tempPath, 'index.ts')],
     [`${aliasKey}`, path.join(tempPath, 'pages') ],
-    ['@', path.join(rootDir, 'client')],
+    ['@', path.join(rootDir, 'src')],
     ['aliasKey', path.join(tempPath)]
   ];
 
   onGetWebpackConfig((config: any) => {
-    aliasMap.forEach(alias => config.resolve.alias.set(alias[0], alias[1]));
+    aliasMap.forEach(alias => {
+      const hasAlias = config.resolve.alias.has(alias[0]);
+      if(!hasAlias) {
+        config.resolve.alias.set(alias[0], alias[1]);
+      }
+    });
   });
 };

--- a/packages/plugin-app-core/src/config/setAlias.ts
+++ b/packages/plugin-app-core/src/config/setAlias.ts
@@ -9,7 +9,7 @@ export default (api, options) => {
   const aliasMap = [
     [`${aliasKey}$`, path.join(tempPath, 'index.ts')],
     [`${aliasKey}`, path.join(tempPath, 'pages') ],
-    ['@', path.join(rootDir, 'src')],
+    ['@', path.join(rootDir, 'client')],
     ['aliasKey', path.join(tempPath)]
   ];
 

--- a/packages/plugin-app-core/src/generator/index.ts
+++ b/packages/plugin-app-core/src/generator/index.ts
@@ -52,8 +52,11 @@ export default class Generator {
 
   private showPrettierError: boolean;
 
-  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log }) {
+  private srcDir: string
+
+  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log, srcDir = 'src' }) {
     this.rootDir = rootDir;
+    this.srcDir = srcDir;
     this.templatesDir = templatesDir;
     this.appTemplateDir = appTemplateDir;
     this.commonTemplateDir = commonTemplateDir;
@@ -166,7 +169,7 @@ export default class Generator {
   }
 
   public renderPageTemplates(templateFile) {
-    const pages = getPages(this.rootDir);
+    const pages = getPages(this.rootDir, this.srcDir);
     pages.forEach((name) => {
       const source = `./pages/${name}/index`;
       this.pageRenderData = { ...this.getPageExport(name) };

--- a/packages/plugin-app-core/src/index.ts
+++ b/packages/plugin-app-core/src/index.ts
@@ -58,6 +58,7 @@ function initGenerator(api, options) {
   const templatesDir = path.join(__dirname, './generator/templates');
   const { targets = [] } = userConfig;
   const isMiniapp = targets.includes('miniapp') || targets.includes('wechat-miniprogram');
+  const srcDir = path.dirname(userConfig.entry);
   return new Generator({
     rootDir,
     targetDir: getValue(ICE_TEMP),
@@ -72,7 +73,8 @@ function initGenerator(api, options) {
       runtimeModules: getRuntimeModules(plugins),
       buildConfig: JSON.stringify(userConfig)
     },
-    log
+    log,
+    srcDir
   });
 }
 

--- a/packages/plugin-app-core/src/utils/getPages.ts
+++ b/packages/plugin-app-core/src/utils/getPages.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fse from 'fs-extra';
 
 function getPages(rootDir: string): string[] {
-  const pagesPath = path.join(rootDir, 'src/pages');
+  const pagesPath = path.join(rootDir, 'client/pages');
   return fse.existsSync(pagesPath) ? fse.readdirSync(pagesPath)
     .filter((page) => {
       // filter .xxx and _xxx

--- a/packages/plugin-app-core/src/utils/getPages.ts
+++ b/packages/plugin-app-core/src/utils/getPages.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 
-function getPages(rootDir: string): string[] {
-  const pagesPath = path.join(rootDir, 'client/pages');
+function getPages(rootDir: string, srcDir = 'src'): string[] {
+  const pagesPath = path.join(rootDir, srcDir, 'pages');
   return fse.existsSync(pagesPath) ? fse.readdirSync(pagesPath)
     .filter((page) => {
       // filter .xxx and _xxx

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -26,13 +26,16 @@ export default class Generator {
 
   private applyMethod: Function
 
+  private srcDir: string
+
   constructor({
     rootDir,
     appStoreTemplatePath,
     pageStoreTemplatePath,
     targetPath,
     applyMethod,
-    projectType
+    projectType,
+    srcDir = 'src'
   }: {
     rootDir: string;
     appStoreTemplatePath: string;
@@ -41,6 +44,7 @@ export default class Generator {
     targetPath: string;
     projectType: string;
     applyMethod: Function;
+    srcDir: string;
   }) {
     this.rootDir = rootDir;
     this.appStoreTemplatePath = appStoreTemplatePath;
@@ -48,6 +52,7 @@ export default class Generator {
     this.targetPath = targetPath;
     this.applyMethod = applyMethod;
     this.projectType = projectType;
+    this.srcDir = srcDir;
   }
 
   private getPageModels(pageName: string, pageModelsDir: string, pageModelFile: string) {
@@ -163,9 +168,9 @@ export default class Generator {
     // generate .ice/store/index.ts
     this.renderAppStore();
 
-    const pages = this.applyMethod('getPages', this.rootDir);
+    const pages = this.applyMethod('getPages', this.rootDir, this.srcDir);
     pages.forEach(pageName => {
-      const pageNameDir = path.join(this.rootDir, 'client', 'pages', pageName);
+      const pageNameDir = path.join(this.rootDir, this.srcDir, 'pages', pageName);
 
       // e.g: src/pages/${pageName}/models/*
       const pageModelsDir = path.join(pageNameDir, 'models');

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -165,7 +165,7 @@ export default class Generator {
 
     const pages = this.applyMethod('getPages', this.rootDir);
     pages.forEach(pageName => {
-      const pageNameDir = path.join(this.rootDir, 'src', 'pages', pageName);
+      const pageNameDir = path.join(this.rootDir, 'client', 'pages', pageName);
 
       // e.g: src/pages/${pageName}/models/*
       const pageModelsDir = path.join(pageNameDir, 'models');

--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -65,6 +65,8 @@ export default async (api) => {
     config.resolve.alias.set('$ice/store', path.join(targetPath, 'store', 'index.ts'));
   });
 
+  const srcDir = path.dirname(userConfig.entry);
+
   const gen = new Generator({
     appStoreTemplatePath,
     pageStoreTemplatePath,
@@ -72,7 +74,8 @@ export default async (api) => {
     targetPath,
     rootDir,
     applyMethod,
-    projectType
+    projectType,
+    srcDir
   });
 
   gen.render();


### PR DESCRIPTION
[Issue：将 src 改为其他目录名之后页面无法正常渲染](https://github.com/alibaba/ice/issues/3402)

更改源码目录 `src` -> client`
- 需要在 `build.json` 中重新配置 `alias`、`entry`、和 `router` 配置文件路径 `configPath`
```diff
{
	"entry": "client/app",
	"alias": {
		"@": "client"
	},
	"router": {
	  "configRoutes": "client/routes.ts"
	}
}
```
- `tsconfig.json` 修改 `src` 为 `client`