### PR TITLE
fix: re-calculate webpack cache id when config disableRuntime

### DIFF
--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.8
+
+- [fix] re-calculate webpack cache id when config `disableRuntime`
+
 ## 1.1.7
 
 - [fix] undefined `postcssOptions.plugins`

--- a/packages/build-user-config/package.json
+++ b/packages/build-user-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/user-config",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Includes methods which are releated to set base user config for framework",
   "homepage": "",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "fs-extra": "^8.1.0",
     "fork-ts-checker-webpack-plugin": "^5.0.5",
     "loader-utils": "^2.0.0",
+    "object-hash": "^2.2.0",
     "regenerator-runtime": "^0.13.3",
     "react-dev-utils": "^11.0.4",
     "webpack-dev-mock": "^1.0.1",

--- a/packages/build-user-config/src/webpack5.js
+++ b/packages/build-user-config/src/webpack5.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const hash = require('object-hash');
 
 // built-in webpack 5 abilities
 module.exports = (config, api) => {
@@ -6,7 +7,7 @@ module.exports = (config, api) => {
   const { userConfig, rootDir, webpack } = context;
   // filesystem cache
   if (!process.env.DISABLE_FS_CACHE) {
-    const version = getValue('WEBPACK_CACHE_ID');
+    const version = getValue('WEBPACK_CACHE_ID') || hash(userConfig);
     const cacheConfig = {
       cache: {
         type: 'filesystem',


### PR DESCRIPTION
Fix #4971 