### PR TITLE
fix: eslint emit error

### DIFF
--- a/packages/build-user-config/src/userConfig/eslint.js
+++ b/packages/build-user-config/src/userConfig/eslint.js
@@ -18,6 +18,7 @@ module.exports = (config, eslint, { rootDir }) => {
         .loader(require.resolve('eslint-loader'))
         .tap((options) => ({
             cache: true,
+            emitError: true,
             eslintPath: require.resolve('eslint'),
             formatter: require.resolve('react-dev-utils/eslintFormatter'),
             ...options,


### PR DESCRIPTION
当配置 `eslint: true` 的时候，阻塞构建的同时需要把 eslint 的报错抛出来