### PR TITLE
plugin-icestark 2.1.0

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.1.0
+
+- [fix] append absolute path for sourcemaps using `SourceMapDevToolPlugin`. ([#259](https://github.com/ice-lab/icestark/issues/259))
+
 # 2.0.9
 
 - [fix] compatible with the case which icejs version is locked

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-icestark",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -5,10 +5,11 @@ import { IPlugin, Json } from '@alib/build-scripts';
 
 const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, context }, options = {}) => {
   const { uniqueName, umd, library } = options as Json;
-  const { rootDir, webpack, pkg } = context;
+  const { rootDir, webpack, pkg, commandArgs, userConfig, command } = context;
   const iceTempPath = getValue('TEMP_PATH') || path.join(rootDir, '.ice');
   // remove output.jsonpFunction in webpack5 see: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-unique-naming
   const isWebpack5 = (webpack as any).version?.startsWith('5');
+  const isDev = command === 'start';
 
   const hasDefaultLayout = glob.sync(`${path.join(rootDir, 'src/layouts/index')}.@(ts?(x)|js?(x))`).length;
   onGetWebpackConfig((config) => {
@@ -25,13 +26,48 @@ const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, cont
     if (!isWebpack5 && uniqueName) {
       config.output.jsonpFunction(`webpackJsonp_${uniqueName}`);
     }
+
+    /**
+     * For no need to change if souceMap type is inline、hidden or eval.
+     */
+    const devtool = config.get('devtool');
+    const inlineOrHiddenSourceMap = ['inline', 'eval', 'hidden'].some(type => devtool.includes(type));
+
+    if (!inlineOrHiddenSourceMap) {
+      const devtoolFallbackModuleFilenameTemplate = config.output.get('devtoolFallbackModuleFilenameTemplate');
+      const devtoolNamespace = config.output.get('devtoolNamespace');
+      const cheap = devtool.includes('cheap');
+      const moduleMaps = devtool.includes('module');
+      const noSources = devtool.includes('nosources');
+
+      const publicPath = isDev ? userConfig.devPublicPath : config.output.get('publicPath') ?? '/';
+      const port = commandArgs.port;
+      const isHttps = commandArgs?.https;
+      const servePath = publicPath === '/' ? `http${isHttps ? 's' : ''}://localhost:${port}` : publicPath;
+
+      // set devtool to false
+      config.devtool(false);
+      // then set SourceMapDevToolPlugin manually.
+      // refer to https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L188
+      config.plugin('SourceMapDevToolPlugin')
+        .use((webpack as any).SourceMapDevToolPlugin, [{
+          append: `\n//# sourceMappingURL=${servePath}/[file].map`,
+          filename: '[file].map',
+          fallbackModuleFilenameTemplate: devtoolFallbackModuleFilenameTemplate,
+          module: moduleMaps ? true : !cheap,
+          columns: !cheap,
+          noSources,
+          namespace: devtoolNamespace
+        }]);
+    }
+
     // umd config
     if (umd) {
       const libraryName = library as string || pkg.name as string || 'microApp';
       config.output
         .library(libraryName)
         .libraryTarget('umd');
-      
+
       // collect entry
       const entries = config.toConfig().entry;
       const entryList = [];


### PR DESCRIPTION
- [x] get rendering container through `props` instead of `getMountNode`. ([#227](https://github.com/ice-lab/icestark/issues/227))
- [x] support `omitSetLibraryName` for removing default setLibraryName.
- [x] append absolute path for sourcemaps using `SourceMapDevToolPlugin`. ([#259](https://github.com/ice-lab/icestark/issues/259))