### PR TITLE
fix: add dependency of react-router-dom to fix yarn install

### DIFF
--- a/packages/plugin-react-app/package.json
+++ b/packages/plugin-react-app/package.json
@@ -34,6 +34,7 @@
     "react-app-renderer": "^3.0.0",
     "react-dev-utils": "^11.0.0",
     "react-refresh": "^0.10.0",
+    "react-router-dom": "^5.1.2",
     "vite-plugin-component-style": "^1.0.0",
     "webpack-plugin-import": "^0.2.6"
   },


### PR DESCRIPTION
通过 build-plugin-router 和 build-plugin-react-app 依赖相同版本的 react-router-dom 方式修复 yarn 安装无法找到依赖的问题