### PR TITLE
fix: disable default file lint for hmr performace

### DIFF
--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [fix] prevent minimize `.scss` by default.
 - [fix] Regexp for runtime folder
+- [fix] disable default file lint for hmr performance
 
 ## 1.1.4
 

--- a/packages/build-user-config/src/config/user.config.js
+++ b/packages/build-user-config/src/config/user.config.js
@@ -193,11 +193,9 @@ module.exports = [
   {
     name: 'eslint',
     validation: (val) => {
-      // for default value
-      if (val === null) return true;
       return validation('eslint', val, 'boolean|object');
     },
-    defaultValue: null,
+    defaultValue: false,
   },
   {
     name: 'tsChecker',

--- a/packages/build-user-config/src/userConfig/eslint.js
+++ b/packages/build-user-config/src/userConfig/eslint.js
@@ -14,7 +14,7 @@ module.exports = (config, eslint, context, { log }) => {
     failOnError: true,
   };
 
-  if (!eslint) {
+  if (eslint === true) {
     enableESlint = true;
     // lint only changed files, skip lint on start
     eslintOptions.lintDirtyModulesOnly = true;

--- a/packages/vite-service/src/wp2vite/index.ts
+++ b/packages/vite-service/src/wp2vite/index.ts
@@ -176,7 +176,7 @@ export const wp2vite = (context: Context): InlineConfig => {
   };
   if (userConfig.eslint !== false) {
     let eslintOptions = { ignoreInitial: false };
-    if (!userConfig.eslint) {
+    if (userConfig.eslint === true) {
       // lint only changed files, skip lint on start
       eslintOptions.ignoreInitial = true;
     } else {


### PR DESCRIPTION
通过 `"eslint": true` 快捷开启