### PR TITLE
fix(vite-service): fix transform for no proxy

### DIFF
--- a/packages/vite-service/src/wp2vite/config.ts
+++ b/packages/vite-service/src/wp2vite/config.ts
@@ -191,9 +191,15 @@ const configMap: ConfigMap = {
     transform: (value: Record<string, any>[]) => {
       // vite proxy do not support config of onProxyRes, onError, logLevel, pathRewrite
       // transform devServer.proxy to server.proxy
+      let hasProxy = false;
       const proxyConfig = {};
       (value || []).forEach(({ context, enable, onProxyRes, onError, pathRewrite, ...rest }) => {
         if (enable !== false) {
+          if (!hasProxy) {
+            hasProxy = true;
+            console.log('Proxy setting detected. HTTPS will be downgraded to TLS only (HTTP/2 will be disabled)');
+          }
+
           proxyConfig[context] = {
             ...rest,
             rewrite: (requestPath: string) => {
@@ -215,7 +221,7 @@ const configMap: ConfigMap = {
           };
         }
       });
-      return proxyConfig;
+      return hasProxy ? proxyConfig : undefined;
     },
   },
   'devServer.https': 'server.https',


### PR DESCRIPTION
Vite would downgrade https server from http2 to tls-only if `server.proxy` is truthy (See [vite code](https://github.com/vitejs/vite/blob/61d076ae0ce724ffc5242358d067f7b1438d24bb/packages/vite/src/node/http.ts#L85)). 

As `{}` is a truthy value, even there is no proxy setting, https would be downgraded.