### PR TITLE
fix: project type logic

### DIFF
--- a/packages/plugin-app-core/src/config/setProjectType.ts
+++ b/packages/plugin-app-core/src/config/setProjectType.ts
@@ -6,10 +6,10 @@ export default (api) => {
   const { context, setValue } = api;
   const { rootDir, userConfig } = context;
   const srcDir = userConfig.sourceDir || getSourceDir(userConfig.entry);
-  const tsEntryFiles = globby.sync([`${srcDir}/app.@(ts?(x))`, `${srcDir}/pages/*/app.@(ts?(x))`], {
+  const tsFiles = globby.sync(`${srcDir}/**/*.{ts,tsx}`, {
     cwd: rootDir
   });
-  const projectType = tsEntryFiles.length ? 'ts' : 'js';
+  const projectType = tsFiles.length ? 'ts' : 'js';
 
   setValue(PROJECT_TYPE, projectType);
 };


### PR DESCRIPTION
修改判断项目类型的逻辑：

在 MPA 的场景下，可能存在 src/app.ts 和 src/pages/Home/app.ts 都不存在的情况。判断逻辑应改为判断 src 目录下是否有 ts/tsx 文件