### PR TITLE
fix: build error when active remoteRuntime

### DIFF
--- a/packages/plugin-react-app/CHANGELOG.md
+++ b/packages/plugin-react-app/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+- [fix] build error when active `remoteRuntime`
+
 ## 2.0.3
 
 - [feat] support apply static loader with query like `?worker|?url|?raw|?worker&inline`

--- a/packages/plugin-react-app/package.json
+++ b/packages/plugin-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-react-app",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The basic webpack configuration for ice project",
   "author": "ice-admin@alibaba-inc.com",
   "main": "lib/index.js",

--- a/packages/plugin-react-app/src/userConfig/remoteRuntime/configApp.ts
+++ b/packages/plugin-react-app/src/userConfig/remoteRuntime/configApp.ts
@@ -61,5 +61,7 @@ export default (api: IPluginAPI, { remoteName, bootstrap, remoteEntry, compilePa
       filepath: path.resolve(runtimeDir, remoteEntry),
       publicPath: `/${runtimePublicPath}`,
     }]).after('HtmlWebpackPlugin');
+    // remove 404 htmlWebpackPlugin while AddAssetHtmlPlugin occurs errors with multi HtmlWebpackPlugin
+    config.plugins.delete('HtmlWebpackPlugin_404');
   });
 };


### PR DESCRIPTION
备选方案：使用 [html-webpack-tags-plugin](https://www.npmjs.com/package/html-webpack-tags-plugin) 替代 AddAssetHtmlPlugin，但由于其代码内部耦合 html-webpack-plugin 的依赖判断（框架内部预编译了 html-webpack-plugin，实际引入为 @builder/pack/deps/html-webpack-plugin），暂时无法直接替换。
考虑应用场景和 404 页面的使用，先通过移除 404 页面生成插件低成本修复