### PR TITLE
fix: globby pattern do not support path of win32

### DIFF
--- a/packages/icejs/package.json
+++ b/packages/icejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice.js",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "description": "command line interface and builtin plugin for icejs",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@alib/build-scripts": "^0.1.13",
-    "build-plugin-app-core": "1.4.9",
+    "build-plugin-app-core": "1.4.10",
     "build-plugin-helmet": "1.0.2",
     "build-plugin-ice-auth": "1.7.4",
     "build-plugin-ice-config": "1.8.2",

--- a/packages/plugin-app-core/CHANGELOG.md
+++ b/packages/plugin-app-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.10
+
+- [fix] globby pattern do not support path of win32
+
 ## 1.4.9
 
 - [fix] ignore project type when get source file

--- a/packages/plugin-app-core/package.json
+++ b/packages/plugin-app-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-app-core",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "the core plugin for icejs and raxjs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-app-core/src/utils/getRoutes.ts
+++ b/packages/plugin-app-core/src/utils/getRoutes.ts
@@ -30,7 +30,7 @@ function getRoutes({ rootDir, tempDir, configPath, projectType, isMpa, srcDir }:
 
   const routesPath = configPath
     ? path.join(rootDir, configPath)
-    : getSourceFile(path.join(srcDir, 'routes'), rootDir);
+    : getSourceFile(`${srcDir}/routes`, rootDir);
 
   // 配置式路由
   const configPathExists = fse.existsSync(routesPath);


### PR DESCRIPTION
win32 下 path.join 的路径 `src\\routes` 作为 globby 的匹配规则无法正确查找到路由文件。
Close #4611