### PR TITLE
fix: generate  mpa entry when use app.ts

### DIFF
--- a/packages/build-mpa-config/CHANGELOG.md
+++ b/packages/build-mpa-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.3
+
+- fix: generate mpa entries when app.ts is entry in ice.js framework
+
 ## 3.2.2
 
 - fix: page wrapper `getInitialProps`

--- a/packages/build-mpa-config/package.json
+++ b/packages/build-mpa-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/mpa-config",
-  "version": "3.2.2",
+  "version": "3.2.3-beta.1",
   "description": "enable mpa project for framework",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/build-mpa-config/package.json
+++ b/packages/build-mpa-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/mpa-config",
-  "version": "3.2.3-beta.1",
+  "version": "3.2.3",
   "description": "enable mpa project for framework",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/build-mpa-config/src/index.ts
+++ b/packages/build-mpa-config/src/index.ts
@@ -30,14 +30,24 @@ export const generateMPAEntries = (api, options: IConfigOptions) => {
   const parsedEntries = {};
   entries.forEach((entry) => {
     const { entryName, entryPath, source } = entry;
-    const exportDefaultDeclarationExists = checkExportDefaultDeclarationExists(path.join(rootDir, 'src', source));
+    const pageEntry = entryPath;
+    const useOriginEntry = /app(\.(t|j)sx?)?$/.test(entryPath);
     // icejs will config entry by api modifyUserConfig
+    let finalEntry = pageEntry;
+    /**
+     * when to generate mpa entries
+     * rax-app: the entry has export default declaration
+     * icejs: the entry is not the app.ts(x) and the entry has export deafult declaration
+     */
+    if (framework === 'rax'|| (framework === 'react' && !useOriginEntry)) {
+      const exportDefaultDeclarationExists = checkExportDefaultDeclarationExists(path.join(rootDir, 'src', source));
+      if (exportDefaultDeclarationExists) {
+        finalEntry = generateEntry(api, { framework, targetDir, pageEntry, entryName });
+      }
+    }
     parsedEntries[entryName] = {
       ...entry,
-      finalEntry: exportDefaultDeclarationExists ?
-        // when the source has export default declaration which means that the custom render page and runApp don't exist, generate an entry
-        generateEntry(api, { framework, targetDir, pageEntry: entryPath, entryName }) :
-        entryPath
+      finalEntry
     };
   });
   return parsedEntries;

--- a/packages/build-mpa-config/src/index.ts
+++ b/packages/build-mpa-config/src/index.ts
@@ -30,10 +30,9 @@ export const generateMPAEntries = (api, options: IConfigOptions) => {
   const parsedEntries = {};
   entries.forEach((entry) => {
     const { entryName, entryPath, source } = entry;
-    const pageEntry = entryPath;
     const useOriginEntry = /app(\.(t|j)sx?)?$/.test(entryPath);
     // icejs will config entry by api modifyUserConfig
-    let finalEntry = pageEntry;
+    let finalEntry = entryPath;
     /**
      * when to generate mpa entries
      * rax-app: the entry has export default declaration
@@ -42,7 +41,7 @@ export const generateMPAEntries = (api, options: IConfigOptions) => {
     if (framework === 'rax'|| (framework === 'react' && !useOriginEntry)) {
       const exportDefaultDeclarationExists = checkExportDefaultDeclarationExists(path.join(rootDir, 'src', source));
       if (exportDefaultDeclarationExists) {
-        finalEntry = generateEntry(api, { framework, targetDir, pageEntry, entryName });
+        finalEntry = generateEntry(api, { framework, targetDir, pageEntry: entryPath, entryName });
       }
     }
     parsedEntries[entryName] = {


### PR DESCRIPTION
原因：原先有部分 ice.js mpa 应用以 src/pages/xxx/app.ts 作为入口时，使用 export default，会导致在临时目录下生成对应的 mpa entry，导致用户自定义的 render 逻辑失效

解决：rax-app 保持现在的逻辑，ice 针对以 app.ts 入口不生成 mpa entry
