### PR TITLE
Fix: basic-plugin-auth export type

### DIFF
--- a/packages/plugin-auth/template/index.tsx.ejs
+++ b/packages/plugin-auth/template/index.tsx.ejs
@@ -35,6 +35,6 @@ export {
   useAuth,
   withAuth,
   Provider,
-
-  IAuth
 };
+
+export type { IAuth }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25416941/128656301-3d42c918-0d54-40ad-aa4b-6f5dd59700bd.png)
修复 webpack 模式下 basic-plugin-auth 插件的类型导出问题