### PR TITLE
Feat/support get initial data and set initial data

### DIFF
--- a/examples/basic-spa/src/app.tsx
+++ b/examples/basic-spa/src/app.tsx
@@ -8,7 +8,7 @@ const appConfig: IAppConfig = {
     parseSearchParams: true,
     getInitialData: async() => {
       const result = await request('/repo');
-      console.log('request result:', result);
+      return result;
     },
     onShow() {
       console.log('app show...');

--- a/examples/basic-spa/src/pages/Home/index.tsx
+++ b/examples/basic-spa/src/pages/Home/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, usePageShow, usePageHide, helpers, logger, config } from 'ice';
+import { Link, usePageShow, usePageHide, helpers, logger, config, getInitialData, setInitialData } from 'ice';
 
 logger.debug('helpers from ice', helpers.urlParse);
 logger.debug('logger from ice', logger.debug);
@@ -10,7 +10,12 @@ logger.error('=== error ===');
 logger.debug('=== debug ===');
 logger.trace('=== trace ===');
 
+console.log('getInitialData outside=====>:', getInitialData());
+
+setInitialData({ a: 1 });
+
 export default function Home(props) {
+  console.log('getInitialData inside=====>:', getInitialData());
 
   logger.info('Home props', props);
   logger.info('render home config.appId', config.appId);

--- a/examples/basic-spa/src/pages/Home/index.tsx
+++ b/examples/basic-spa/src/pages/Home/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, usePageShow, usePageHide, helpers, logger, config, getInitialData, setInitialData } from 'ice';
+import { Link, usePageShow, usePageHide, helpers, logger, config, getInitialData } from 'ice';
 
 logger.debug('helpers from ice', helpers.urlParse);
 logger.debug('logger from ice', logger.debug);
@@ -11,8 +11,6 @@ logger.debug('=== debug ===');
 logger.trace('=== trace ===');
 
 console.log('getInitialData outside=====>:', getInitialData());
-
-setInitialData({ a: 1 });
 
 export default function Home(props) {
   console.log('getInitialData inside=====>:', getInitialData());

--- a/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
@@ -4,7 +4,7 @@ import miniappRenderer from 'miniapp-renderer';
 import createShareAPI, { history } from 'create-app-shared';
 
 <% if (isReact) {%>
-  import reactAppRenderer, { getInitialData, setInitialData } from 'react-app-renderer';
+  import reactAppRenderer, { getInitialData } from 'react-app-renderer';
   import { withRouter as defaultWithRouter } from 'react-router';
   import genWithSearchParams from './genWithSearchParams';
 <% } %>
@@ -96,7 +96,6 @@ export {
   useSearchParams,
   withSearchParams,
   getInitialData,
-  setInitialData,
 <% } %>
   // LifeCycles api
   usePageShow,

--- a/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
@@ -4,7 +4,7 @@ import miniappRenderer from 'miniapp-renderer';
 import createShareAPI, { history } from 'create-app-shared';
 
 <% if (isReact) {%>
-  import reactAppRenderer from 'react-app-renderer';
+  import reactAppRenderer, { getInitialData, setInitialData } from 'react-app-renderer';
   import { withRouter as defaultWithRouter } from 'react-router';
   import genWithSearchParams from './genWithSearchParams';
 <% } %>
@@ -95,6 +95,8 @@ export {
 <% if (isReact) {%>
   useSearchParams,
   withSearchParams,
+  getInitialData,
+  setInitialData,
 <% } %>
   // LifeCycles api
   usePageShow,

--- a/packages/react-app-renderer/src/index.ts
+++ b/packages/react-app-renderer/src/index.ts
@@ -1,4 +1,4 @@
-import { reactAppRenderer, reactAppRendererWithSSR, getInitialData, setInitialData } from './renderer';
+import { reactAppRenderer, reactAppRendererWithSSR, getInitialData } from './renderer';
 
-export { reactAppRendererWithSSR, getInitialData, setInitialData };
+export { reactAppRendererWithSSR, getInitialData };
 export default reactAppRenderer;

--- a/packages/react-app-renderer/src/index.ts
+++ b/packages/react-app-renderer/src/index.ts
@@ -1,4 +1,4 @@
-import { reactAppRenderer, reactAppRendererWithSSR } from './renderer';
+import { reactAppRenderer, reactAppRendererWithSSR, getInitialData, setInitialData } from './renderer';
 
-export { reactAppRendererWithSSR };
+export { reactAppRendererWithSSR, getInitialData, setInitialData };
 export default reactAppRenderer;

--- a/packages/react-app-renderer/src/renderer.tsx
+++ b/packages/react-app-renderer/src/renderer.tsx
@@ -17,7 +17,7 @@ export function reactAppRendererWithSSR(context, options) {
 
 let __initialData__;
 
-export function setInitialData(initialData) {
+function setInitialData(initialData) {
   __initialData__ = initialData;
 }
 

--- a/packages/react-app-renderer/src/renderer.tsx
+++ b/packages/react-app-renderer/src/renderer.tsx
@@ -15,6 +15,16 @@ export function reactAppRendererWithSSR(context, options) {
   return _renderApp(context, options);
 }
 
+let __initialData__;
+
+export function setInitialData(initialData) {
+  __initialData__ = initialData;
+}
+
+export function getInitialData() {
+  return __initialData__;
+}
+
 export async function reactAppRenderer(options) {
   const { appConfig, setAppConfig, loadStaticModules } = options || {};
 
@@ -38,6 +48,9 @@ export async function reactAppRenderer(options) {
       initialData = await appConfig.app.getInitialData();
     }
   }
+
+  // set InitialData, can get the return value through getInitialData method
+  setInitialData(initialData);
 
   const context = { initialData, pageInitialProps };
   _renderApp(context, options);


### PR DESCRIPTION
## 需求

https://github.com/alibaba/ice/issues/3671

## 新增 API 

新增 `getInitialData` 和 `setInitialData` API 用于在更简单的获取和设置 initialData。

**说明**

**1. 为什么需要 `getInitialData` API ?**

> 在某些情况下希望更简单(相比 store)的获取通过 getInitialData 返回的 initialData 值。

**2. 为什么需要 `setInitialData` API ?**

> 既然能获取 initialData 值，通常情况下也会存在设置 initialData 的场景，因此提供了 `setInitialData` API

**3. 为什不是直接获取 `initialData ?`**

> 1. 基于 1、2 是否只存在获取而不存在设置 initialData 的值，从设计和使用场景来看， 通常提供 `set` 和 `get` 的对称性 API 会是更好的组合。



