### PR TITLE
fix: alias in mode vite

### DIFF
--- a/packages/plugin-router/CHANGELOG.md
+++ b/packages/plugin-router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- [fix] optimize alias for `react-router-dom`
+
 ## 2.0.1
 
 - [fix] bump version of `@builder/pack`

--- a/packages/plugin-router/package.json
+++ b/packages/plugin-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-ice-router",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "build-plugin-ice-router",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-router/src/index.ts
+++ b/packages/plugin-router/src/index.ts
@@ -57,7 +57,9 @@ const plugin = ({ context, onGetWebpackConfig, modifyUserConfig, getValue, apply
 
     // alias for react-router-dom
     const routerName = 'react-router-dom';
-    config.resolve.alias.set(routerName, require.resolve(routerName));
+    const packagePath = require.resolve(`${routerName}/package.json`);
+    // use react-router-dom path while react-router-dom has module field in package.json
+    config.resolve.alias.set(routerName, path.dirname(packagePath));
 
     // config historyApiFallback for router type browser
     config.devServer.set('historyApiFallback', true);

--- a/packages/vite-service/CHANGELOG.md
+++ b/packages/vite-service/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.2
+
+- [fix] alias path allow with node_modules
+
 ## 1.1.1
 
 - [fix] sourcemap does not work with mode vite

--- a/packages/vite-service/package.json
+++ b/packages/vite-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/vite-service",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "vite implementation",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/vite-service/src/wp2vite/config.ts
+++ b/packages/vite-service/src/wp2vite/config.ts
@@ -93,7 +93,8 @@ const configMap: ConfigMap = {
     name: 'resolve.alias',
     transform: (value, ctx) => {
       const { rootDir } = ctx;
-      const blackList = ['webpack/hot', 'node_modules'];
+      // webpack/hot is not necessary in mode vite
+      const blackList = ['webpack/hot'];
       const data: Record<string, any> = Object.keys(value).reduce(
         (acc, key) => {
           if (!blackList.some((word) => value[key]?.includes(word)))


### PR DESCRIPTION
vite 模式下默认过滤了 node_modules 相关的 alias，导致与 webpack 模式差异较大。
对于内置设置的 alias，存在 esm 规范产物的应该优先使用，比如 react-router-dom 包