### PR TITLE
fix: reset miniapp entry

### DIFF
--- a/packages/plugin-miniapp/src/index.ts
+++ b/packages/plugin-miniapp/src/index.ts
@@ -1,8 +1,9 @@
 import * as miniappConfig from 'miniapp-runtime-config';
+import * as builderShared from 'miniapp-builder-shared';
 import * as path from 'path';
 
 module.exports = (api) => {
-  const { onGetWebpackConfig, context, registerUserConfig } = api;
+  const { onGetWebpackConfig, context, registerUserConfig, getValue } = api;
   const { rootDir, userConfig } = context;
   const { targets = [] } = userConfig;
 
@@ -14,6 +15,11 @@ module.exports = (api) => {
           name: target,
           validation: 'object'
         });
+
+        const projectType = getValue('PROJECT_TYPE');
+        // Reset entry
+        config.entryPoints.clear();
+        config.entry('index').add(builderShared.pathHelper.getDepPath(rootDir, `app.${projectType}`));
 
         const outputPath = path.resolve(rootDir, outputDir, target);
         config.output.path(path.join(rootDir, 'build', target));


### PR DESCRIPTION
- 小程序下重新设置 entry 无需配置 `react-dev-utils/webpackHotDevClient`