### PR TITLE
fix: update userconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,22 @@ jobs:
       matrix:
         node-version: [10.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: nelonoel/branch-name@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+    - uses: actions/checkout@v2
+    - name: Set branch name
+      run: echo >>$GITHUB_ENV BRANCH_NAME=${GITHUB_REF#refs/heads/}
+    - name: Echo branch name
+      run: echo ${BRANCH_NAME}
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://registry.npmjs.org/
       - run: npm run setup
       - run: npm run dependency:check
       - run: npm run lint
       - run: npm run test
       - run: npm run version:check
       - run: npm run coverage
-      - run: npm run generate:docs
-      - run: npm run upload:oss
         env:
           ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
           ACCESS_KEY_SECRET: ${{ secrets.ACCESS_KEY_SECRET }}

--- a/packages/build-user-config/src/config/constants.js
+++ b/packages/build-user-config/src/config/constants.js
@@ -11,14 +11,5 @@ module.exports = {
   GET_RAX_APP_WEBPACK_CONFIG: 'getRaxAppWebpackConfig',
   USER_CONFIG_KEY_WITHOUT_BUILD: [
     'plugins',
-    // task name
-    'web',
-    'miniapp',
-    'weex',
-    'kraken',
-    'wechat-miniprogram',
-    'bytedance-microapp',
-    // tasks config
-    'targets',
   ],
 };

--- a/packages/build-user-config/src/utils/modifyUserConfig.js
+++ b/packages/build-user-config/src/utils/modifyUserConfig.js
@@ -17,8 +17,6 @@ module.exports = (api, defaultRegistration) => {
           : defaultConfig[configKey];
         // eslint-disable-next-line no-param-reassign
         delete userConfig[configKey];
-      } else {
-        newConfig[configKey] = userConfig[configKey];
       }
     });
     // migrate sourcemap to sourceMap

--- a/packages/build-user-config/src/utils/modifyUserConfig.js
+++ b/packages/build-user-config/src/utils/modifyUserConfig.js
@@ -1,7 +1,7 @@
 const { USER_CONFIG_KEY_WITHOUT_BUILD } = require('../config/constants');
 
 module.exports = (api, defaultRegistration) => {
-  const { modifyUserConfig } = api;
+  const { modifyUserConfig, context } = api;
   const defaultConfig = {};
   defaultRegistration.forEach(({name, defaultValue}) => {
     defaultConfig[name] = defaultValue;
@@ -17,6 +17,8 @@ module.exports = (api, defaultRegistration) => {
           : defaultConfig[configKey];
         // eslint-disable-next-line no-param-reassign
         delete userConfig[configKey];
+      } else {
+        newConfig[configKey] = userConfig[configKey];
       }
     });
     // migrate sourcemap to sourceMap
@@ -24,6 +26,7 @@ module.exports = (api, defaultRegistration) => {
       newConfig.sourceMap = newConfig.sourcemap;
     }
     delete newConfig.sourcemap;
+    context.userConfig = newConfig;
     return newConfig;
   });
 };


### PR DESCRIPTION
当 `motifyUserConfig` 在 A 插件中执行的时候，A 插件中任意生命周期里拿到的 `context.userConfig` 都是被删减过后的值，无法获取到最新值。原因是 `motifyUserConfig` 修改的 `context` 和当前插件的 `context` 不是同一个对象，所以需要在 motify 之后更新 `userConfig`