### PR TITLE
fix: override externals

### DIFF
--- a/packages/plugin-app-base/src/userConfig/externals.js
+++ b/packages/plugin-app-base/src/userConfig/externals.js
@@ -1,3 +1,12 @@
 module.exports = (config, value) => {
-  config.merge({ externals: value });
+  if (config.has('externals')) {
+    const externals = config.get('externals');
+    if (Array.isArray(externals)) {
+      config.externals([...externals, value]);
+    } else {
+      config.externals([externals, value]);
+    }
+  } else {
+    config.merge({ externals: [value] });
+  }
 };


### PR DESCRIPTION
修复 `externals` 默认配置覆盖的问题