### PR TITLE
feat: request 增加泛型支持，修复request.get等方法返回数据类型错误

### DIFF
--- a/packages/plugin-request/template/request.ts
+++ b/packages/plugin-request/template/request.ts
@@ -1,27 +1,27 @@
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosRequestConfig } from 'axios';
 import * as utils from 'axios/lib/utils';
 import createAxiosInstance from './createAxiosInstance';
 
 export interface IRequestProps {
-  get: (url: string, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  delete: (url: string, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  head: (url: string, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  options: (url: string, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  post: (url: string, data?: any, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  put: (url: string, data?: any, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
-  patch: (url: string, data?: any, config?: AxiosRequestConfig) => Promise<AxiosResponse<any>>;
+  get: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  delete: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  head: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  options: <T = any>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  post: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
+  put: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
+  patch: <T = any>(url: string, data?: any, config?: AxiosRequestConfig) => Promise<T>;
 }
 
 interface IRequest extends IRequestProps {
-  (options: AxiosRequestConfig): any;
-  (url: string, config?: AxiosRequestConfig): any;
+  <T = any>(options: AxiosRequestConfig): Promise<T>;
+  <T = any>(url: string, config?: AxiosRequestConfig): Promise<T>;
 }
 
 /**
  * 请求体，返回 response.data | response
  * @param options 请求配置 https://github.com/axios/axios#request-config
  */
-const request = async function (options) {
+const request = async function <T = any>(options): Promise<T> {
   try {
     const instanceName = options.instanceName ? options.instanceName : 'default';
     const axiosInstance = createAxiosInstance()[instanceName];
@@ -42,8 +42,8 @@ const request = async function (options) {
 
 // Provide aliases for supported request methods
 utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData(method) {
-  request[method] = function(url, config) {
-    return request(utils.merge(config || {}, {
+  request[method] = function <T = any>(url, config) {
+    return request<T>(utils.merge(config || {}, {
       method,
       url
     }));
@@ -51,8 +51,8 @@ utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData
 });
 
 utils.forEach(['post', 'put', 'patch'], function forEachMethodWithData(method) {
-  request[method] = function(url, data, config) {
-    return request(utils.merge(config || {}, {
+  request[method] = function <T = any>(url, data, config) {
+    return request<T>(utils.merge(config || {}, {
       method,
       url,
       data

--- a/packages/rax-app-renderer/package.json
+++ b/packages/rax-app-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-app-renderer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",

--- a/packages/rax-app-renderer/tsconfig.json
+++ b/packages/rax-app-renderer/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./",
     "rootDir": "src",
     "outDir": "lib",
-    "jsx": "preserve",
+    "jsx": "react",
     "jsxFactory": "createElement",
     "module": "esNext",
     "target": "es5",


### PR DESCRIPTION
Signed-off-by: 二凢 <dingyu.wdy@alibaba-inc.com>

### 加强 request 对 typescript 的支持。

1. `request.get`, `request.post` 等方法返回的数据类型为 `Promise<any>`, 不应该是 `Promise<AxiosResponse<any>>`
2. `request` 返回数据类型为 `Promise<any>`, 不应该是 `any`
3. 增加泛型支持，默认为 `any`

### 测试方法：
1. 使用 ice ts 模板
2. `request('/')`， `request<boolean>('/')`
3. `request.get('/')`， `request.get<boolean>('/')`
