### PR TITLE
fix: fail to copy dts file to correct dir

### DIFF
--- a/packages/icejs/bin/copy-dts-to-ice-temp.js
+++ b/packages/icejs/bin/copy-dts-to-ice-temp.js
@@ -1,8 +1,10 @@
 const path = require('path');
 const fs = require('fs');
 
+const projectRootDir = process.env.INIT_CWD; // the original working directory that npm was executed from
 const dtsBundleFile = 'ice.d.ts';
-const iceTempDir = path.join(process.cwd(), '.ice');
+
+const iceTempDir = path.join(projectRootDir, '.ice');
 const iceTempDtsBundlePath = path.join(iceTempDir, dtsBundleFile);
 const dtsBundlePath = path.join(__dirname, '..', 'lib', dtsBundleFile);
 


### PR DESCRIPTION
当执行 postinstall 脚本时，process.cwd() 拿到的是该依赖的路径`/my-project/node_modules/ice.js`，而不是 `/my-project`，导致复制 ice.d.ts 类型声明文件到错误的目录 (`/my-project/node_modules/ice.js/.ice/ice.d.ts`)

参考：
- https://stackoverflow.com/questions/34781630/how-to-automatically-copy-files-from-package-to-local-directory-via-postinstall
- https://docs.npmjs.com/cli/v8/commands/npm-run-script#description