### PR TITLE
fix: windows build error in vite mode

### DIFF
--- a/packages/vite-service/src/plugins/html.ts
+++ b/packages/vite-service/src/plugins/html.ts
@@ -3,6 +3,7 @@ import { template as templateComplier, set } from 'lodash';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import cheerio from 'cheerio';
+import { formatPath } from '@builder/app-helpers';
 
 const getHtmlContent = ({
   template,
@@ -51,12 +52,14 @@ export const htmlPlugin = ({ filename, template, entry, rootDir, templateParamet
     template,
     templateParameters,
   });
-
+  // vite will get relative path by `path.posix.relative(config.root, id)`
+  // path.posix.relative will get error path when pass relative path of index html
+  const absoluteHtmlPath = formatPath(path.join(rootDir, filename));
   return {
     name: `vite-plugin-html-${pageName}`,
     enforce: 'pre',
     config(cfg) {
-      cfg.build = set(cfg.build, `rollupOptions.input.${pageName}`, filename);
+      cfg.build = set(cfg.build, `rollupOptions.input.${pageName}`, absoluteHtmlPath);
     },
     resolveId(id) {
       if (id.includes('.html')) {
@@ -65,7 +68,7 @@ export const htmlPlugin = ({ filename, template, entry, rootDir, templateParamet
       return null;
     },
     load(id) {
-      if (id === filename) {
+      if (id === absoluteHtmlPath) {
         return html;
       }
       return null;


### PR DESCRIPTION
windows 下如果传入的 html 地址为相对路径，通过 path.posix.relative 获取值会有问题