### PR TITLE
fix: match the correct pathname of mock server

### DIFF
--- a/packages/webpack-dev-mock/CHANGELOG.md
+++ b/packages/webpack-dev-mock/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+
+- [fix] match the correct pathname of request
+
 ## 1.3.1
 
 - [fix] update dependencies

--- a/packages/webpack-dev-mock/package.json
+++ b/packages/webpack-dev-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dev-mock",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Webpack devserver middleware mock server",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/webpack-dev-mock/src/matchPath.ts
+++ b/packages/webpack-dev-mock/src/matchPath.ts
@@ -20,7 +20,7 @@ function decodeParam(val) {
 function matchPath(req, mockConfig) {
   const { method: reqMethod } = req;
   // compatible with http server
-  const reqPath = req.path || req.url;
+  const reqPath = req?._parsedUrl?.pathname || req.path || req.url;
   for (let m = 0; m < mockConfig.length; m += 1) {
     const mock = mockConfig[m];
     const { path: mockPath, method: mockMethod } = mock;


### PR DESCRIPTION
vite 模式下不存在 req.path，而 req.url 会带上 query 参数，统一通过 _parseUrl 上的内容进行获取
Fix #4894