### PR TITLE
fix: deep clone let custom config  lost

### DIFF
--- a/packages/create-app-shared/CHANGELOG.md
+++ b/packages/create-app-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.4
+
+- [fix] remove `deepmerge`, and fix deep clone let custom config `__proto__` lost
+
 ## 0.2.3
 
 - [fix] ts types of export apis

--- a/packages/create-app-shared/package.json
+++ b/packages/create-app-shared/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "deepmerge": "^4.2.2",
     "history": "^4.9.0",
     "miniapp-history": "^0.1.0",
     "query-string": "^6.13.1",

--- a/packages/create-app-shared/src/createBaseApp.ts
+++ b/packages/create-app-shared/src/createBaseApp.ts
@@ -4,9 +4,6 @@ import { createHistory } from './history';
 import { isMiniAppPlatform } from './env';
 import collectAppLifeCycle from './collectAppLifeCycle';
 
-// eslint-disable-next-line
-const deepmerge = require('deepmerge');
-
 const DEFAULE_APP_CONFIG = {
   app: {
     rootId: 'root'
@@ -16,11 +13,22 @@ const DEFAULE_APP_CONFIG = {
   }
 };
 
+function mergeDefaultConfig(defaultConfig, config) {
+  Object.keys(defaultConfig).forEach(key => {
+    if (!config[key]) {
+      config[key] = defaultConfig[key];
+    } else if (typeof config[key] === 'object') {
+      config[key] = mergeDefaultConfig(defaultConfig[key], config[key]);
+    }
+  });
+  return config;
+}
+
 export default ({ loadRuntimeModules, createElement, initHistory = true }) => {
   const createBaseApp = (appConfig, buildConfig, context: any = {}) => {
 
     // Merge default appConfig to user appConfig
-    appConfig = deepmerge(DEFAULE_APP_CONFIG, appConfig);
+    appConfig = mergeDefaultConfig(DEFAULE_APP_CONFIG, appConfig);
 
     // Set history
     let history: History;

--- a/packages/create-app-shared/src/createBaseApp.ts
+++ b/packages/create-app-shared/src/createBaseApp.ts
@@ -15,10 +15,10 @@ const DEFAULE_APP_CONFIG = {
 
 function mergeDefaultConfig(defaultConfig, config) {
   Object.keys(defaultConfig).forEach(key => {
-    if (!config[key]) {
-      config[key] = defaultConfig[key];
-    } else if (typeof config[key] === 'object') {
+    if (typeof config[key] === 'object' && config[key] !== null) {
       config[key] = mergeDefaultConfig(defaultConfig[key], config[key]);
+    } else {
+      config[key] = defaultConfig[key];
     }
   });
   return config;


### PR DESCRIPTION
如果开发者通过 `runApp` 传入的配置对象上存在不可枚举的属性或者原型链上的属性，通过 `deepmerge` 中的 `deepClone` 会导致这些属性丢失