### PR TITLE
fix: join route path

### DIFF
--- a/packages/plugin-router/src/runtime/formatRoutes.tsx
+++ b/packages/plugin-router/src/runtime/formatRoutes.tsx
@@ -13,11 +13,9 @@ export default function formatRoutes(routes: IRouterConfig[], parentPath: string
     }
     if (item.children) {
       item.children = formatRoutes(item.children, item.path);
-    } else if (item.path) {
+    } else if (item.component) {
       const itemComponent = item.component as any;
-      if (itemComponent) {
-        itemComponent.pageConfig = Object.assign({}, itemComponent.pageConfig, { componentName: itemComponent.name });
-      }
+      itemComponent.pageConfig = Object.assign({}, itemComponent.pageConfig, { componentName: itemComponent.name });
     }
     return item;
   });

--- a/packages/plugin-router/src/runtime/formatRoutes.tsx
+++ b/packages/plugin-router/src/runtime/formatRoutes.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import * as path from 'path';
 import * as queryString from 'query-string';
+import { IRouterConfig } from '../types';
 
 const { useEffect, useState } = React;
 
-export default function formatRoutes(routes, parentPath) {
+export default function formatRoutes(routes: IRouterConfig[], parentPath: string) {
   return routes.map((item) => {
+    if (item.path) {
+      const joinPath = path.join(parentPath || '', item.path);
+      item.path = joinPath === '/' ? '/' : joinPath.replace(/\/$/, '');
+    }
     if (item.children) {
       item.children = formatRoutes(item.children, item.path);
     } else if (item.path) {
-      const joinPath = path.join(parentPath || '', item.path);
-      // react-router: path=/project/ not match /project
-      item.path = joinPath === '/' ? '/' : joinPath.replace(/\/$/, '');
-      const itemComponent = item.component;
+      const itemComponent = item.component as any;
       if (itemComponent) {
         itemComponent.pageConfig = Object.assign({}, itemComponent.pageConfig, { componentName: itemComponent.name });
       }


### PR DESCRIPTION
多层嵌套路由 path 拼接规则有问题
三层以下正常的原因：默认做了 parent path 为空的兜底逻辑