### PR TITLE
feat: add plugin-dev-inspector

### DIFF
--- a/packages/plugin-dev-inspector/README.md
+++ b/packages/plugin-dev-inspector/README.md
@@ -1,0 +1,27 @@
+## build-plugin-dev-inspector
+
+用于在本地调试时，快速定位页面上的组件所在的源码的位置。
+
+Install:
+
+```bash
+$ npm i --save-dev build-plugin-dev-inspector
+```
+
+### 基础用法
+
+在 `build.json` 中引入插件：
+
+```json
+{
+  "plugins": [
+    "build-plugin-dev-inspector"
+  ]
+}
+```
+
+完成上述配置后，则在本地调试的环境下，把鼠标 hover 到想要调试的元素，就会显示出遮罩框；再点击一下，会自动在编辑器中跳转到对应的文件中，并且跳转到对应的行和列。
+
+示例：
+
+![img](https://img.alicdn.com/imgextra/i4/O1CN01xDJWsb1fJAz3VPeGE_!!6000000003985-1-tps-1080-588.gif)

--- a/packages/plugin-dev-inspector/package.json
+++ b/packages/plugin-dev-inspector/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "build-plugin-dev-inspector",
+  "version": "0.1.0",
+  "description": "devtool for inspecting react components and jump to local IDE for ice.js and rax-app",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:raxjs/rax-app.git"
+  },
+  "dependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/generator": "^7.11.6",
+    "@babel/parser": "^7.11.5",
+    "@babel/traverse": "^7.11.5",
+    "inspector-dom": "^0.1.1",
+    "loader-utils": "^2.0.0"
+  }
+}

--- a/packages/plugin-dev-inspector/package.json
+++ b/packages/plugin-dev-inspector/package.json
@@ -16,6 +16,7 @@
     "url": "git@github.com:raxjs/rax-app.git"
   },
   "dependencies": {
+    "@alib/build-scripts": "^0.1.31",
     "@babel/core": "^7.11.6",
     "@babel/generator": "^7.11.6",
     "@babel/parser": "^7.11.5",

--- a/packages/plugin-dev-inspector/package.json
+++ b/packages/plugin-dev-inspector/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:raxjs/rax-app.git"
+    "url": "git@github.com:alibaba/ice.git"
   },
   "dependencies": {
     "@alib/build-scripts": "^0.1.31",

--- a/packages/plugin-dev-inspector/src/index.ts
+++ b/packages/plugin-dev-inspector/src/index.ts
@@ -2,12 +2,12 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { IPlugin } from '@alib/build-scripts';
 
-const plugin: IPlugin = ({ onGetWebpackConfig }: any) => {
+const plugin: IPlugin = ({ onGetWebpackConfig }) => {
   if (process.env.NODE_ENV === 'production') {
     return;
   }
 
-  onGetWebpackConfig((config: any) => {
+  onGetWebpackConfig((config) => {
     // inject source file path/line/column to JSX data attributes props
     config.module
       .rule('inspector')
@@ -24,9 +24,10 @@ const plugin: IPlugin = ({ onGetWebpackConfig }: any) => {
 
     // add webpack dev server middleware for launch IDE app with api request
     const root = process.env.PWD;
+    const originalDevServeBefore = config.devServer.get('before');
     config.merge({
       devServer: {
-        before(app) {
+        before(app, server) {
           app.get('/vscode/goto', (req, res) => {
             try {
               const { query } = req;
@@ -39,6 +40,9 @@ const plugin: IPlugin = ({ onGetWebpackConfig }: any) => {
               res.json({ success: false, message });
             }
           });
+          if (typeof originalDevServeBefore === 'function') {
+            originalDevServeBefore(app, server);
+          }
         },
       }
     });

--- a/packages/plugin-dev-inspector/src/index.ts
+++ b/packages/plugin-dev-inspector/src/index.ts
@@ -29,10 +29,12 @@ const plugins = ({ onGetWebpackConfig }: any) => {
           const { query } = req;
           const { file, line, column } = query;
           spawn('code', ['--goto', `${root}/${file}:${line}:${column}`], { stdio: 'inherit' });
+          res.json({ success: true });
         } catch (e) {
-          // ignore
+          const message = `build-plugin-dev-inspector call VS Code failed: ${e}`;
+          console.log(message);
+          res.json({ success: false, message });
         }
-        res.json({ success: true });
       });
     });
   });

--- a/packages/plugin-dev-inspector/src/index.ts
+++ b/packages/plugin-dev-inspector/src/index.ts
@@ -1,0 +1,41 @@
+import * as path from 'path';
+import { spawn } from 'child_process';
+
+const plugins = ({ onGetWebpackConfig }: any) => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  onGetWebpackConfig((config: any) => {
+    // inject source file path/line/column to JSX data attributes props
+    config.module
+      .rule('inspector')
+      .test(/\.(jsx?|tsx)$/)
+      .exclude
+      .add(/node_modules/)
+      .add(/\.ice\//)
+      .add(/\.rax\//)
+      .end()
+      .use('inspector')
+      .loader(path.join(__dirname, './loader'))
+      .options({})
+      .end();
+
+    // add webpack dev server middleware for launch IDE app with api request
+    const root = process.env.PWD;
+    config.devServer.set('before', (app: any) => {
+      app.get('/vscode/goto', (req, res) => {
+        try {
+          const { query } = req;
+          const { file, line, column } = query;
+          spawn('code', ['--goto', `${root}/${file}:${line}:${column}`], { stdio: 'inherit' });
+        } catch (e) {
+          // ignore
+        }
+        res.json({ success: true });
+      });
+    });
+  });
+};
+
+export default plugins;

--- a/packages/plugin-dev-inspector/src/loader.ts
+++ b/packages/plugin-dev-inspector/src/loader.ts
@@ -1,0 +1,189 @@
+// fork form https://github.com/zthxxx/react-dev-inspector/blob/master/src/plugins/webpack/inspector-loader.ts
+import * as path from 'path';
+import { getOptions } from 'loader-utils';
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
+import traverse, { NodePath } from '@babel/traverse';
+import {
+  jsxAttribute,
+  jsxIdentifier,
+  stringLiteral,
+  Node,
+  JSXOpeningElement,
+  JSXIdentifier,
+  JSXMemberExpression,
+  JSXNamespacedName,
+  JSXAttribute,
+} from '@babel/types';
+
+const isNil = (value: any): value is null | undefined => value === null || value === undefined;
+
+type NodeHandler<T = Node, O = void> = (node: T, option: O) => {
+  /**
+   * stop processing flag
+   */
+  stop?: boolean;
+
+  /**
+   * throw error
+   */
+  error?: any;
+
+  /**
+   * node after processing
+   */
+  result?: Node;
+};
+
+const doJSXIdentifierName: NodeHandler<JSXIdentifier> = (name) => {
+  if (name.name.endsWith('Fragment')) {
+    return { stop: true };
+  }
+  return { stop: false };
+};
+
+const doJSXMemberExpressionName: NodeHandler<JSXMemberExpression> = (name) => {
+  return doJSXIdentifierName(name.property);
+};
+
+const doJSXNamespacedNameName: NodeHandler<JSXNamespacedName> = (name) => {
+  return doJSXIdentifierName(name.name);
+};
+
+type ElementTypes = JSXOpeningElement['name']['type'];
+
+const doJSXPathName: NodeHandler<JSXOpeningElement['name']> = (name) => {
+  const dealMap: { [key in ElementTypes]: NodeHandler } = {
+    JSXIdentifier: doJSXIdentifierName,
+    JSXMemberExpression: doJSXMemberExpressionName,
+    JSXNamespacedName: doJSXNamespacedNameName,
+  };
+
+  return dealMap[name.type](name);
+};
+
+
+const doJSXOpeningElement: NodeHandler<
+JSXOpeningElement,
+{ relativePath: string }
+> = (node, option) => {
+  const { stop } = doJSXPathName(node.name);
+  if (stop) return { stop };
+
+  const { relativePath } = option;
+  const line = node.loc?.start.line;
+  const column = node.loc?.start.column;
+
+  const lineAttr: JSXAttribute | null = isNil(line)
+    ? null
+    : jsxAttribute(
+      jsxIdentifier('data-inspector-line'),
+      stringLiteral(line.toString()),
+    );
+
+  const columnAttr: JSXAttribute | null = isNil(column)
+    ? null
+    : jsxAttribute(
+      jsxIdentifier('data-inspector-column'),
+      stringLiteral(column.toString()),
+    );
+
+  const relativePathAttr: JSXAttribute = jsxAttribute(
+    jsxIdentifier('data-inspector-relative-path'),
+    stringLiteral(relativePath),
+  );
+
+  const attributes = [lineAttr, columnAttr, relativePathAttr] as JSXAttribute[];
+
+  // Make sure that there are exist together
+  if (attributes.every(Boolean)) {
+    node.attributes.push(...attributes);
+  }
+
+  return { result: node };
+};
+
+/**
+ * simple path match method, only use string and regex
+ */
+export const pathMatch = (filePath: string, matches?: Array<string | RegExp>): boolean => {
+  if (!matches?.length) return false;
+
+  return matches.some((match) => {
+    if (typeof match === 'string') {
+      return filePath.includes(match);
+    } else if (match instanceof RegExp) {
+      return match.test(filePath);
+    }
+    // default is do not filter when match is illegal, so return true
+    return true;
+  });
+};
+
+/**
+ * [webpack compile time]
+ *
+ * inject line, column, relative-path to JSX html data attribute in source code
+ *
+ * @type webpack.loader.Loader
+ * ref: https://astexplorer.net  +  @babel/parser
+ */
+export default function inspectorLoader(this: any, source: string) {
+  const {
+    rootContext: rootPath,
+    resourcePath: filePath,
+  } = this;
+
+  /**
+   * example:
+   * rootPath: /home/xxx/project
+   * filePath: /home/xxx/project/src/ooo/xxx.js
+   * relativePath: src/ooo/xxx.js
+   */
+  const relativePath = path.relative(rootPath, filePath);
+
+  const options: any = getOptions(this);
+
+  const isSkip = pathMatch(filePath, options.exclude);
+  if (isSkip) {
+    return source;
+  }
+
+  const ast: Node = parse(source, {
+    sourceType: 'module',
+    allowUndeclaredExports: true,
+    allowImportExportEverywhere: true,
+    plugins: [
+      'typescript',
+      'jsx',
+      'decorators-legacy',
+      'classProperties',
+      ...options?.babelPlugins ?? [],
+    ],
+    ...options?.babelOptions,
+  });
+
+
+  /**
+   * astexplorer + @babel/parser
+   * https://astexplorer.net
+   */
+  traverse(ast, {
+    enter(nodePath: NodePath<Node>) {
+      if (nodePath.type === 'JSXOpeningElement') {
+        doJSXOpeningElement(
+          nodePath.node as JSXOpeningElement,
+          { relativePath },
+        );
+      }
+    },
+  });
+
+  const {
+    code,
+  } = generate(ast, {
+    decoratorsBeforeExport: true,
+  });
+
+  return code;
+}

--- a/packages/plugin-dev-inspector/src/loader.ts
+++ b/packages/plugin-dev-inspector/src/loader.ts
@@ -1,4 +1,6 @@
-// fork form https://github.com/zthxxx/react-dev-inspector/blob/master/src/plugins/webpack/inspector-loader.ts
+// Credit: react-dev-inspector 1.1.4 (c) https://github.com/zthxxx
+// <https://github.com/zthxxx/react-dev-inspector/blob/master/src/plugins/webpack/inspector-loader.ts>
+
 import * as path from 'path';
 import { getOptions } from 'loader-utils';
 import { parse } from '@babel/parser';
@@ -62,7 +64,6 @@ const doJSXPathName: NodeHandler<JSXOpeningElement['name']> = (name) => {
   return dealMap[name.type](name);
 };
 
-
 const doJSXOpeningElement: NodeHandler<
 JSXOpeningElement,
 { relativePath: string }
@@ -106,7 +107,7 @@ JSXOpeningElement,
 /**
  * simple path match method, only use string and regex
  */
-export const pathMatch = (filePath: string, matches?: Array<string | RegExp>): boolean => {
+export const pathMatch = (filePath: string, matches?: (string | RegExp)[]): boolean => {
   if (!matches?.length) return false;
 
   return matches.some((match) => {
@@ -162,7 +163,6 @@ export default function inspectorLoader(this: any, source: string) {
     ],
     ...options?.babelOptions,
   });
-
 
   /**
    * astexplorer + @babel/parser

--- a/packages/plugin-dev-inspector/src/runtime.tsx
+++ b/packages/plugin-dev-inspector/src/runtime.tsx
@@ -1,0 +1,24 @@
+import * as Inspector from 'inspector-dom';
+
+export default ({ addProvider, context: { createElement } }) => {
+  const Provider = ({ children }) => {
+    return createElement('div', null, children);
+  };
+
+  const inspector = Inspector({
+    root: 'body', // root element
+    excluded: [], // excluded children, string or node Element
+    outlineStyles: '2px solid orange', // styles
+    onClick: (el) => {
+      console.log('Element was clicked:', el);
+      try {
+        fetch(`/vscode/goto?file=${el.getAttribute('data-inspector-relative-path')}&line=${el.getAttribute('data-inspector-line')}&column=${el.getAttribute('data-inspector-column')}`);
+      } catch (e) {
+        // ignore
+      }
+    },
+  });
+
+  inspector.enable();
+  addProvider(Provider);
+};

--- a/packages/plugin-dev-inspector/src/runtime.tsx
+++ b/packages/plugin-dev-inspector/src/runtime.tsx
@@ -1,9 +1,6 @@
 import * as Inspector from 'inspector-dom';
 
-export default ({ addProvider, context: { createElement } }) => {
-  const Provider = ({ children }) => {
-    return createElement('div', null, children);
-  };
+export default () => {
 
   const inspector = Inspector({
     root: 'body', // root element
@@ -20,5 +17,4 @@ export default ({ addProvider, context: { createElement } }) => {
   });
 
   inspector.enable();
-  addProvider(Provider);
 };

--- a/packages/plugin-dev-inspector/src/runtime.tsx
+++ b/packages/plugin-dev-inspector/src/runtime.tsx
@@ -14,7 +14,7 @@ export default ({ addProvider, context: { createElement } }) => {
       try {
         fetch(`/vscode/goto?file=${el.getAttribute('data-inspector-relative-path')}&line=${el.getAttribute('data-inspector-line')}&column=${el.getAttribute('data-inspector-column')}`);
       } catch (e) {
-        // ignore
+        console.log('build-plugin-dev-inspector fetch error: ', e);
       }
     },
   });

--- a/packages/plugin-dev-inspector/tsconfig.json
+++ b/packages/plugin-dev-inspector/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,6 @@
     { "path": "packages/plugin-webpack5" },
     { "path": "packages/webpack-dev-mock" },
     { "path": "packages/plugin-keep-alive" },
+    { "path": "packages/plugin-dev-inspector" },
   ]
 }


### PR DESCRIPTION
增加插件 build-plugin-dev-inspector

同时支持 rax 及 ice.

在本地调试的环境下，把鼠标 hover 到想要调试的元素，就会显示出遮罩框；再点击一下，会自动在编辑器中跳转到对应的文件中，并且跳转到对应的行和列。

实现原理：使用 inspector-dom 选择节点，使用 loader 将组件信息放入节点中，最后开启 devserver 通过 vs code goto 命令唤醒对应文件

效果：

![img](https://img.alicdn.com/imgextra/i4/O1CN01xDJWsb1fJAz3VPeGE_!!6000000003985-1-tps-1080-588.gif)