### PR TITLE
fix: ts compile config

### DIFF
--- a/packages/rax-app-renderer/package.json
+++ b/packages/rax-app-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app-renderer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",

--- a/packages/rax-app-renderer/tsconfig.json
+++ b/packages/rax-app-renderer/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./",
     "rootDir": "src",
     "outDir": "lib",
-    "jsx": "preserve",
+    "jsx": "react",
     "jsxFactory": "createElement",
     "module": "esNext",
     "target": "es5",


### PR DESCRIPTION
## 问题

`rax-app-renderer/renderer.tsx` 编译后为 `rax-app-renderer-renderer.jsx` 导致引用失败，实际应该编译成 `rax-app-renderer/renderer.js`

## 原因


### jsx 配置

在 tsconfig 中设置了 jsx 为  preserve 导致编译后文件后缀为 `jsx`，关于 jsx 解释如下：

```json
{
  jsx: "preserve"
}
```

-  在 preserve 模式下生成代码中会保留 JSX 以供后续的转换操作使用（比如：Babel）。 另外，输出文件会带有 `.jsx` 扩展名
- 在 react 模式会生成 React.createElement，在使用前不需要再进行转换操作了，输出文件的扩展名为 `.js`

![image](https://user-images.githubusercontent.com/3995814/89985254-59aa3000-dcad-11ea-9143-b42dcbfeb5ac.png)

### jsxFactory 配置

```json
{
   jsxFactory: "createElement"
}
```

当 jsx 设置为 react 时，默认会使用 `React.createElement("div")` 创建元素， 所以在 rax 中编译时需要将 jsxFactory 配置为 createElement，这样创建元素时会使用  `createElement("div")` 来生成，而不是 `React.createElement("div")`
