### PR TITLE
fix: compatible with functional postcss options

### DIFF
--- a/examples/basic-spa/build.json
+++ b/examples/basic-spa/build.json
@@ -9,5 +9,14 @@
   "eslint": {
     "disable": false,
     "quiet": true
+  },
+  "postcssOptions": {
+    "plugins": {
+      "postcss-preset-env": {
+        "browsers": [
+          "last 2 versions"
+        ]
+      }
+    }
   }
 }

--- a/packages/build-scripts-config/src/config/webpack/defaultPostcssPlugins.js
+++ b/packages/build-scripts-config/src/config/webpack/defaultPostcssPlugins.js
@@ -1,0 +1,12 @@
+const plugins = [['postcss-preset-env', {
+  browsers: [
+    'last 2 versions',
+    'Firefox ESR',
+    '> 1%',
+    'ie >= 9',
+    'iOS >= 8',
+    'Android >= 4',
+  ],
+}]];
+
+module.exports = plugins;

--- a/packages/build-scripts-config/src/config/webpack/postcss.config.js
+++ b/packages/build-scripts-config/src/config/webpack/postcss.config.js
@@ -1,14 +1,10 @@
+const plugins = require('./defaultPostcssPlugins');
+
 module.exports = () => ({
-  plugins: [
-    ['postcss-preset-env', {
-      browsers: [
-        'last 2 versions',
-        'Firefox ESR',
-        '> 1%',
-        'ie >= 9',
-        'iOS >= 8',
-        'Android >= 4',
-      ],
-    }],
-  ],
+  plugins: plugins.map(([pluginName, pluginOptions]) => {
+    // eslint-disable-next-line
+    return require(pluginName)(pluginOptions);
+  }),
 });
+
+exports.pluginsConfig = plugins;

--- a/packages/build-user-config/src/userConfig/postcssOptions.js
+++ b/packages/build-user-config/src/userConfig/postcssOptions.js
@@ -17,7 +17,7 @@ module.exports = (config, postcssOptions) => {
             const postcssFile = `${optionConfig.path}/defaultPostcssPlugins`;
             finalPostcssOptions = {
               // eslint-disable-next-line
-              plugins: require(postcssFile) || [],
+              plugins: (optionConfig.ctx ? require(postcssFile)(optionConfig.ctx) : require(postcssFile)) || [],
             };
           } catch(err) {
             console.log('[Error] fail to load default postcss config');

--- a/packages/build-user-config/src/userConfig/postcssOptions.js
+++ b/packages/build-user-config/src/userConfig/postcssOptions.js
@@ -3,21 +3,38 @@ module.exports = (config, postcssOptions) => {
   if (postcssOptions) {
     const styleRules = ['css', 'css-module', 'scss', 'scss-module', 'less', 'less-module'];
     let finalPostcssOptions = {};
+    let restLoaderOptions = {};
     // get default post css config
     if (checkPostcssLoader(config, 'css')) {
       const builtInOptions = config.module.rule('css').use('postcss-loader').get('options');
-      if (builtInOptions && builtInOptions.config && builtInOptions.config.path) {
-        try {
-          const postcssFile = `${builtInOptions.config.path}/postcss.config`;
-          // eslint-disable-next-line
-          finalPostcssOptions = require(postcssFile)();
-        } catch(err) {
-          console.log('[Error] fail to load default postcss config');
+      if (builtInOptions) {
+        const { config: optionConfig, ...restOptions } = builtInOptions;
+        if (restOptions) {
+          restLoaderOptions = restOptions;
         }
+        if (builtInOptions.config && builtInOptions.config.path) {
+          try {
+            const postcssFile = `${optionConfig.path}/defaultPostcssPlugins`;
+            finalPostcssOptions = {
+              // eslint-disable-next-line
+              plugins: require(postcssFile) || [],
+            };
+          } catch(err) {
+            console.log('[Error] fail to load default postcss config');
+          }
+        } else {
+          // compatible with rax config
+          finalPostcssOptions = builtInOptions || { plugins: []};
+        } 
       }
     }
+    if (!finalPostcssOptions.plugins) {
+      // set default plugin value
+      finalPostcssOptions.plugins = [];
+    }
+
     // merge plugins
-    const { plugins = [] } = finalPostcssOptions;
+    const { plugins } = finalPostcssOptions;
     Object.keys(postcssOptions.plugins || {}).forEach((pluginName) => {
       let pluginOptions = {};
       const targetIndex = plugins.findIndex((pluginConfig) => {
@@ -25,7 +42,7 @@ module.exports = (config, postcssOptions) => {
         if (options) {
           pluginOptions = options;
         }
-        return name === pluginName;
+        return typeof name === 'string' && name === pluginName;
       });
       const options = postcssOptions.plugins[pluginName];
       if (targetIndex > -1) {
@@ -35,17 +52,27 @@ module.exports = (config, postcssOptions) => {
         } else {
           // shallow merge for options
           const mergedOptions = {...pluginOptions, ...options};
-          finalPostcssOptions.plugins.splice(targetIndex, 0, [pluginName, mergedOptions]);
+          finalPostcssOptions.plugins.splice(targetIndex, 1, [pluginName, mergedOptions]);
         }
       } else {
         finalPostcssOptions.plugins.push([pluginName, options]);
       }
     });
-
+    const postcssPlugins = finalPostcssOptions.plugins.map((pluginInfo) => {
+      const [name, options] = Array.isArray(pluginInfo) ? pluginInfo : [pluginInfo];
+      if (typeof name === 'string') {
+        // eslint-disable-next-line
+        return require(name)(options);
+      } else {
+        return pluginInfo;
+      }
+    });
     // modify css rules
     styleRules.forEach((ruleName) => {
       if (checkPostcssLoader(config, ruleName)) {
-        config.module.rule(ruleName).use('postcss-loader').tap(() => finalPostcssOptions);
+        config.module.rule(ruleName).use('postcss-loader').tap(() => {
+          return {...restLoaderOptions, ...finalPostcssOptions, plugins: postcssPlugins };
+        });
       }
     });
   }


### PR DESCRIPTION
postcss-loader 为 3.x 版本，目前 rax 和 react 基础配置中均以 require 形式进行使用