### PR TITLE
fix: page not render when app.ts has export default declaration in mpa

### DIFF
--- a/packages/build-mpa-config/CHANGELOG.md
+++ b/packages/build-mpa-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2
+
+- [fix] the page doesn't render when the app.ts entry exports a component in mpa
+
 ## 3.1.1
 
 - [chore] `hydrate` should be set when staticExport

--- a/packages/build-mpa-config/src/index.ts
+++ b/packages/build-mpa-config/src/index.ts
@@ -17,7 +17,7 @@ interface IConfigOptions {
 }
 export const generateMPAEntries = (api, options: IConfigOptions) => {
   const { context } = api;
-  const { type = 'web', framework = 'rax', targetDir = '' } = options;
+  const { framework = 'rax', targetDir = '' } = options;
   let { entries } = options;
   const { rootDir, commandArgs } = context;
   if (commandArgs.mpaEntry) {
@@ -30,20 +30,14 @@ export const generateMPAEntries = (api, options: IConfigOptions) => {
   const parsedEntries = {};
   entries.forEach((entry) => {
     const { entryName, entryPath, source } = entry;
-    const pageEntry = entryPath;
-    const useOriginEntry = /app(\.(t|j)sx?)?$/.test(entryPath) || type === 'node';
     const exportDefaultDeclarationExists = checkExportDefaultDeclarationExists(path.join(rootDir, 'src', source));
     // icejs will config entry by api modifyUserConfig
-    let finalEntry = pageEntry;
-    // when the source is not the custom render page or runApp, do not generate entry
-    if (exportDefaultDeclarationExists && !useOriginEntry) {
-      // generate mpa entries
-      finalEntry = generateEntry(api, { framework, targetDir, pageEntry, entryName });
-    }
-
     parsedEntries[entryName] = {
       ...entry,
-      finalEntry,
+      finalEntry: exportDefaultDeclarationExists ?
+        // when the source has export default declaration which means that the custom render page and runApp don't exist, generate an entry
+        generateEntry(api, { framework, targetDir, pageEntry: entryPath, entryName }) :
+        entryPath
     };
   });
   return parsedEntries;


### PR DESCRIPTION
问题：在 MPA 应用中，当入口为 src/pages/Home/app.ts，并且入口包含 `export default`，页面没有正常渲染出来

解决：检查当入口没有 export default 时，判定是 runApp 或者自定义渲染逻辑，不再限定是 app.ts 文件