### PR TITLE
fix: revert ice-skin-loader

### DIFF
--- a/packages/webpack-loader-skin/CHANGELOG.md
+++ b/packages/webpack-loader-skin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ice-skin-loader Changelog
 
+## 0.3.2
+
+- [fix] nextPrefix 仅用于 0.x & 1.x 混用样式处理
+
 ## 0.3.1
 
 - [fix] 修复 nextPrefix 在业务代码中不生效问题

--- a/packages/webpack-loader-skin/package.json
+++ b/packages/webpack-loader-skin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-skin-loader",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ice skin loader",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/webpack-loader-skin/src/index.js
+++ b/packages/webpack-loader-skin/src/index.js
@@ -35,8 +35,8 @@ module.exports = function (source) {
   }
 
   let prefixVars = '';
-  if (useNext && themeConfig.nextPrefix) {
-    // 修改 next-prefix
+  if (themeConfig.nextPrefix && /@alifd[\\/]next[\\/](lib|es)[\\/](.+).scss$/.test(modulePath)) {
+    // 将 next 1.x 的 prefix 从 next- 改为自定义前缀，解决 0.x&1.x 混用的问题
     prefixVars = `$css-prefix: "${themeConfig.nextPrefix}";`;
   }
 


### PR DESCRIPTION
 nextPrefix 仅用于 0.x 1.x next 组件混用问题：https://github.com/ice-lab/ice-scripts/pull/100
目前 npm 版本锁定在 0.3.0 批量发布时，一致发布 beta 版本