### PR TITLE
release: plugin icestark 2.0.7

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.0.7
 
 - [chore] publish source code of runtime
+- [feat] turn lifecycle function of icestark into `async`. ([#4190](https://github.com/alibaba/ice/pull/4190))
+- [fix] set IAppRouter alias with AppRouterProps. ([#4192](https://github.com/alibaba/ice/pull/4192))
+- [fix] fix wrong ast parser of `@ice/stark-app` & `react-dom`. ([#4193](https://github.com/alibaba/ice/pull/4193))
 
 ## 2.0.6
 

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-icestark",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/babelPluginMicroapp.ts
+++ b/packages/plugin-icestark/src/babelPluginMicroapp.ts
@@ -4,17 +4,17 @@ const templateIfStatement = 'if (!isInIcestark()) {}';
 
 const templateExportStatement = `
 setLibraryName(LIBRARY);
-export const mount = (props) => {
+export const mount = async (props) => {
   APP_CALLEE(APP_CONFIG);
 };
-export const unmount = ({ container, customProps }) => {
+export const unmount = async ({ container, customProps }) => {
   if (APP_CONFIG?.icestark?.regsiterAppLeave) {
     APP_CONFIG.icestark.regsiterAppLeave(container, customProps);
   } else {
     ReactDOM.unmountComponentAtNode(container);
   }
 };
-export const bootstrap = () => {
+export const bootstrap = async () => {
   console.log('bootstrap');
 };`;
 const templateModeStatement = `

--- a/packages/plugin-icestark/src/babelPluginMicroapp.ts
+++ b/packages/plugin-icestark/src/babelPluginMicroapp.ts
@@ -62,7 +62,7 @@ export default (api, { entryList, libraryName }) => {
                     importSpecifier.push(value.local.name);
                   }
                 });
-              } else if (t.isIdentifier(item.source, { value: '@ice/stark-app'})) {
+              } else if (t.isStringLiteral(item.source, { value: '@ice/stark-app'})) {
                 starkappStatement = true;
                 let importIsInIcestark = false;
                 let importSetLibraryName = false;
@@ -81,7 +81,7 @@ export default (api, { entryList, libraryName }) => {
                   item.specifiers.push(t.importSpecifier(t.identifier('setLibraryName'), t.identifier('setLibraryName')));
                 }
               // check import ReactDOM from 'react-dom';
-              } else if (t.isIdentifier(item.source, { value: 'react-dom'})) {
+              } else if (t.isStringLiteral(item.source, { value: 'react-dom'})) {
                 reactdomStatement = true;
                 let importReactDOM = false;
                 item.specifiers.forEach((value) => {

--- a/packages/plugin-icestark/src/types/base.ts
+++ b/packages/plugin-icestark/src/types/base.ts
@@ -1,15 +1,7 @@
-import * as React from 'react';
 import { CompatibleAppConfig } from '@ice/stark/lib/AppRoute';
+import { AppRouterProps } from '@ice/stark/lib/AppRouter';
 
-export interface IAppRouter {
-  ErrorComponent?: React.ComponentType;
-  LoadingComponent?: React.ComponentType;
-  NotFoundComponent?: React.ComponentType;
-  shouldAssetsRemove?: (
-    assetUrl?: string,
-    element?: HTMLElement | HTMLLinkElement | HTMLStyleElement | HTMLScriptElement,
-  ) => boolean;
-}
+export type IAppRouter = Omit<AppRouterProps, 'onRouteChange' | 'onAppEnter' | 'onAppLeave'>;
 
 export interface IGetApps {
   (): CompatibleAppConfig[] | Promise<CompatibleAppConfig[]>;


### PR DESCRIPTION
- [x] fix wrong ast parser of @ice/stark-app & react-dom, #4191
- [x] turn lifecycles into `async`, #4190
- [x] set IAppRouter alias with AppRouterProps, #4192