### PR TITLE
fix: lock sass version

### DIFF
--- a/packages/build-scripts-config/CHANGELOG.md
+++ b/packages/build-scripts-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+- [fix] lock sass version until it's define a js api for handling warnings
+
 ## 3.0.1
 
 - [feat] enable stage 3 for postcss preset env

--- a/packages/build-scripts-config/package.json
+++ b/packages/build-scripts-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-scripts-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Basic configs for build-scripts and its plugins",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
@@ -40,7 +40,7 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-safe-parser": "^4.0.1",
     "regenerator-runtime": "^0.13.3",
-    "sass": "^1.32.0",
+    "sass": "1.32.13",
     "sass-loader": "^10.0.0",
     "terser-webpack-plugin": "^2.3.1",
     "time-fix-plugin": "^2.0.6",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4219965/119455514-406dfe00-bd6c-11eb-8d01-65774d5e6a88.png)
sass 1.33/34 版本出现大量 warning 日志，目前仅支持 cli 方式调用的时候禁止输出，暂时锁定版本已优化调试信息
https://github.com/sass/dart-sass/issues/672#issuecomment-846311746