### PR TITLE
Fix/src rename

### DIFF
--- a/packages/plugin-app-core/src/config/setAlias.ts
+++ b/packages/plugin-app-core/src/config/setAlias.ts
@@ -9,7 +9,7 @@ export default (api, options) => {
   const aliasMap = [
     [`${aliasKey}$`, path.join(tempPath, 'index.ts')],
     [`${aliasKey}`, path.join(tempPath, 'pages') ],
-    ['@', path.join(rootDir, 'src')],
+    ['@', path.join(rootDir, 'client')],
     ['aliasKey', path.join(tempPath)]
   ];
 

--- a/packages/plugin-app-core/src/config/setAlias.ts
+++ b/packages/plugin-app-core/src/config/setAlias.ts
@@ -9,12 +9,17 @@ export default (api, options) => {
   const aliasMap = [
     [`${aliasKey}$`, path.join(tempPath, 'index.ts')],
     [`${aliasKey}`, path.join(tempPath, 'pages') ],
-    ['@', path.join(rootDir, 'client')],
+    ['@', path.join(rootDir, 'src')],
     ['aliasKey', path.join(tempPath)]
   ];
 
   onGetWebpackConfig((config: any) => {
-    aliasMap.forEach(alias => config.resolve.alias.set(alias[0], alias[1]));
+    aliasMap.forEach(alias => {
+      const hasAlias = config.resolve.alias.has(alias[0]);
+      if(!hasAlias) {
+        config.resolve.alias.set(alias[0], alias[1]);
+      }
+    });
     if (options.framework === 'react') {
       // add alias of basic dependencies
       const basicDependencies = [

--- a/packages/plugin-app-core/src/config/setProjectType.ts
+++ b/packages/plugin-app-core/src/config/setProjectType.ts
@@ -1,10 +1,12 @@
 import * as globby from 'globby';
+import getSourceDir from '../utils/getSourceDir';
 import { PROJECT_TYPE } from '../constant';
 
 export default (api) => {
   const { context, setValue } = api;
-  const { rootDir } = context;
-  const tsEntryFiles = globby.sync(['src/app.@(ts?(x))', 'src/pages/*/app.@(ts?(x))'], {
+  const { rootDir, userConfig } = context;
+  const srcDir = getSourceDir(userConfig.entry)
+  const tsEntryFiles = globby.sync([`${srcDir}/app.@(ts?(x))`, `${srcDir}/pages/*/app.@(ts?(x))`], {
     cwd: rootDir
   });
   const projectType = tsEntryFiles.length ? 'ts' : 'js';

--- a/packages/plugin-app-core/src/config/setProjectType.ts
+++ b/packages/plugin-app-core/src/config/setProjectType.ts
@@ -5,7 +5,7 @@ import { PROJECT_TYPE } from '../constant';
 export default (api) => {
   const { context, setValue } = api;
   const { rootDir, userConfig } = context;
-  const srcDir = getSourceDir(userConfig.entry)
+  const srcDir = getSourceDir(userConfig.entry);
   const tsEntryFiles = globby.sync([`${srcDir}/app.@(ts?(x))`, `${srcDir}/pages/*/app.@(ts?(x))`], {
     cwd: rootDir
   });

--- a/packages/plugin-app-core/src/config/setRegisterMethod.ts
+++ b/packages/plugin-app-core/src/config/setRegisterMethod.ts
@@ -1,6 +1,7 @@
 import getPages from '../utils/getPages';
 import getRoutes from '../utils/getRoutes';
 import formatPath from '../utils/formatPath';
+import getSourceDir from '../utils/getSourceDir';
 import { getExportApiKeys } from '../constant';
 
 export default (api, options) => {
@@ -11,6 +12,7 @@ export default (api, options) => {
   registerMethod('getPages', getPages);
   registerMethod('formatPath', formatPath);
   registerMethod('getRoutes', getRoutes);
+  registerMethod('getSourceDir', getSourceDir);
 
   // registerMethod for modify page
   registerMethod('addPageExport', generator.addPageExport);

--- a/packages/plugin-app-core/src/generator/index.ts
+++ b/packages/plugin-app-core/src/generator/index.ts
@@ -52,8 +52,11 @@ export default class Generator {
 
   private showPrettierError: boolean;
 
-  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log }) {
+  private srcDir: string
+
+  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log, srcDir = 'src' }) {
     this.rootDir = rootDir;
+    this.srcDir = srcDir;
     this.templatesDir = templatesDir;
     this.appTemplateDir = appTemplateDir;
     this.commonTemplateDir = commonTemplateDir;
@@ -166,7 +169,7 @@ export default class Generator {
   }
 
   public renderPageTemplates(templateFile) {
-    const pages = getPages(this.rootDir);
+    const pages = getPages(this.rootDir, this.srcDir);
     pages.forEach((name) => {
       const source = `./pages/${name}/index`;
       this.pageRenderData = { ...this.getPageExport(name) };

--- a/packages/plugin-app-core/src/generator/index.ts
+++ b/packages/plugin-app-core/src/generator/index.ts
@@ -54,7 +54,7 @@ export default class Generator {
 
   private srcDir: string
 
-  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log, srcDir = 'src' }) {
+  constructor({ rootDir, targetDir, templatesDir, appTemplateDir, commonTemplateDir, defaultData, log, srcDir}) {
     this.rootDir = rootDir;
     this.srcDir = srcDir;
     this.templatesDir = templatesDir;

--- a/packages/plugin-app-core/src/index.ts
+++ b/packages/plugin-app-core/src/index.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 import Generator from './generator';
 import getRuntimeModules from './utils/getRuntimeModules';
+import getSourceDir from './utils/getSourceDir';
 import { ICE_TEMP } from './constant';
 import dev from './dev';
 import { setAlias, setProjectType, setEntry, setTempDir, setRegisterMethod, setRegisterUserConfig } from './config';
@@ -58,7 +59,7 @@ function initGenerator(api, options) {
   const templatesDir = path.join(__dirname, './generator/templates');
   const { targets = [] } = userConfig;
   const isMiniapp = targets.includes('miniapp') || targets.includes('wechat-miniprogram');
-  const srcDir = path.dirname(userConfig.entry);
+  const srcDir = getSourceDir(userConfig.entry);
   return new Generator({
     rootDir,
     targetDir: getValue(ICE_TEMP),

--- a/packages/plugin-app-core/src/index.ts
+++ b/packages/plugin-app-core/src/index.ts
@@ -58,6 +58,7 @@ function initGenerator(api, options) {
   const templatesDir = path.join(__dirname, './generator/templates');
   const { targets = [] } = userConfig;
   const isMiniapp = targets.includes('miniapp') || targets.includes('wechat-miniprogram');
+  const srcDir = path.dirname(userConfig.entry);
   return new Generator({
     rootDir,
     targetDir: getValue(ICE_TEMP),
@@ -72,7 +73,8 @@ function initGenerator(api, options) {
       runtimeModules: getRuntimeModules(plugins),
       buildConfig: JSON.stringify(userConfig)
     },
-    log
+    log,
+    srcDir
   });
 }
 

--- a/packages/plugin-app-core/src/utils/getPages.ts
+++ b/packages/plugin-app-core/src/utils/getPages.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fse from 'fs-extra';
 
 function getPages(rootDir: string): string[] {
-  const pagesPath = path.join(rootDir, 'src/pages');
+  const pagesPath = path.join(rootDir, 'client/pages');
   return fse.existsSync(pagesPath) ? fse.readdirSync(pagesPath)
     .filter((page) => {
       // filter .xxx and _xxx

--- a/packages/plugin-app-core/src/utils/getPages.ts
+++ b/packages/plugin-app-core/src/utils/getPages.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 
-function getPages(rootDir: string): string[] {
-  const pagesPath = path.join(rootDir, 'client/pages');
+function getPages(rootDir: string, srcDir = 'src'): string[] {
+  const pagesPath = path.join(rootDir, srcDir, 'pages');
   return fse.existsSync(pagesPath) ? fse.readdirSync(pagesPath)
     .filter((page) => {
       // filter .xxx and _xxx

--- a/packages/plugin-app-core/src/utils/getPages.ts
+++ b/packages/plugin-app-core/src/utils/getPages.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 
-function getPages(rootDir: string, srcDir = 'src'): string[] {
+function getPages(rootDir: string, srcDir: string): string[] {
   const pagesPath = path.join(rootDir, srcDir, 'pages');
   return fse.existsSync(pagesPath) ? fse.readdirSync(pagesPath)
     .filter((page) => {

--- a/packages/plugin-app-core/src/utils/getRoutes.ts
+++ b/packages/plugin-app-core/src/utils/getRoutes.ts
@@ -7,7 +7,7 @@ interface IParams {
   configPath: string;
   projectType: string;
   isMpa: boolean;
-  srcDir: string
+  srcDir: string;
 }
 
 interface IResult {

--- a/packages/plugin-app-core/src/utils/getRoutes.ts
+++ b/packages/plugin-app-core/src/utils/getRoutes.ts
@@ -7,6 +7,7 @@ interface IParams {
   configPath: string;
   projectType: string;
   isMpa: boolean;
+  srcDir: string
 }
 
 interface IResult {
@@ -14,7 +15,7 @@ interface IResult {
   isConfigRoutes: boolean;
 }
 
-function getRoutes({ rootDir, tempDir, configPath, projectType, isMpa }: IParams): IResult {
+function getRoutes({ rootDir, tempDir, configPath, projectType, isMpa, srcDir }: IParams): IResult {
   // if is mpa use empty router file
   if (isMpa) {
     const routesTempPath = path.join(tempDir, 'routes.ts');
@@ -28,7 +29,7 @@ function getRoutes({ rootDir, tempDir, configPath, projectType, isMpa }: IParams
 
   const routesPath = configPath
     ? path.join(rootDir, configPath)
-    : path.join(rootDir, `src/routes.${projectType}`);
+    : path.join(rootDir, srcDir, `/routes.${projectType}`);
 
   // 配置式路由
   const configPathExists = fse.existsSync(routesPath);

--- a/packages/plugin-app-core/src/utils/getSourceDir.ts
+++ b/packages/plugin-app-core/src/utils/getSourceDir.ts
@@ -1,0 +1,9 @@
+import * as path from 'path';
+
+function getSourceDir (entry: string): string {
+  // entry: src/app -> srcDir: src
+  // entry: client/app -> srcDir: client
+  return path.dirname(entry);
+}
+
+export default getSourceDir;

--- a/packages/plugin-router/src/index.ts
+++ b/packages/plugin-router/src/index.ts
@@ -19,14 +19,15 @@ const plugin: IPlugin = ({ context, onGetWebpackConfig, modifyUserConfig, getVal
   const { configPath } = routerOptions;
   const { mpa: isMpa } = userConfig;
   const routesTempPath = path.join(iceTempPath, `routes.${projectType}`);
+  const srcDir = applyMethod('getSourceDir', userConfig.entry);
   const { routesPath, isConfigRoutes } = applyMethod('getRoutes', {
     rootDir,
     tempDir: iceTempPath,
     configPath,
     projectType,
-    isMpa
+    isMpa,
+    srcDir
   });
-
   // add babel plugins for ice lazy
   modifyUserConfig('babelPlugins',
     [

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -26,13 +26,16 @@ export default class Generator {
 
   private applyMethod: Function
 
+  private srcDir: string
+
   constructor({
     rootDir,
     appStoreTemplatePath,
     pageStoreTemplatePath,
     targetPath,
     applyMethod,
-    projectType
+    projectType,
+    srcDir = 'src'
   }: {
     rootDir: string;
     appStoreTemplatePath: string;
@@ -41,6 +44,7 @@ export default class Generator {
     targetPath: string;
     projectType: string;
     applyMethod: Function;
+    srcDir: string;
   }) {
     this.rootDir = rootDir;
     this.appStoreTemplatePath = appStoreTemplatePath;
@@ -48,6 +52,7 @@ export default class Generator {
     this.targetPath = targetPath;
     this.applyMethod = applyMethod;
     this.projectType = projectType;
+    this.srcDir = srcDir;
   }
 
   private getPageModels(pageName: string, pageModelsDir: string, pageModelFile: string) {
@@ -163,9 +168,9 @@ export default class Generator {
     // generate .ice/store/index.ts
     this.renderAppStore();
 
-    const pages = this.applyMethod('getPages', this.rootDir);
+    const pages = this.applyMethod('getPages', this.rootDir, this.srcDir);
     pages.forEach(pageName => {
-      const pageNameDir = path.join(this.rootDir, 'client', 'pages', pageName);
+      const pageNameDir = path.join(this.rootDir, this.srcDir, 'pages', pageName);
 
       // e.g: src/pages/${pageName}/models/*
       const pageModelsDir = path.join(pageNameDir, 'models');

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -165,7 +165,7 @@ export default class Generator {
 
     const pages = this.applyMethod('getPages', this.rootDir);
     pages.forEach(pageName => {
-      const pageNameDir = path.join(this.rootDir, 'src', 'pages', pageName);
+      const pageNameDir = path.join(this.rootDir, 'client', 'pages', pageName);
 
       // e.g: src/pages/${pageName}/models/*
       const pageModelsDir = path.join(pageNameDir, 'models');

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -35,7 +35,7 @@ export default class Generator {
     targetPath,
     applyMethod,
     projectType,
-    srcDir = 'src'
+    srcDir
   }: {
     rootDir: string;
     appStoreTemplatePath: string;

--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -29,19 +29,21 @@ export default async (api) => {
 
   // add babel plugins for ice lazy
   const { configPath } = userConfig.router || {};
-  const { mpa: isMpa } = userConfig;
+  const { mpa: isMpa, entry } = userConfig;
+  const srcDir = applyMethod('getSourceDir', entry);
   let { routesPath } = applyMethod('getRoutes', {
     rootDir,
     tempDir: targetPath,
     configPath,
     projectType,
-    isMpa
+    isMpa,
+    srcDir
   });
 
   if (isMpa) {
     const routesFile = `routes.${projectType}`;
     const pagesPath = path.join(rootDir, 'src', 'pages');
-    const pages = applyMethod('getPages', rootDir);
+    const pages = applyMethod('getPages', rootDir, srcDir);
     const pagesRoutePath = pages.map(pageName => {
       return path.join(pagesPath, pageName, routesFile);
     });
@@ -64,8 +66,6 @@ export default async (api) => {
   onGetWebpackConfig(config => {
     config.resolve.alias.set('$ice/store', path.join(targetPath, 'store', 'index.ts'));
   });
-
-  const srcDir = path.dirname(userConfig.entry);
 
   const gen = new Generator({
     appStoreTemplatePath,

--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -65,6 +65,8 @@ export default async (api) => {
     config.resolve.alias.set('$ice/store', path.join(targetPath, 'store', 'index.ts'));
   });
 
+  const srcDir = path.dirname(userConfig.entry);
+
   const gen = new Generator({
     appStoreTemplatePath,
     pageStoreTemplatePath,
@@ -72,7 +74,8 @@ export default async (api) => {
     targetPath,
     rootDir,
     applyMethod,
-    projectType
+    projectType,
+    srcDir
   });
 
   gen.render();


### PR DESCRIPTION
[Issue：将 src 改为其他目录名之后页面无法正常渲染](https://github.com/alibaba/ice/issues/3402)

更改源码目录 `src` -> `client`
- 更改入口 `entry`。如需使用指向源码目录的 `alias` `@`，需要在 `build.json` 中配置。
```json
// build.json
{
	"entry": "client/app",
	"alias": {
		"@": "client"
	}
}
```
- `tsconfig.json` 修改 `src` 为 `client`