### PR TITLE
fix: path-to-regexp usage

### DIFF
--- a/packages/create-use-router/package.json
+++ b/packages/create-use-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-use-router",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",

--- a/packages/create-use-router/src/index.ts
+++ b/packages/create-use-router/src/index.ts
@@ -1,4 +1,4 @@
-import * as pathToRegexp from 'path-to-regexp';
+import * as pathToRegexpModule from 'path-to-regexp';
 
 const cache = {};
 function decodeParam(val) {
@@ -27,7 +27,7 @@ function matchPath(route, pathname, parentParams) {
   const keys = cache[keysCacheKey] || [];
 
   if (!regexp) {
-    regexp = pathToRegexp(path, keys, {
+    regexp = (pathToRegexpModule as any).pathToRegexp(path, keys, {
       end,
       strict,
       sensitive


### PR DESCRIPTION
In `path-to-regexp` v3.x, it can be used like: `const pathToRegexp  = require('path-to-regexp')`.
But in v6.x, it only can be used like: `const { pathToRegexp } = require('path-to-regexp')`