### PR TITLE
fix: origin appConfig object was modified

### DIFF
--- a/packages/react-app-renderer/CHANGELOG.md
+++ b/packages/react-app-renderer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+- [fix] origin appConfig object was modified
+
 ## 2.0.2
 
 - [fix] throw error when not setting route type

--- a/packages/react-app-renderer/package.json
+++ b/packages/react-app-renderer/package.json
@@ -15,7 +15,6 @@
     "@loadable/server": "^5.14.0",
     "create-app-container": "^0.1.2",
     "create-use-router": "^0.1.1",
-    "lodash.clonedeep": "^4.5.0",
     "query-string": "^6.13.7"
   },
   "devDependencies": {

--- a/packages/react-app-renderer/package.json
+++ b/packages/react-app-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-renderer",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",
@@ -15,6 +15,7 @@
     "@loadable/server": "^5.14.0",
     "create-app-container": "^0.1.2",
     "create-use-router": "^0.1.1",
+    "lodash.clonedeep": "^4.5.0",
     "query-string": "^6.13.7"
   },
   "devDependencies": {

--- a/packages/react-app-renderer/src/server.tsx
+++ b/packages/react-app-renderer/src/server.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as clonedeep from 'lodash.clonedeep';
 import * as ReactDOMServer from 'react-dom/server';
 import { ChunkExtractor } from '@loadable/server';
 import { getRenderApp } from './renderer';
@@ -35,11 +34,24 @@ function renderInServer(context, options) {
 }
 
 export default function reactAppRendererWithSSR(context, options) {
-  const appConfig = clonedeep(options.appConfig || {});
+  const appConfig = deepCloneConfig(options.appConfig || {});
   appConfig.router = appConfig.router || {};
   if (appConfig.router.type !== 'browser') {
     throw new Error('[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://ice.work/docs/guide/basic/router');
   }
   appConfig.router.type = 'static';
   return renderInServer(context, options);
+}
+
+function deepCloneConfig(config) {
+  if(typeof config !== 'object' || config === null) {
+    return config;
+  }
+  const ret = {};
+  Object.keys(config).forEach((key: string) => {
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+      ret[key] = deepCloneConfig(config[key]);
+    }
+  });
+  return ret;
 }

--- a/packages/react-app-renderer/src/server.tsx
+++ b/packages/react-app-renderer/src/server.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as clonedeep from 'lodash.clonedeep';
 import * as ReactDOMServer from 'react-dom/server';
 import { ChunkExtractor } from '@loadable/server';
 import { getRenderApp } from './renderer';
@@ -34,7 +35,7 @@ function renderInServer(context, options) {
 }
 
 export default function reactAppRendererWithSSR(context, options) {
-  const { appConfig } = options || {};
+  const appConfig = clonedeep(options.appConfig || {});
   appConfig.router = appConfig.router || {};
   if (appConfig.router.type !== 'browser') {
     throw new Error('[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://ice.work/docs/guide/basic/router');

--- a/packages/react-app-renderer/src/server.tsx
+++ b/packages/react-app-renderer/src/server.tsx
@@ -34,23 +34,24 @@ function renderInServer(context, options) {
 }
 
 export default function reactAppRendererWithSSR(context, options) {
-  const appConfig = deepCloneConfig(options.appConfig || {});
+  const cloneOptions = deepClone(options);
+  const { appConfig } = cloneOptions || {};
   appConfig.router = appConfig.router || {};
   if (appConfig.router.type !== 'browser') {
     throw new Error('[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://ice.work/docs/guide/basic/router');
   }
   appConfig.router.type = 'static';
-  return renderInServer(context, options);
+  return renderInServer(context, cloneOptions);
 }
 
-function deepCloneConfig(config) {
+function deepClone(config) {
   if(typeof config !== 'object' || config === null) {
     return config;
   }
   const ret = {};
   Object.getOwnPropertyNames(config).forEach((key: string) => {
     if (Object.prototype.hasOwnProperty.call(config, key)) {
-      ret[key] = deepCloneConfig(config[key]);
+      ret[key] = deepClone(config[key]);
     }
   });
   return ret;

--- a/packages/react-app-renderer/src/server.tsx
+++ b/packages/react-app-renderer/src/server.tsx
@@ -48,7 +48,7 @@ function deepCloneConfig(config) {
     return config;
   }
   const ret = {};
-  Object.keys(config).forEach((key: string) => {
+  Object.getOwnPropertyNames(config).forEach((key: string) => {
     if (Object.prototype.hasOwnProperty.call(config, key)) {
       ret[key] = deepCloneConfig(config[key]);
     }


### PR DESCRIPTION
### 问题描述

在开启 SSR 应用，dev 模式下是能正常的，prod 环境下会报错  '[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://ice.work/docs/guide/basic/router'

### 问题排查

抛出上面的错误是 `react-app-renderer` 中的 `reactAppRendererWithSSR` 函数。

假设当前应用的 `appConfig` 配置如下的：
```js
import { runApp } from 'ice';

const appConfig = {
  app: {
    rootId: 'ice-container',
  },
  router: {
    type: 'browser'
  }
};

runApp(appConfig);
```

在生产环境下，尝试在本地复现问题以更好的排查，增加下面的 log 日志：

```diff
export default function reactAppRendererWithSSR(context, options) {
  const { appConfig } = options || {};
+ console.log('appConfig:', appConfig);
  appConfig.router = appConfig.router || {};
  if (appConfig.router.type !== 'browser') {
    throw new Error('[SSR]: Only support BrowserRouter when using SSR. You should set the router type to "browser". For more detail, please visit https://ice.work/docs/guide/basic/router');
  }
  appConfig.router.type = 'static';
  return renderInServer(context, options);
}
```
打印的日志如下：
![image](https://user-images.githubusercontent.com/44047106/117629544-dae71280-b1ac-11eb-85d4-c7f94e0afd0d.png)

很明显 `.ice/appConfig.ts` 中的 `appConfig.router.type` 从原来的 `browser` 被修改为 `static`。`reactAppRendererWithSSR`函数中修改了同一个对象引用。

**为什么 dev 环境是没问题的？而 prod 环境是有问题的？**
dev 环境下第一次走的是 SSR，后面的都走 CSR；prod 环境下，由于 BrowserRouter 需要服务端的支持，每次请求到服务端时，都会走到上面的 `reactAppRendererWithSSR` 逻辑中，后面拿到的 `appConfig.router.type` 都为 `static`

### 解决
对 appConfig 对象进行 deepClone，不直接修改同一个对象引用
