### PR TITLE
fix: error message of friendly-errors-webpack-plugin

### DIFF
--- a/packages/build-user-config/package.json
+++ b/packages/build-user-config/package.json
@@ -15,7 +15,7 @@
     "eslint-loader": "^4.0.0",
     "eslint-reporting-webpack-plugin": "^0.1.0",
     "fork-ts-checker-webpack-plugin": "^5.0.5",
-    "friendly-errors-webpack-plugin": "^1.7.0",
+    "@nuxtjs/friendly-errors-webpack-plugin": "^2.1.0",
     "fs-extra": "^8.1.0",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.15",

--- a/packages/build-user-config/src/getEnhancedWebpackConfig.js
+++ b/packages/build-user-config/src/getEnhancedWebpackConfig.js
@@ -54,12 +54,11 @@ module.exports = (api, { target, webpackConfig, babelConfig, libName = 'rax' }) 
 
     webpackConfig
       .plugin('friendly-error')
-      .use(require.resolve('friendly-errors-webpack-plugin'), [
+      .use(require.resolve('@nuxtjs/friendly-errors-webpack-plugin'), [
         {
           clearConsole: false,
         },
-      ])
-      .end();
+      ]);
   } else {
     webpackConfig.optimization.minimize(true);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,6 +2786,16 @@
     mkdirp "^1.0.4"
     rimraf "^2.7.1"
 
+"@nuxtjs/friendly-errors-webpack-plugin@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npm.taobao.org/@nuxtjs/friendly-errors-webpack-plugin/download/@nuxtjs/friendly-errors-webpack-plugin-2.1.0.tgz#90d0b587b2f118f7f54e3da3d79329ffc72a8578"
+  integrity sha1-kNC1h7LxGPf1Tj2j15Mp/8cqhXg=
+  dependencies:
+    chalk "^2.3.2"
+    error-stack-parser "^2.0.0"
+    string-width "^2.0.0"
+    strip-ansi "^4.0.0"
+
 "@octokit/auth-token@^2.4.0":
   version "2.4.5"
   resolved "https://registry.npm.taobao.org/@octokit/auth-token/download/@octokit/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
@@ -5187,7 +5197,7 @@ ccount@^1.0.0:
   resolved "https://registry.npm.taobao.org/ccount/download/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha1-JGaH3rtgFHNRMb6KurLZOJj40EM=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz?cache=0&sync_timestamp=1591687076871&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
@@ -8122,15 +8132,6 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
-
-friendly-errors-webpack-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.npm.taobao.org/friendly-errors-webpack-plugin/download/friendly-errors-webpack-plugin-1.7.0.tgz#efc86cbb816224565861a1be7a9d84d0aafea136"
-  integrity sha1-78hsu4FiJFZYYaG+ep2E0Kr+oTY=
-  dependencies:
-    chalk "^1.1.3"
-    error-stack-parser "^2.0.0"
-    string-width "^2.0.0"
 
 from2@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
use @nuxtjs/friendly-errors-webpack-plugin instead while friendly-errors-webpack-plugin is not longer ship new versions