### PR TITLE
fix: runApp params type

### DIFF
--- a/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
@@ -48,7 +48,7 @@ const {
   withRouter: defaultWithRouter
 }, loadRuntimeModules);
 
-export function runApp(appConfig, staticConfig?: any) {
+export function runApp(appConfig?, staticConfig?: any) {
   let renderer;
   <% if(isRax){ %>
     renderer = raxAppRenderer;

--- a/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/runApp.ts.ejs
@@ -2,6 +2,7 @@ import { createElement, useEffect, Component } from '<%- framework %>';
 import { isMiniApp, isWeChatMiniProgram, isByteDanceMicroApp, isWeb } from 'universal-env';
 import miniappRenderer from 'miniapp-renderer';
 import createShareAPI, { history } from 'create-app-shared';
+import { IAppConfig } from './types';
 
 <% if (isReact) {%>
   import reactAppRenderer, { getInitialData } from 'react-app-renderer';
@@ -48,7 +49,7 @@ const {
   withRouter: defaultWithRouter
 }, loadRuntimeModules);
 
-export function runApp(appConfig?, staticConfig?: any) {
+export function runApp(appConfig?: IAppConfig, staticConfig?: any) {
   let renderer;
   <% if(isRax){ %>
     renderer = raxAppRenderer;

--- a/packages/plugin-app-core/src/generator/templates/common/types.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/types.ts.ejs
@@ -4,6 +4,7 @@
 
 <% if (isRax) {%>
   import { RaxElement as FrameworkElement, ComponentType as FrameworkComponentType, RaxNode as FrameworkNode } from 'rax';
+  import { History } from 'history';
 <% } %>
 
 <%- appConfigTypesImports %>
@@ -35,12 +36,31 @@ export interface IApp {
   [key: string]: any;
 }
 
+<% if (isRax) {%>
+export interface IRouter {
+  type?: 'hash' | 'browser' | 'memory' | 'static';
+  // common props for BrowserRouter & HashRouter & MemoryRouter
+  basename?: string;
+  fallback?: FrameworkNode;
+  history?: History;
+}
+<% } %>
+
 <% if (appConfigTypesImports) { %>
   export interface IAppConfig {
     app?: IApp
     <%- appConfigTypesExports %>
   }
 <% } %>
+export interface IAppConfig {
+  app?: IApp,
+  <% if (isRax) {%>
+  router?: IRouter
+  <% } %>
+  <% if (appConfigTypesImports) { %>
+    <%- appConfigTypesExports %>
+  <% } %>
+}
 
 declare global {
   interface Window {

--- a/packages/plugin-app-core/src/generator/templates/common/types.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/types.ts.ejs
@@ -46,12 +46,6 @@ export interface IRouter {
 }
 <% } %>
 
-<% if (appConfigTypesImports) { %>
-  export interface IAppConfig {
-    app?: IApp
-    <%- appConfigTypesExports %>
-  }
-<% } %>
 export interface IAppConfig {
   app?: IApp,
   <% if (isRax) {%>


### PR DESCRIPTION
去掉 `runApp` 参数为空时，ts 的提示报错