### PR TITLE
fix rax-config-ali error block webpack

### DIFF
--- a/packages/eslint-reporting-webpack-plugin/package.json
+++ b/packages/eslint-reporting-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-reporting-webpack-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A friendly ESLint reporting plugin for webpack.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/eslint-reporting-webpack-plugin/src/index.js
+++ b/packages/eslint-reporting-webpack-plugin/src/index.js
@@ -33,6 +33,10 @@ module.exports = class EslintReportingPlugin {
         configFile: configFiles[0],
       });
       formatter = eslint.getFormatter();
+
+      // Run ESlint used method, avoid plugin or parser error block webpack.
+      eslint.isPathIgnored('');
+      eslint.executeOnFiles([]);
     } catch (e) {
       // When user eslint has error, don‘t run this plugin
       userESLintHasError = true;


### PR DESCRIPTION
ESlint config `rax-config-ali` 's typescript  plugin parser error will occurred when use isPathIgnored and executeOnFiles.

Run used method in advance, can avoid block webpack