### PR TITLE
feat: support pass page config to page

### DIFF
--- a/packages/build-mpa-config/CHANGELOG.md
+++ b/packages/build-mpa-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.5
+
+- feat add `props.pageConfig` in Rax App MPA page component
+
 ## 3.2.4
 
 - fix: generate mpa entries when app.ts is entry in rax-app

--- a/packages/build-mpa-config/src/generateEntry.ts
+++ b/packages/build-mpa-config/src/generateEntry.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as globby from 'globby';
 import { formatPath } from '@builder/app-helpers';
 
-function generateEntry(api, { framework, targetDir, pageEntry, entryName }) {
+function generateEntry(api, { framework, targetDir, pageEntry, entryName, pageConfig = {} }) {
   const { context: { userConfig: { web: webConfig = {} }, rootDir }, getValue } = api;
   const entryFolder = path.join(targetDir, 'mpaEntry');
   const entryPath = path.join(entryFolder, `${entryName}.tsx`);
@@ -16,7 +16,8 @@ function generateEntry(api, { framework, targetDir, pageEntry, entryName }) {
     resourcePath: `${formatPath(path.extname(pageEntry) ? pageEntry.split('.').slice(0, -1).join('.') : pageEntry)}`,
     customTabBarPath,
     needCustomTabBar,
-    globalStyle: globalStyles.length && formatPath(path.join(rootDir, globalStyles[0]))
+    globalStyle: globalStyles.length && formatPath(path.join(rootDir, globalStyles[0])),
+    pageConfig: JSON.stringify(pageConfig),
   });
   return entryPath;
 }

--- a/packages/build-mpa-config/src/index.ts
+++ b/packages/build-mpa-config/src/index.ts
@@ -29,12 +29,13 @@ export const generateMPAEntries = (api, options: IConfigOptions) => {
 
   const parsedEntries = {};
   entries.forEach((entry) => {
-    const { entryName, entryPath, source } = entry;
+    const { entryName, entryPath, ...pageConfig } = entry;
+    const { source } = pageConfig;
     const useOriginEntry = /app(\.(t|j)sx?)?$/.test(entryPath);
     // icejs will config entry by api modifyUserConfig
     // when the entry has no export default declaration or is app.ts, do not generate entry
     const finalEntry = !useOriginEntry && checkExportDefaultDeclarationExists(path.join(rootDir, 'src', source)) ?
-      generateEntry(api, { framework, targetDir, pageEntry: entryPath, entryName }) :
+      generateEntry(api, { framework, targetDir, pageEntry: entryPath, entryName, pageConfig }) :
       entryPath;
 
     parsedEntries[entryName] = {

--- a/packages/build-mpa-config/src/template/rax.ts.ejs
+++ b/packages/build-mpa-config/src/template/rax.ts.ejs
@@ -36,18 +36,27 @@ class PageWrapper extends Component {
 
 
 if (!isNode) {
-  const isSSR = window.__INITIAL_DATA__ && window.__INITIAL_DATA__.__SSR_ENABLED__;
+  const isSSR = (window as any).__INITIAL_DATA__ && (window as any).__INITIAL_DATA__.__SSR_ENABLED__;
 
   if (isWeex || isKraken) {
-    render(<PageWrapper />, null, { driver: DriverUniversal });
+    render(<PageWrapper pageConfig={<%- pageConfig %> } />, null, { driver: DriverUniversal });
   } else {
     const renderApp = async function() {
-      let comProps = {};
+      let comProps = {
+        pageConfig: <%- pageConfig %>,
+      };
       // process App.getInitialProps
       if (isSSR && window.__INITIAL_DATA__.pageInitialProps !== null) {
-        comProps = window.__INITIAL_DATA__.pageInitialProps;
+        comProps = {
+          ...comProps,
+          ...window.__INITIAL_DATA__.pageInitialProps,
+        };
       } else if (PageComponent.getInitialProps) {
-        comProps = await PageComponent.getInitialProps();
+        const initialProps = await PageComponent.getInitialProps();
+        comProps = {
+          ...comProps,
+          ...initialProps,
+        };
       }
 
       render(<PageWrapper {...comProps} />, document.getElementById('root'), { driver: DriverUniversal, hydrate: <%- hydrate %> });

--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.5
+
+- [feat] add `props.pageConfig` in Rax App SPA page component
+
 ## 0.3.4
 
 - [fix] remove deprecated api of esbuild-loader

--- a/packages/build-user-config/src/loaders/AppConfigLoader/index.js
+++ b/packages/build-user-config/src/loaders/AppConfigLoader/index.js
@@ -53,25 +53,23 @@ module.exports = function (appJSON) {
         return Component;
       })
     `;
-    const importComponentInClient = `() => () => {
-      function Component(props) {
-        return createElement(require('${formatPath(pageSource)}').default, { pageConfig: ${JSON.stringify(route)}, ...props })
-      }
-      return Component;
-    }`;
-    // without useRouter
-    const importComponentInServer = `() => {
+
+    const importComponentDirectly = `() => {
       function Component(props) {
         return createElement(require('${formatPath(pageSource)}').default, { pageConfig: ${JSON.stringify(route)}, ...props })
       }
       return Component;
     }`;
 
+    // For rax-use-router lazy load page component
+    const importComponentInClient = `() => ${importComponentDirectly}`;
+
     let importComponent;
     if (target === 'web') {
       importComponent = dynamicImportComponent;
     } else if (target === 'ssr') {
-      importComponent = importComponentInServer;
+      // without useRouter
+      importComponent = importComponentDirectly;
     } else {
       importComponent = importComponentInClient;
     }

--- a/packages/build-user-config/src/loaders/AppConfigLoader/index.js
+++ b/packages/build-user-config/src/loaders/AppConfigLoader/index.js
@@ -46,16 +46,26 @@ module.exports = function (appJSON) {
         const reference = mod.default;
         function Component(props) {
           ${routeTitle ? `document.title="${routeTitle}"` : ''}
-          return createElement(reference, Object.assign({}, routeProps, props));
+          return createElement(reference, { pageConfig: ${JSON.stringify(route)}, ...routeProps, ...props });
         }
         Component.__path = '${route.path}';
         Component.getInitialProps = reference.getInitialProps;
         return Component;
       })
     `;
-    const importComponentInClient = `() => () => require('${formatPath(pageSource)}').default`;
+    const importComponentInClient = `() => () => {
+      function Component(props) {
+        return createElement(require('${formatPath(pageSource)}').default, { pageConfig: ${JSON.stringify(route)}, ...props })
+      }
+      return Component;
+    }`;
     // without useRouter
-    const importComponentInServer = `() => require('${formatPath(pageSource)}').default`;
+    const importComponentInServer = `() => {
+      function Component(props) {
+        return createElement(require('${formatPath(pageSource)}').default, { pageConfig: ${JSON.stringify(route)}, ...props })
+      }
+      return Component;
+    }`;
 
     let importComponent;
     if (target === 'web') {


### PR DESCRIPTION
The configure which developer config in `src/app.json` `route` field, will pass to page component as `props.pageConfig`