### PR TITLE
refactor(create-use-router): remove routerConfig cache for HMR 

### DIFF
--- a/packages/create-use-router/CHANGELOG.md
+++ b/packages/create-use-router/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.2.0
+
+- chore: remove routerConfig cache for HMR
+- chore: remove routerConfig is a function check

--- a/packages/create-use-router/package.json
+++ b/packages/create-use-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-use-router",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://github.com/alibaba/ice#readme",

--- a/packages/create-use-router/src/index.ts
+++ b/packages/create-use-router/src/index.ts
@@ -239,7 +239,7 @@ export function createUseRouter(api) {
         router.removeHandle(handleId);
         unlisten();
       };
-    }, []);
+    }, [routerConfig]);
 
     return { component };
   }

--- a/packages/create-use-router/src/index.ts
+++ b/packages/create-use-router/src/index.ts
@@ -2,8 +2,6 @@ import * as pathToRegexpModule from 'path-to-regexp';
 
 const cache = {};
 
-let _initialized = false;
-let _routerConfig = null;
 const router = {
   history: null,
   handles: [],
@@ -194,25 +192,18 @@ function matchRoute(route, baseUrl, pathname, parentParams) {
 function getInitialComponent(routerConfig) {
   let InitialComponent = [];
 
-  if (_routerConfig === null) {
-    if (typeof routerConfig === 'function') {
-      routerConfig = routerConfig();
+  if (process.env.NODE_ENV !== 'production') {
+    if (!routerConfig) {
+      throw new Error('Error: useRouter should have routerConfig.');
     }
-
-    if (process.env.NODE_ENV !== 'production') {
-      if (!routerConfig) {
-        throw new Error('Error: useRouter should have routerConfig.');
-      }
-      if (!routerConfig.history || !routerConfig.routes) {
-        throw new Error('Error: routerConfig should contain history and routes.');
-      }
+    if (!routerConfig.history || !routerConfig.routes) {
+      throw new Error('Error: routerConfig should contain history and routes.');
     }
-    _routerConfig = routerConfig;
   }
-  if (_routerConfig.InitialComponent) {
-    InitialComponent = _routerConfig.InitialComponent;
+  if (routerConfig.InitialComponent) {
+    InitialComponent = routerConfig.InitialComponent;
   }
-  router.history = _routerConfig.history;
+  router.history = routerConfig.history;
 
   return InitialComponent;
 }
@@ -224,10 +215,8 @@ export function createUseRouter(api) {
     const [component, setComponent] = useState(getInitialComponent(routerConfig));
 
     useLayoutEffect(() => {
-      if (_initialized) throw new Error('Error: useRouter can only be called once.');
-      _initialized = true;
-      const history = _routerConfig.history;
-      const routes = _routerConfig.routes;
+      const history = routerConfig.history;
+      const routes = routerConfig.routes;
 
       // @ts-ignore
       router.root = Array.isArray(routes) ? { routes } : routes;
@@ -238,7 +227,7 @@ export function createUseRouter(api) {
       });
 
       // Init path match
-      if (!_routerConfig.InitialComponent) {
+      if (!routerConfig.InitialComponent) {
         matchLocation(history.location);
       }
 


### PR DESCRIPTION
- 从应用维度来看，cache `routerConfig` 带来的收益极小
- HMR 生效时，共享文件内存会导致代码执行报错