### PR TITLE
Fix: fail to check store file in Windows

### DIFF
--- a/packages/plugin-store/CHANGELOG.md
+++ b/packages/plugin-store/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.7
+
+- [fix] can't find an existed store file in windows
+
 ## 1.9.6
 
 - [feat] support reset page store after router switch  

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -212,7 +212,8 @@ export default class Generator {
   private renderPageLayout({ pageName, pageNameDir, pageModelsDir, pageModelFile, pageStoreFile, existedStoreFile }: IRenderPageParams) {
     const pageComponentTemplatePath = path.join(__dirname, './template/pageComponent.tsx.ejs');
     const pageComponentTargetPath = path.join(this.targetPath, 'pages', pageName, 'Layout.tsx');
-    const pageComponentSourcePath = formatPath(`${pageNameDir}/Layout`);
+    const layoutDir = path.join(pageNameDir, 'Layout');
+    const pageComponentSourcePath = formatPath(layoutDir);
 
     if (!fse.pathExistsSync(pageComponentSourcePath)) {
       return;
@@ -236,7 +237,7 @@ export default class Generator {
 
     if (existedStoreFile || fse.pathExistsSync(pageModelsDir) || fse.pathExistsSync(pageModelFile)) {
       pageLayoutRenderData.hasPageStore = true;
-      checkPageIndexFileExists(pageComponentSourcePath, this.projectType);
+      checkPageIndexFileExists(layoutDir, this.projectType);
     }
 
     this.applyMethod('addRenderFile', pageComponentTemplatePath, pageComponentTargetPath, pageLayoutRenderData);

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -203,7 +203,7 @@ export default class Generator {
 
     if (existedStoreFile || fse.pathExistsSync(pageModelsDir) || fse.pathExistsSync(pageModelFile)) {
       pageComponentRenderData.hasPageStore = true;
-      checkPageIndexFileExists(pageNameDir, this.projectType);
+      checkPageIndexFileExists(pageNameDir);
     }
 
     this.applyMethod('addRenderFile', pageComponentTemplatePath, pageComponentTargetPath, pageComponentRenderData);
@@ -212,8 +212,7 @@ export default class Generator {
   private renderPageLayout({ pageName, pageNameDir, pageModelsDir, pageModelFile, pageStoreFile, existedStoreFile }: IRenderPageParams) {
     const pageComponentTemplatePath = path.join(__dirname, './template/pageComponent.tsx.ejs');
     const pageComponentTargetPath = path.join(this.targetPath, 'pages', pageName, 'Layout.tsx');
-    const layoutDir = path.join(pageNameDir, 'Layout');
-    const pageComponentSourcePath = formatPath(layoutDir);
+    const pageComponentSourcePath = formatPath(`${pageNameDir}/Layout`);
 
     if (!fse.pathExistsSync(pageComponentSourcePath)) {
       return;
@@ -237,7 +236,7 @@ export default class Generator {
 
     if (existedStoreFile || fse.pathExistsSync(pageModelsDir) || fse.pathExistsSync(pageModelFile)) {
       pageLayoutRenderData.hasPageStore = true;
-      checkPageIndexFileExists(layoutDir, this.projectType);
+      checkPageIndexFileExists(pageNameDir);
     }
 
     this.applyMethod('addRenderFile', pageComponentTemplatePath, pageComponentTargetPath, pageLayoutRenderData);

--- a/packages/plugin-store/src/generator.ts
+++ b/packages/plugin-store/src/generator.ts
@@ -272,18 +272,18 @@ export default class Generator {
     // generate .ice/store/types.ts
     this.renderAppStoreTypes({ hasAppModels, existsAppStoreFile });
 
-    const pages = this.applyMethod('getPages', this.rootDir, this.srcDir);
-    pages.forEach(pageName => {
+    const pageNames = this.applyMethod('getPages', this.rootDir, this.srcDir);
+    pageNames.forEach(pageName => {
       const { pageModelsDir, pageModelFile, pageNameDir } = getPageModelPath({
         rootDir: this.rootDir,
         srcDir: this.srcDir,
-        pagePath: pageName,
+        pageName,
         projectType: this.projectType,
       });
       const pageStoreFile = formatPath(getPageStorePath({
         rootDir: this.rootDir,
         srcDir: this.srcDir,
-        pagePath: pageName,
+        pageName,
         projectType: this.projectType,
       }));
       const existedStoreFile = fse.pathExistsSync(pageStoreFile);

--- a/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
+++ b/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
@@ -1,5 +1,6 @@
 import * as globby from 'globby';
-import chalk from 'chalk';
+
+const chalk = require('chalk');
 
 /**
  * Check if the src/pages/${pageName}/index.[j|t]s?(x) or src/pages/${pageName}/Layout/index.[j|t]s?(x) exists

--- a/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
+++ b/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
@@ -4,10 +4,11 @@ const chalk = require('chalk');
 
 /**
  * Check if the src/pages/${pageName}/index.[j|t]s?(x) or src/pages/${pageName}/Layout/index.[j|t]s?(x) exists
+ * @param pagePath the page dir absoulute path. e.g. /basic-store/src/page/About
  */
-export default (pagePath: string, projectType: string) => {
+export default (pagePath: string) => {
   const matchingPaths = globby.sync(
-    [`index.${projectType}?(x)`, `Layout/index.${projectType}?(x)`],
+    ['index.@((t|j)s?(x))', 'Layout/index.@((t|j)s?(x))'],
     { cwd: pagePath }
   );
   if (!matchingPaths.length) {

--- a/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
+++ b/packages/plugin-store/src/utils/checkPageIndexFileExists.ts
@@ -1,20 +1,18 @@
 import * as globby from 'globby';
-import { join } from 'path';
-
-const chalk = require('chalk');
+import chalk from 'chalk';
 
 /**
  * Check if the src/pages/${pageName}/index.[j|t]s?(x) or src/pages/${pageName}/Layout/index.[j|t]s?(x) exists
  */
-export default (path: string, projectType: string) => {
-  const matchingPaths = globby.sync([
-    join(path, `index.${projectType}?(x)`),
-    join(path, 'Layout', `index.${projectType}?(x)`)
-  ]);
+export default (pagePath: string, projectType: string) => {
+  const matchingPaths = globby.sync(
+    [`index.${projectType}?(x)`, `Layout/index.${projectType}?(x)`],
+    { cwd: pagePath }
+  );
   if (!matchingPaths.length) {
     console.log(chalk.yellow(
       chalk.black.bgYellow(' WARNING '),
-      `The page ${path} has no index.[js|jsx|tsx]. Please wrap the <Provider> in this page by yourself. For more detail, please see https://ice.work/docs/guide/basic/store.`
+      `The page ${pagePath} has no index.[js|jsx|tsx]. Please wrap the <Provider> in this page by yourself. For more detail, please see https://ice.work/docs/guide/basic/store.`
     ));
   }
 };

--- a/packages/plugin-store/src/utils/checkStoreAndModelExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelExist.ts
@@ -2,15 +2,15 @@ import * as fse from 'fs-extra';
 import { getAppModelsPath, getAppStorePath, getPageModelPath, getPageStorePath } from './getPath';
 
 export default ({ rootDir, srcDir, projectType, applyMethod }) => {
-  const pagesPath = applyMethod('getPages', rootDir, srcDir);
+  const pageNames = applyMethod('getPages', rootDir, srcDir);
   const appStoreFilePath = getAppStorePath({ rootDir, srcDir, projectType });
   const appModelsDir = getAppModelsPath({ rootDir, srcDir });
 
   return fse.pathExistsSync(appStoreFilePath) ||
       fse.pathExistsSync(appModelsDir) ||
-      pagesPath.some(pagePath => {
-        const pageStoreFilePath = getPageStorePath({rootDir, srcDir, pagePath, projectType });
-        const { pageModelsDir, pageModelFile } = getPageModelPath({rootDir, srcDir, pagePath, projectType });
+      pageNames.some(pageName => {
+        const pageStoreFilePath = getPageStorePath({rootDir, srcDir, pageName, projectType });
+        const { pageModelsDir, pageModelFile } = getPageModelPath({rootDir, srcDir, pageName, projectType });
 
         return fse.pathExistsSync(pageStoreFilePath) ||
           fse.pathExistsSync(pageModelsDir) ||

--- a/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
@@ -30,6 +30,7 @@ function checkFileExists(absolutePath: string, matchingPaths: string[], targetFi
   if (matchingPaths.length && !matchingPaths.find(matchingPath => matchingPath === targetFilePath)) {
     console.log(chalk.yellow(
       chalk.black.bgYellow(' WARNING '),
-      `Expect ${path.join(absolutePath, targetFilePath)}, but found ${matchingPaths.map(matchingPath => path.join(absolutePath, matchingPath))}.`));
+      `Expect ${path.join(absolutePath, targetFilePath)}, but found ${matchingPaths.map(matchingPath => path.join(absolutePath, matchingPath))}.`
+    ));
   }
 }

--- a/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
@@ -5,20 +5,20 @@ const chalk = require('chalk');
 
 export default ({ rootDir, srcDir, projectType, pages }) => {
   const srcPath = path.join(rootDir, srcDir);
-  const appStoreFilePath = path.join(srcPath, `store.${projectType}`);
+  const appStoreFilePath = `store.${projectType}`;
   const appStoreMatchingPaths = globby.sync( 'store.*', { cwd: srcPath });
-  checkFileExists(appStoreMatchingPaths, appStoreFilePath);
+  checkFileExists(srcPath, appStoreMatchingPaths, appStoreFilePath);
 
   pages.forEach(page => {
     const pagePath = path.join(srcPath, 'pages', page);
 
-    const pageStoreFilePath = path.join(pagePath, `store.${projectType}`);
+    const pageStoreFilePath = `store.${projectType}`;
     const pageStoreMatchingPaths = globby.sync('store.*', { cwd: pagePath });
-    checkFileExists(pageStoreMatchingPaths, pageStoreFilePath);
+    checkFileExists(pagePath, pageStoreMatchingPaths, pageStoreFilePath);
 
-    const pageModelFilePath = path.join(pagePath, `model.${projectType}`);
-    const pageModelMatchingPaths = globby.sync('store.*', { cwd: pagePath });
-    checkFileExists(pageModelMatchingPaths, pageModelFilePath);
+    const pageModelFilePath = `model.${projectType}`;
+    const pageModelMatchingPaths = globby.sync('model.*', { cwd: pagePath });
+    checkFileExists(pagePath, pageModelMatchingPaths, pageModelFilePath);
   });
 };
 
@@ -26,8 +26,10 @@ export default ({ rootDir, srcDir, projectType, pages }) => {
  * Check the store[j|t]s or model[j|t]s which framework will read if one of them exists.
  * e.g.: in TS project, when user writed store.js file, but framework will read store.ts, warning will occur in the terminal.
  */
-function checkFileExists(matchingPaths: string[], targetFilePath: string) {
+function checkFileExists(absolutePath: string, matchingPaths: string[], targetFilePath: string) {
   if (matchingPaths.length && !matchingPaths.find(matchingPath => matchingPath === targetFilePath)) {
-    console.log(chalk.yellow(chalk.black.bgYellow(' WARNING '), `Expect ${targetFilePath}, but found ${matchingPaths.join(', ')}.`));
+    console.log(chalk.yellow(
+      chalk.black.bgYellow(' WARNING '),
+      `Expect ${path.join(absolutePath, targetFilePath)}, but found ${matchingPaths.map(matchingPath => path.join(absolutePath, matchingPath))}.`));
   }
 }

--- a/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
@@ -1,6 +1,7 @@
 import * as globby from 'globby';
 import * as path from 'path';
-import chalk from 'chalk';
+
+const chalk = require('chalk');
 
 export default ({ rootDir, srcDir, projectType, pages }) => {
   const srcPath = path.join(rootDir, srcDir);

--- a/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
@@ -1,5 +1,6 @@
 import * as globby from 'globby';
 import * as path from 'path';
+import { getPagePath } from './getPath';
 
 const chalk = require('chalk');
 
@@ -9,8 +10,8 @@ export default ({ rootDir, srcDir, projectType, pages }) => {
   const appStoreMatchingPaths = globby.sync( 'store.*', { cwd: srcPath });
   checkFileExists(srcPath, appStoreMatchingPaths, appStoreFilePath);
 
-  pages.forEach(page => {
-    const pagePath = path.join(srcPath, 'pages', page);
+  pages.forEach(pageName => {
+    const pagePath = getPagePath({ rootDir, srcDir, pageName });
 
     const pageStoreFilePath = `store.${projectType}`;
     const pageStoreMatchingPaths = globby.sync('store.*', { cwd: pagePath });
@@ -30,7 +31,7 @@ function checkFileExists(absolutePath: string, matchingPaths: string[], targetFi
   if (matchingPaths.length && !matchingPaths.find(matchingPath => matchingPath === targetFilePath)) {
     console.log(chalk.yellow(
       chalk.black.bgYellow(' WARNING '),
-      `Expect ${path.join(absolutePath, targetFilePath)}, but found ${matchingPaths.map(matchingPath => path.join(absolutePath, matchingPath))}.`
+      `Expect ${path.join(absolutePath, targetFilePath)}, but found ${matchingPaths.map(matchingPath => path.join(absolutePath, matchingPath)).join(', ')}.`
     ));
   }
 }

--- a/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
+++ b/packages/plugin-store/src/utils/checkStoreAndModelFileExist.ts
@@ -1,22 +1,22 @@
 import * as globby from 'globby';
 import * as path from 'path';
-
-const chalk = require('chalk');
+import chalk from 'chalk';
 
 export default ({ rootDir, srcDir, projectType, pages }) => {
-  const appStoreFilePath = path.join(rootDir, srcDir, `store.${projectType}`);
-  const appStoreMatchingPaths = globby.sync(path.join(rootDir, srcDir, 'store.*'));
+  const srcPath = path.join(rootDir, srcDir);
+  const appStoreFilePath = path.join(srcPath, `store.${projectType}`);
+  const appStoreMatchingPaths = globby.sync( 'store.*', { cwd: srcPath });
   checkFileExists(appStoreMatchingPaths, appStoreFilePath);
 
   pages.forEach(page => {
-    const pagePath = path.join(rootDir, srcDir, 'pages', page);
+    const pagePath = path.join(srcPath, 'pages', page);
 
     const pageStoreFilePath = path.join(pagePath, `store.${projectType}`);
-    const pageStoreMatchingPaths = globby.sync(path.join(pagePath, 'store.*'));
+    const pageStoreMatchingPaths = globby.sync('store.*', { cwd: pagePath });
     checkFileExists(pageStoreMatchingPaths, pageStoreFilePath);
 
     const pageModelFilePath = path.join(pagePath, `model.${projectType}`);
-    const pageModelMatchingPaths = globby.sync(path.join(pagePath, 'model.*'));
+    const pageModelMatchingPaths = globby.sync('store.*', { cwd: pagePath });
     checkFileExists(pageModelMatchingPaths, pageModelFilePath);
   });
 };

--- a/packages/plugin-store/src/utils/getPath.ts
+++ b/packages/plugin-store/src/utils/getPath.ts
@@ -12,20 +12,23 @@ export function getAppModelsPath({ rootDir, srcDir }) {
   return path.join(rootDir, srcDir, 'models');
 }
 
-export function getPageStorePath({ rootDir, srcDir, projectType, pagePath }) {
-  pagePath = path.join('pages', pagePath);
+/**
+ * return absolute page path. e.g.: /project/src/pages/Home
+ */
+export function getPagePath({ rootDir, srcDir, pageName }) {
+  return path.join(rootDir, srcDir, 'pages', pageName);
+}
 
-  const pageNameDir = path.join(rootDir, srcDir, pagePath);
+export function getPageStorePath({ rootDir, srcDir, projectType, pageName }) {
+  const pageNameDir = getPagePath({ rootDir, srcDir, pageName });
   // e.g: src/pages/${pageName}/store.ts
   const pageStoreFilePath = path.join(pageNameDir, `store.${projectType}`);
 
   return pageStoreFilePath;
 }
 
-export function getPageModelPath({ rootDir, srcDir, projectType, pagePath }) {
-  pagePath = path.join('pages', pagePath);
-
-  const pageNameDir = path.join(rootDir, srcDir, pagePath);
+export function getPageModelPath({ rootDir, srcDir, projectType, pageName }) {
+  const pageNameDir = getPagePath({ rootDir, srcDir, pageName });
   // e.g: src/pages/${pageName}/models/*
   const pageModelsDir = path.join(pageNameDir, 'models');
   // e.g: src/pages/${pageName}/model.ts


### PR DESCRIPTION
问题：在 Windows 中调试项目，src/pages/Home/store.ts 已存在，但还是在终端显示 Warning 找不到对应的 store.ts

原因：

原来在匹配目标文件时，是使用以下的用法：
```ts
import * as globby from 'globby';

// globby.sync(pattern, options)
// srcPath 是绝对路径
globby.sync(path.join(srcPath, 'store.*'))
```

这里的 `path.join` 方法会将所有给定的 `path` 片段连接到一起（使用平台特定的分隔符作为定界符），然后规范化生成的路径。这会导致在 windows 和 mac 上生成的路径有不同的差异：
```js
path.join('src', 'store.*')
// windows
// \\xxx\\src\\store.*
// linux or macos
// /xxx/src/store.*
```

在 [How to write patterns on Windows? ](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) 中提到，pattern 中应使用`/` 作为要匹配的字符，而使用 `\` 用于转义字符。

在匹配路径的时候，因为在 fast-glob 内部会把 cwd 路径统一 normalize 掉（详见[代码](https://github.com/mrmlnc/fast-glob/blob/ffff3ecc11d5d752b14386c55affaaaa4a8a2879/src/utils/path.ts#L11)），使得在所有平台上得到统一的路径。当在 Windows 上运行上面的代码时，很明显是匹配不上的：

```ts
globby.sync(path.join(srcPath, 'store.*'))

// \xxxx\src\store.* 和 /xxxx/src/store.ts 做匹配
```

文档中推荐使用 `cwd` 参数，解决上面的问题

```ts
globby.sync('store.*', { cwd: srcPath })
globby.sync('Layout/index.*', { cwd: srcPath })
```