### PR TITLE
Fix/setting store true in build.json is invalid

### DIFF
--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -15,7 +15,7 @@ export default async (api) => {
   const isRax = framework === 'rax';
 
   // get mpa entries in src/pages
-  const { mpa: isMpa, entry, store: userConfigStore } = userConfig;
+  const { mpa: isMpa, entry, store: storeConfig } = userConfig;
   let srcDir;
   if (isRax) {
     srcDir = 'src';
@@ -33,7 +33,7 @@ export default async (api) => {
   const projectType = getValue('PROJECT_TYPE');
 
   const storeAndModelExists = checkStoreAndModelExists({ rootDir, srcDir, projectType, isRax, applyMethod });
-  if (!userConfigStore && !storeAndModelExists) {
+  if (!storeConfig && !storeAndModelExists) {
     applyMethod('addDisableRuntimePlugin', pluginName);
     return;
   }

--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -15,7 +15,7 @@ export default async (api) => {
   const isRax = framework === 'rax';
 
   // get mpa entries in src/pages
-  const { mpa: isMpa, entry } = userConfig;
+  const { mpa: isMpa, entry, store: userConfigStore } = userConfig;
   let srcDir;
   if (isRax) {
     srcDir = 'src';
@@ -33,7 +33,7 @@ export default async (api) => {
   const projectType = getValue('PROJECT_TYPE');
 
   const storeAndModelExists = checkStoreAndModelExists({ rootDir, srcDir, projectType, isRax, applyMethod });
-  if (!storeAndModelExists) {
+  if (!userConfigStore && !storeAndModelExists) {
     applyMethod('addDisableRuntimePlugin', pluginName);
     return;
   }


### PR DESCRIPTION
Fix: 用户在 `build.json` 中开启了 `store: true` 后，`plugin-store` 没有引入

期待：在 `build.json` 中开启 `store: true` 的优先级是最高的，即使用户没有 `src/store.ts` / `src/models/*` / `src/pages/Home/store.ts` / `src/pages/Home/models/*` (Ref: https://github.com/alibaba/ice/pull/3932)