### PR TITLE
Fix: react-router-dom types not found

### DIFF
--- a/packages/plugin-router/CHANGELOG.md
+++ b/packages/plugin-router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.4
+
+- [fix] react-router-dom ts types not found
+
 ## 1.9.3
 
 - [chore] ts types

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -11,6 +11,7 @@
     "test": "__tests__"
   },
   "dependencies": {
+    "@types/react-router-dom": "^5.1.4",
     "@builder/app-helpers": "^2.0.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
@@ -26,7 +27,6 @@
     "@types/glob": "^7.1.1",
     "@types/history": "^4.7.5",
     "@types/node": "^12.12.12",
-    "@types/react-router-dom": "^5.1.4",
     "typescript": "^4.0.0"
   },
   "files": [

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -11,7 +11,6 @@
     "test": "__tests__"
   },
   "dependencies": {
-    "@types/react-router-dom": "^5.1.4",
     "@builder/app-helpers": "^2.0.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
@@ -28,6 +27,9 @@
     "@types/history": "^4.7.5",
     "@types/node": "^12.12.12",
     "typescript": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@types/react-router-dom": "^5.1.4"
   },
   "files": [
     "lib",

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -11,6 +11,7 @@
     "test": "__tests__"
   },
   "dependencies": {
+    "@types/react-router-dom": "^5.1.4",
     "@builder/app-helpers": "^2.0.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
@@ -29,7 +30,6 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
-    "@types/react-router-dom": "^5.1.4"
   },
   "files": [
     "lib",

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -11,8 +11,8 @@
     "test": "__tests__"
   },
   "dependencies": {
-    "@types/react-router-dom": "^5.1.4",
     "@builder/app-helpers": "^2.0.2",
+    "@types/react-router-dom": "^5.1.4",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "history": "^4.10.1",
@@ -28,8 +28,6 @@
     "@types/history": "^4.7.5",
     "@types/node": "^12.12.12",
     "typescript": "^4.0.0"
-  },
-  "peerDependencies": {
   },
   "files": [
     "lib",


### PR DESCRIPTION
### 问题
IRouterConfig 类型依赖到 `@types/react-router-dom` 包中的类型，但当前 plugin-router 中 `@types/react-router-dom` 是在 devDeps，安装 ice.js 依赖时没有安装该依赖到项目中，导致下面的报错：

![image](https://user-images.githubusercontent.com/44047106/114371604-3f658080-9bb3-11eb-8520-3095ed425f55.png)
![image](https://user-images.githubusercontent.com/44047106/114371540-29f05680-9bb3-11eb-809a-98ce856c47f2.png)

