### PR TITLE
fix: compatible with case which icejs verison is locked

### DIFF
--- a/packages/icejs/package.json
+++ b/packages/icejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice.js",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "command line interface and builtin plugin for icejs",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/icejs/src/getBuiltInPlugins.ts
+++ b/packages/icejs/src/getBuiltInPlugins.ts
@@ -10,6 +10,9 @@ const getBuiltInPlugins: IGetBuiltInPlugins = (userConfig) => {
       'build-plugin-ice-mpa'
     ];
   }
+  // eslint-disable-next-line
+  const pkg = require('../package.json');
+  process.env.__FRAMEWORK_VERSION__ = pkg.version;
   const coreOptions = {
     'framework': 'react',
     'alias': process.env.__FRAMEWORK_NAME__ || 'ice'

--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.0.9
+
+- [fix] compatible with the case which icejs version is locked
+
 # 2.0.8
 
 - [fix] make `router.basename` work in a non-icestark context. ([#4234](https://github.com/alibaba/ice/issues/4234))

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -12,6 +12,9 @@ const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, cont
 
   const hasDefaultLayout = glob.sync(`${path.join(rootDir, 'src/layouts/index')}.@(ts?(x)|js?(x))`).length;
   onGetWebpackConfig((config) => {
+    config
+      .plugin('DefinePlugin')
+      .tap(([args]) => [{ ...args, 'process.env.__FRAMEWORK_VERSION__': JSON.stringify(process.env.__FRAMEWORK_VERSION__) }]);
     // set alias for default layout
     config.resolve.alias.set('$ice/Layout', hasDefaultLayout ? path.join(rootDir, 'src/layouts') : path.join(__dirname, 'runtime/Layout'));
     // set alias for icestark

--- a/packages/plugin-icestark/src/runtime.tsx
+++ b/packages/plugin-icestark/src/runtime.tsx
@@ -68,7 +68,8 @@ const module = ({ appConfig, addDOMRender, buildConfig, setRenderRouter, wrapper
       fallback
     };
 
-    if (wrapperRouterRender) {
+    // compatible with the case which lock icejs version
+    if (wrapperRouterRender && !!process.env.__FRAMEWORK_VERSION__) {
       wrapperRouterRender((originRender) => (routes, RoutesComponent) => {
         return originRender(routes, RoutesComponent, routerProps);
       });


### PR DESCRIPTION
plugin-icestark 2.0.8 版本除了依赖 wrapperRouterRender 之外，还依赖到了 plugin-router 中的 renderRouter 中支持 customProps 能力。如果锁了版本的情况下可能会存在有 wrapperRouterRender 但是没有 customProps 能力，导致业务上的 breakchange。

统一在环境变量中输出版本信息，后续可以作为一些版本依赖的判断依据，用于提示输出和 cache 版本的标识