### PR TITLE
feat: enhance debug package

### DIFF
--- a/packages/build-app-helpers/package.json
+++ b/packages/build-app-helpers/package.json
@@ -10,7 +10,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/build-app-templates/package.json
+++ b/packages/build-app-templates/package.json
@@ -10,7 +10,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/build-babel-config/package.json
+++ b/packages/build-babel-config/package.json
@@ -22,5 +22,9 @@
   },
   "dependencies": {
     "@builder/pack": "0.2.17"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/build-jest-config/package.json
+++ b/packages/build-jest-config/package.json
@@ -25,5 +25,9 @@
     "@builder/babel-config": "^1.0.0",
     "regenerator-runtime": "^0.13.3",
     "core-js": "^3.3.1"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/build-mpa-config/package.json
+++ b/packages/build-mpa-config/package.json
@@ -10,7 +10,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/build-user-config/package.json
+++ b/packages/build-user-config/package.json
@@ -26,7 +26,8 @@
     "trusted-cert": "^1.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/build-webpack-config/package.json
+++ b/packages/build-webpack-config/package.json
@@ -29,5 +29,9 @@
     "typescript": "^4.0.0",
     "fs-extra": "^10.0.0",
     "webpack-dev-mock": "^1.0.1"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/create-app-container/package.json
+++ b/packages/create-app-container/package.json
@@ -11,7 +11,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "universal-env": "^3.0.0"

--- a/packages/create-app-shared/package.json
+++ b/packages/create-app-shared/package.json
@@ -28,7 +28,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/create-cli-utils/package.json
+++ b/packages/create-cli-utils/package.json
@@ -11,7 +11,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "build-scripts": "^1.1.0-5",

--- a/packages/create-ice/package.json
+++ b/packages/create-ice/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "lib",
-    "bin"
+    "bin",
+    "!lib/**/*.map"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/create-use-router/package.json
+++ b/packages/create-use-router/package.json
@@ -11,7 +11,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/icejs/package.json
+++ b/packages/icejs/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "files": [
     "bin",
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "bin": {
     "icejs": "./bin/ice-cli.js"

--- a/packages/icejs/tsconfig.json
+++ b/packages/icejs/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "lib",
     "esModuleInterop": true
-  }
+  },
+  "exclude": ["bin"]
 }

--- a/packages/miniapp-renderer/package.json
+++ b/packages/miniapp-renderer/package.json
@@ -14,7 +14,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-antd/package.json
+++ b/packages/plugin-antd/package.json
@@ -14,5 +14,9 @@
   },
   "dependencies": {
     "babel-plugin-import": "^1.11.2"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-app-core/package.json
+++ b/packages/plugin-app-core/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "src/runtime.tsx"
+    "src/runtime.tsx",
+    "!lib/**/*.map"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/plugin-auth/package.json
+++ b/packages/plugin-auth/package.json
@@ -18,7 +18,8 @@
   "files": [
     "lib",
     "template",
-    "src/runtime.tsx"
+    "src/runtime.tsx",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-config/package.json
+++ b/packages/plugin-config/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "config"
+    "config",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-css-assets-local/package.json
+++ b/packages/plugin-css-assets-local/package.json
@@ -14,5 +14,9 @@
   },
   "dependencies": {
     "extract-css-assets-webpack-plugin": "^0.2.5"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-dev-inspector/package.json
+++ b/packages/plugin-dev-inspector/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-faas/package.json
+++ b/packages/plugin-faas/package.json
@@ -14,5 +14,9 @@
   },
   "dependencies": {
     "@midwayjs/faas-dev-pack": "^1.0.0"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-fusion/package.json
+++ b/packages/plugin-fusion/package.json
@@ -34,5 +34,9 @@
   "repository": {
     "type": "http",
     "url": "https://github.com/alibaba/ice/tree/master/packages/plugin-fusion"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-helmet/package.json
+++ b/packages/plugin-helmet/package.json
@@ -11,7 +11,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "react-helmet": "^6.1.0"

--- a/packages/plugin-ice-ssr/package.json
+++ b/packages/plugin-ice-ssr/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "@babel/types": "^7.11.5",

--- a/packages/plugin-jsx-plus/package.json
+++ b/packages/plugin-jsx-plus/package.json
@@ -24,5 +24,9 @@
     "babel-plugin-transform-jsx-slot": "^0.1.1",
     "babel-runtime-jsx-plus": "^0.1.4"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-keep-alive/package.json
+++ b/packages/plugin-keep-alive/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-load-assets/package.json
+++ b/packages/plugin-load-assets/package.json
@@ -18,5 +18,9 @@
   },
   "dependencies": {
     "build-plugin-wrap-code": "^0.1.0"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-logger/package.json
+++ b/packages/plugin-logger/package.json
@@ -13,7 +13,8 @@
   "files": [
     "lib",
     "logger",
-    "src/runtime.ts"
+    "src/runtime.ts",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "fs-extra": "^8.1.0",

--- a/packages/plugin-modular-import/package.json
+++ b/packages/plugin-modular-import/package.json
@@ -14,5 +14,9 @@
   },
   "dependencies": {
     "babel-plugin-import": "^1.11.2"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-moment-locales/package.json
+++ b/packages/plugin-moment-locales/package.json
@@ -15,5 +15,9 @@
     "url": "https://github.com/alibaba/ice/tree/master/packages/plugin-moment-locales"
   },
   "author": "ICE Team",
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-mpa/package.json
+++ b/packages/plugin-mpa/package.json
@@ -10,7 +10,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-prerender/package.json
+++ b/packages/plugin-prerender/package.json
@@ -17,5 +17,9 @@
   },
   "devDependencies": {
     "build-scripts": "^1.1.0-5"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-react-app/package.json
+++ b/packages/plugin-react-app/package.json
@@ -47,5 +47,9 @@
     "type": "http",
     "url": "https://github.com/alibaba/ice/tree/master/packages/plugin-react-app"
   },
-  "gitHead": "07ac7bb07162aac8c90778dd1de4a2060f8df498"
+  "gitHead": "07ac7bb07162aac8c90778dd1de4a2060f8df498",
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-rematch/package.json
+++ b/packages/plugin-rematch/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "src/runtime.tsx"
+    "src/runtime.tsx",
+    "!lib/**/*.map"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/plugin-request/package.json
+++ b/packages/plugin-request/package.json
@@ -14,7 +14,8 @@
     "lib",
     "request",
     "template",
-    "src/runtime.ts"
+    "src/runtime.ts",
+    "!lib/**/*.map"
   ],
   "dependencies": {
     "@ahooksjs/use-request": "^2.0.0",

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -33,7 +33,8 @@
   "files": [
     "lib",
     "src",
-    "templates"
+    "templates",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-service/package.json
+++ b/packages/plugin-service/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "lib",
-    "templates"
+    "templates",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-smart-debug/package.json
+++ b/packages/plugin-smart-debug/package.json
@@ -15,5 +15,9 @@
   "dependencies": {
     "build-plugin-load-assets": "^0.1.3",
     "build-plugin-wrap-code": "^0.1.0"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/plugin-stark-module/package.json
+++ b/packages/plugin-stark-module/package.json
@@ -7,7 +7,8 @@
     "lib",
     "templates",
     "test",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!lib/**/*.map"
   ],
   "scripts": {
     "clean": "rimraf lib",

--- a/packages/plugin-store/package.json
+++ b/packages/plugin-store/package.json
@@ -13,7 +13,8 @@
   "files": [
     "lib",
     "src/types",
-    "src/runtime.tsx"
+    "src/runtime.tsx",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/plugin-theme/package.json
+++ b/packages/plugin-theme/package.json
@@ -9,7 +9,8 @@
   "files": [
     "lib",
     "template",
-    "src/runtime.tsx"
+    "src/runtime.tsx",
+    "!lib/**/*.map"
   ],
   "author": "ice-admin@alibaba-inc.com",
   "license": "MIT",

--- a/packages/plugin-wrap-code/package.json
+++ b/packages/plugin-wrap-code/package.json
@@ -21,5 +21,9 @@
   },
   "peerDependencies": {
     "webpack": "^4.0.0"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/react-app-renderer/package.json
+++ b/packages/react-app-renderer/package.json
@@ -24,7 +24,8 @@
     "create-app-shared": "^1.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/resolve-sass-import/package.json
+++ b/packages/resolve-sass-import/package.json
@@ -18,5 +18,9 @@
     "fs-extra": "^8.1.0",
     "loader-utils": "^1.2.3",
     "resolve": "^1.19.0"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/swc-loader/package.json
+++ b/packages/swc-loader/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/webpack-dev-mock/package.json
+++ b/packages/webpack-dev-mock/package.json
@@ -30,5 +30,9 @@
   },
   "devDependencies": {
     "express": "^4.16.3"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/webpack-dev-mock/tsconfig.json
+++ b/packages/webpack-dev-mock/tsconfig.json
@@ -5,4 +5,5 @@
     "rootDir": "src",
     "outDir": "lib"
   },
+  "exclude": ["demo"]
 }

--- a/packages/webpack-loader-skin/package.json
+++ b/packages/webpack-loader-skin/package.json
@@ -23,5 +23,9 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/packages/webpack-plugin-extract-css-assets/package.json
+++ b/packages/webpack-plugin-extract-css-assets/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "files": [
-    "lib/"
+    "lib/",
+    "!lib/**/*.map"
   ],
   "repository": {
     "type": "http",

--- a/packages/webpack-plugin-extract-css-assets/tsconfig.json
+++ b/packages/webpack-plugin-extract-css-assets/tsconfig.json
@@ -5,4 +5,5 @@
     "rootDir": "src",
     "outDir": "lib"
   },
+  "exclude": ["test"]
 }

--- a/packages/webpack-plugin-import/package.json
+++ b/packages/webpack-plugin-import/package.json
@@ -18,5 +18,9 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "lib",
+    "!lib/**/*.map"
+  ]
 }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,8 +4,9 @@
     "jsx": "react",
     "experimentalDecorators": true,
     "declaration": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true
   },
 }


### PR DESCRIPTION
## 增强 packages 调试能力

### 背景

在调试 icejs 中的 package 时，大部分都是用 console.log 或者 debugger 调试 icejs 的 package，目前暂不支持在 VS Code 中进行断点调试，查看上下文的信息有点麻烦

### 方案
编译 packages js 和 ts 代码时，生成 sourceMap，这样 VS Code Debug 可以通过编译后的文件找到源代码并使得在源代码中设置的断点生效

### 效果图
![2021-07-28 14-58-22 2021-07-28 14_59_01](https://user-images.githubusercontent.com/44047106/127278230-eda48921-6192-4bed-90ec-23def3816da8.gif)
