### PR TITLE
fix: 🐛 more elegant way to use `registerAppEnter` & `registerAppLeave`

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.2
+
+- [fix] more elegant way to use `registerAppEnter` & `registerAppLeave`.
+
 ## 2.4.1
 
 - [chore] slove typescript errors when enabling `tsChecker: true`. ([#4800](https://github.com/alibaba/ice/issues/4800))

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-icestark",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/runtime.tsx
+++ b/packages/plugin-icestark/src/runtime.tsx
@@ -60,23 +60,25 @@ const module = ({
       return new Promise(resolve => {
         if (isInIcestark()) {
           if (localIcestarkType === 'normal') {
-            registerAppEnter(() => {
-              const mountNode = getMountNode();
+            // @ts-ignore remove this next time for https://github.com/ice-lab/icestark/pull/440
+            registerAppEnter((props) => {
+              const container = (props && props.container) || getMountNode();
               if (enterRegistration) {
-                enterRegistration(mountNode, App, resolve);
+                enterRegistration(container, App, resolve);
               } else {
-                ReactDOM.render(<App />, mountNode, () => {
+                ReactDOM.render(<App />, container, () => {
                   resolve(true);
                 });
               }
             });
             // make sure the unmount event is triggered
-            registerAppLeave(() => {
-              const mountNode = getMountNode();
+            // @ts-ignore remove this next time for https://github.com/ice-lab/icestark/pull/440
+            registerAppLeave((props) => {
+              const container = (props && props.container) || getMountNode();
               if (leaveRegistration) {
-                leaveRegistration(mountNode);
+                leaveRegistration(container);
               } else {
-                ReactDOM.unmountComponentAtNode(mountNode);
+                ReactDOM.unmountComponentAtNode(container);
               }
             });
           } else {


### PR DESCRIPTION
- [x] more elegant way to use `registerAppEnter` & `registerAppLeave`