### PR TITLE
Fix: compatible with page name with - in store 

### DIFF
--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -93,7 +93,7 @@ export default class Generator {
       };
     }
 
-    const pageComponentName = `Page${pageName}`;
+    const pageComponentName = 'PageComponent';
     return {
       isSingleModel: true,
       importStr: `import ${pageComponentName} from '${this.applyMethod('formatPath', pageModelFile)}';`,
@@ -166,7 +166,7 @@ export default class Generator {
     const pageComponentTargetPath = path.join(this.targetPath, 'pages', pageName, 'Page.tsx');
     const pageComponentSourcePath = this.applyMethod('formatPath', pageNameDir);
 
-    const pageComponentName = `Page${pageName}`;
+    const pageComponentName = 'PageComponent';
     const pageComponentRenderData = {
       isRax: this.isRax,
       pageComponentImport: `import ${pageComponentName} from '${pageComponentSourcePath}'`,
@@ -271,7 +271,7 @@ export default class Generator {
       // generate .ice/pages/${pageName}/store.ts
       this.renderPageStore(params);
 
-      // generate .ice/pages/${pageName}/index.ts	
+      // generate .ice/pages/${pageName}/index.ts
       this.renderPageIndex(params);
 
       // generate .ice/pages/${pageName}/Page.tsx


### PR DESCRIPTION
问题：
当组件名是连字符（带 - ）的时候，组件命名会有问题，比如：

```jsx
// `PageAbout-a` will occur error 
import PageAbout-a from '/Users/luhc228/workspace/github.com/alibaba/ice/examples/basic-store/src/pages/About-a';

const PageComponentName = PageAbout-a;
```
