### PR TITLE
fix: No loader specified

### DIFF
--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.7
+
+- [fix] `no loader specified error` is reported when using `postcssrc: true` in ssr app
+
 ## 0.3.6
 
 - [feat] use trusted-cert to generate ca

--- a/packages/build-user-config/src/userConfig/postcssrc.js
+++ b/packages/build-user-config/src/userConfig/postcssrc.js
@@ -9,7 +9,10 @@ module.exports = (config, postcssrc) => {
       'less',
       'less-module',
     ].forEach(rule => {
-      if (config.module.rules.has(rule)) {
+      if (
+        config.module.rules.has(rule) &&
+        config.module.rule(rule).uses.has('postcss-loader')
+      ) {
         config.module
           .rule(rule)
           .use('postcss-loader')


### PR DESCRIPTION
SSR 场景，target 为 node 的 webpack config 中没有 postcss-loader

https://github.com/alibaba/ice/blob/d11ec74c50011e8e1647fec3ae9fab89a9e17a4b/packages/build-user-config/src/userConfig/postcssrc.js#L15

只 use( 'postcss-loader' )，而不配置 .loader()，会导致 webpack 报错 "No loader specified"