### PR TITLE
fix: ssr matchedRoute undefined

### DIFF
--- a/packages/plugin-ice-ssr/package.json
+++ b/packages/plugin-ice-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-ice-ssr",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "ssr plugin",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-ice-ssr/src/server.ts.ejs
+++ b/packages/plugin-ice-ssr/src/server.ts.ejs
@@ -79,7 +79,9 @@ function getComponentByPath(routes, currPath)  {
     const matchedRoute = routeList.find(route => {
       return matchPath(currPath, route);
     });
-    return matchedRoute.children ? findMatchRoute(matchedRoute.children) : matchedRoute;
+    if (matchedRoute) {
+      return matchedRoute.children ? findMatchRoute(matchedRoute.children) : matchedRoute;
+    }
   }
   const matchedRoute = findMatchRoute(routes);
   return matchedRoute && matchedRoute.component;


### PR DESCRIPTION
问题描述：
项目中使用 SSR 时，遇到请求不存在路由，进入下面的逻辑时候，matchedRoute 会是 undefined，会报错。如下图：
![image](https://user-images.githubusercontent.com/44047106/98338315-faa64e00-2044-11eb-97c2-9474fc296262.png)
