### PR TITLE
fix: load runtime modules

### DIFF
--- a/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
@@ -1,8 +1,4 @@
-interface IRuntime<T> {
-  loadModule: (module: { default: T } | T) => void;
-}
-
-function loadRuntimeModules(runtime: IRuntime) {
+function loadRuntimeModules(runtime) {
   <% if (runtimeModules.length) {%>
     <% runtimeModules.forEach((runtimeModule) => { %>
       <% if(!runtimeModule.staticModule){ %>

--- a/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
@@ -1,18 +1,10 @@
-<% const moduleNames = []; %>
-<% if (runtimeModules.length) {%>
-  <% runtimeModules.filter((moduleInfo) => !moduleInfo.staticModule).forEach((runtimeModule, index) => { %>
-    <% moduleNames.push('module' + index) %>import module<%= index %> from '<%= runtimeModule.path %>';<% }) %>
-<% } %>
-
-interface IRuntime<T> {
-  loadModule: (module: { default: T } | T) => void;
-}
-
-function loadRuntimeModules(runtime: IRuntime<Function>) {
-  <% if (moduleNames.length) {%>
-    [<% moduleNames.forEach((name, index) => { %>
-      <%= name %><% if (moduleNames.length > index + 1) {%>,<% }%>
-    <% }) %>].forEach((runtimeMoudle) => runtime.loadModule(runtimeMoudle));
+function loadRuntimeModules(runtime) {
+  <% if (runtimeModules.length) {%>
+    <% runtimeModules.forEach((runtimeModule) => { %>
+      <% if(!runtimeModule.staticModule){ %>
+        runtime.loadModule(require('<%= runtimeModule.path %>'));
+      <% } %>
+    <% }) %>
   <% } %>
 }
 

--- a/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
@@ -1,4 +1,8 @@
-function loadRuntimeModules(runtime) {
+interface IRuntime<T> {
+  loadModule: (module: { default: T } | T) => void;
+}
+
+function loadRuntimeModules(runtime: IRuntime) {
   <% if (runtimeModules.length) {%>
     <% runtimeModules.forEach((runtimeModule) => { %>
       <% if(!runtimeModule.staticModule){ %>

--- a/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadRuntimeModules.ts.ejs
@@ -1,4 +1,8 @@
-function loadRuntimeModules(runtime) {
+interface IRuntime<T> {
+  loadModule: (module: { default: T } | T) => void;
+}
+
+function loadRuntimeModules(runtime: IRuntime<Function>) {
   <% if (runtimeModules.length) {%>
     <% runtimeModules.forEach((runtimeModule) => { %>
       <% if(!runtimeModule.staticModule){ %>

--- a/packages/plugin-app-core/src/generator/templates/common/loadStaticModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadStaticModules.ts.ejs
@@ -1,12 +1,10 @@
-<% const moduleNames = []; %>
-<% if (runtimeModules.length) {%>
-  <% runtimeModules.filter((moduleInfo) => moduleInfo.staticModule).forEach((runtimeModule, index) => { %>
-    <% moduleNames.push('module' + index) %>import module<%= index %> from '<%= runtimeModule.path %>';<% }) %>
-<% } %>import { IAppConfig } from './types';
-
-function loadStaticModules(appConfig: IAppConfig) {
-  <% if (moduleNames.length) {%>
-    <% moduleNames.forEach((name) => { %><%= name%>({appConfig});<% }) %>
+function loadStaticModules(appConfig) {
+  <% if (runtimeModules.length) {%>
+    <% runtimeModules.forEach((runtimeModule) => { %>
+      <% if(runtimeModule.staticModule){ %>
+        require('<%= runtimeModule.path %>').default({appConfig});
+      <% } %>
+    <% }) %>
   <% } %>
 }
 

--- a/packages/plugin-app-core/src/generator/templates/common/loadStaticModules.ts.ejs
+++ b/packages/plugin-app-core/src/generator/templates/common/loadStaticModules.ts.ejs
@@ -1,4 +1,6 @@
-function loadStaticModules(appConfig) {
+import { IAppConfig } from './types';
+
+function loadStaticModules(appConfig: IAppConfig) {
   <% if (runtimeModules.length) {%>
     <% runtimeModules.forEach((runtimeModule) => { %>
       <% if(runtimeModule.staticModule){ %>


### PR DESCRIPTION
采用 import 方式加载 runtime，会因 import 顺序问题，让 runtime 中引入的源码无法从 ice 中导入部的 API

比如 plugin-router 的 runtime 中依赖了 src/routes.ts，routes 文件中依赖的所有组件将无法使用从 ice 中导入的 withRouter 等 API（在 runApp 中导出）