### PR TITLE
Fix: router types not export when router is false

### DIFF
--- a/packages/plugin-router/src/index.ts
+++ b/packages/plugin-router/src/index.ts
@@ -63,6 +63,19 @@ const plugin = ({ context, onGetWebpackConfig, modifyUserConfig, getValue, apply
     config.devServer.set('historyApiFallback', true);
   });
 
+  // copy types
+  fse.copySync(path.join(__dirname, '../src/types/index.ts'), path.join(iceTempPath, 'router/types/index.ts'));
+  fse.copySync(path.join(__dirname, '../src/types/base.ts'), path.join(iceTempPath, 'router/types/base.ts'));
+  // set IAppRouterProps to IAppConfig
+  applyMethod('addAppConfigTypes', { source: './router/types', specifier: '{ IAppRouterProps }', exportName: 'router?: IAppRouterProps' });
+  // export IRouterConfig to the public
+  applyMethod('addTypesExport', { source: './router/types' });
+  // add import declarations
+  applyMethod('addImportDeclarations', {
+    importSource: '$$ice/router/types',
+    exportMembers: ['IAppRouterProps', 'IRouterConfig'],
+  });
+
   if (!disableRouter) {
     // add babel plugins for ice lazy
     modifyUserConfig('babelPlugins',
@@ -101,19 +114,6 @@ const plugin = ({ context, onGetWebpackConfig, modifyUserConfig, getValue, apply
         'useParams',
         'useRouteMatch'
       ]
-    });
-
-    // copy types
-    fse.copySync(path.join(__dirname, '../src/types/index.ts'), path.join(iceTempPath, 'router/types/index.ts'));
-    fse.copySync(path.join(__dirname, '../src/types/base.ts'), path.join(iceTempPath, 'router/types/base.ts'));
-    // set IAppRouterProps to IAppConfig
-    applyMethod('addAppConfigTypes', { source: './router/types', specifier: '{ IAppRouterProps }', exportName: 'router?: IAppRouterProps' });
-    // export IRouterConfig to the public
-    applyMethod('addTypesExport', { source: './router/types' });
-    // add import declarations
-    applyMethod('addImportDeclarations', {
-      importSource: '$$ice/router/types',
-      exportMembers: ['IAppRouterProps', 'IRouterConfig'],
     });
 
     // do not watch folder pages when route config is exsits


### PR DESCRIPTION
Fix: mpa 应用下的 spa，导入 routes 后 ts 类型错误，详细见下图：

![image](https://user-images.githubusercontent.com/44047106/104871450-01770880-5986-11eb-872b-d9cf0d7b49fa.png)

原因：在 build.json 中配置了 `routes: false` 后，不会生成类型文件

