### PR TITLE
fix: compatible with disable runtime when config mpa

### DIFF
--- a/packages/icejs/package.json
+++ b/packages/icejs/package.json
@@ -29,7 +29,7 @@
     "build-plugin-ice-auth": "2.0.0",
     "build-plugin-ice-config": "2.0.1",
     "build-plugin-ice-logger": "2.0.0",
-    "build-plugin-ice-mpa": "2.0.1",
+    "build-plugin-ice-mpa": "2.0.2",
     "build-plugin-ice-request": "2.0.0",
     "build-plugin-ice-router": "2.0.3",
     "build-plugin-ice-ssr": "3.0.3",

--- a/packages/plugin-mpa/CHANGELOG.md
+++ b/packages/plugin-mpa/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 2.0.2
+
+- [fix] compatible with the situation when config both `disableRuntime` and `mpa`
+
 ## 2.0.1
 
 - [feat] support disable rewrite rules for FaaS render

--- a/packages/plugin-mpa/package.json
+++ b/packages/plugin-mpa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-ice-mpa",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "enable mpa project for icejs framework",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-mpa/src/index.ts
+++ b/packages/plugin-mpa/src/index.ts
@@ -100,15 +100,17 @@ const plugin: IPlugin = (api) => {
     }
     // modify entry
     modifyUserConfig('entry', finalMPAEntries);
-    applyMethod('addImportDeclaration', {
-      multipleSource: {
-        runApp: redirectEntries.map(({ entryPath, runAppPath }) => ({
-          filename: entryPath,
-          value: runAppPath,
-          type: 'normal',
-        })),
-      },
-    });
+    if (redirectEntries.length > 0) {
+      applyMethod('addImportDeclaration', {
+        multipleSource: {
+          runApp: redirectEntries.map(({ entryPath, runAppPath }) => ({
+            filename: entryPath,
+            value: runAppPath,
+            type: 'normal',
+          })),
+        },
+      });
+    }
     // set page template
     onGetWebpackConfig(config => {
       setPageTemplate(rootDir, entries, (mpa as any).template || {}, config, setValue);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,9 +5044,9 @@ build-scripts-config@^3.0.0:
     webpack-simple-progress-plugin "0.0.4"
 
 build-scripts@^1.0.0, build-scripts@^1.0.1, build-scripts@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/build-scripts/-/build-scripts-1.2.0.tgz#9be18aa73d6a5f5111fe81043038aa75e52006a8"
-  integrity sha512-OkSCr4iIre4KcN8WOO46uY+mvZjmNUuonim3niMDY8jf4L117h23JATm/m0xLFxe3LJ2KXCscAKK6VKbU4I/ow==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/build-scripts/-/build-scripts-1.2.1.tgz#626bf4343c425124320bea0189bfdafa6501280e"
+  integrity sha512-qumrwcAO1SwhN23Nn98gkHCmZw+PZ4nGjQdBp2vfQSq8/rElqXBP4SlgfbX7RP0ZfRZdUXeUgfRegco48XnJ6g==
   dependencies:
     address "^1.1.0"
     camelcase "^5.3.1"


### PR DESCRIPTION
disableRuntime 的情况下 `addImportDeclaration` 未注册，并且 `redirectEntries` 为空（没有在 .ice 目录下生成入口）
Fix #4907