### PR TITLE
fix: only pass `modules` to css module rule

### DIFF
--- a/packages/build-user-config/src/userConfig/cssLoaderOptions.js
+++ b/packages/build-user-config/src/userConfig/cssLoaderOptions.js
@@ -1,5 +1,7 @@
 module.exports = (config, cssLoaderOptions) => {
   if (cssLoaderOptions) {
+    const {modules, ...restOptions} = cssLoaderOptions;
+
     [
       'scss',
       'scss-module',
@@ -12,12 +14,14 @@ module.exports = (config, cssLoaderOptions) => {
       'less-global',
     ].forEach(rule => {
       if (config.module.rules.get(rule)) {
+        const isCSSModule = /\-module$/.test(rule);
+
         config.module
           .rule(rule)
           .use('css-loader')
           .tap((options) => ({
             ...options,
-            ...cssLoaderOptions,
+            ...(isCSSModule ? cssLoaderOptions : restOptions),
           }));
       }
     });


### PR DESCRIPTION
如果用户在 cssLoaderOptions 中传入了 `modules` 配置项，会导致全部的 css rules 都应用 css modules，这个 PR 对 `modules` 配置进行了处理，只传给 `*-module` 的规则