### PR TITLE
Release: plugin-icestark 2.5.1

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+- [fix] output of assets should be prefixed `index` instead of `app`, which break changed by version 2.5.0.
+
 ## 2.5.0
 
 - [feat] use `vite-plugin-index-html` as a substitute in Vite mode.

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/core": "^7.15.5",
     "@babel/types": "^7.11.5",
+    "@builder/app-helpers": "^2.4.2",
     "@ice/stark": "^2.0.0",
     "@ice/stark-app": "^1.2.0",
     "cheerio": "^1.0.0-rc.10",

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-icestark",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/entryHelper.ts
+++ b/packages/plugin-icestark/src/entryHelper.ts
@@ -1,3 +1,4 @@
+import { formatPath } from '@builder/app-helpers';
 /*
 {
   index: [
@@ -17,16 +18,22 @@ export const getEntryFiles = (entries: object): string[] => {
     .reduce((pre, next) => {
       // The type of `entries` is ChainedMap, get values by values()
       const value = entries[next].values();
+      const formatedValue = formatPath((Array.isArray(value) ? value.slice(-1)[0] : value));
       return [
         ...pre,
-        ...(Array.isArray(value) ? value : [value])
+        formatedValue
       ];
     }, []);
 };
 
-/**
- * Get the latest value when running spa
- */
-export const getEntryForSPA = (entries: object) => {
-  return getEntryFiles(entries).slice(-1)[0];
+export const getEntries = (entries: object) => {
+  return Object.keys(entries)
+    .reduce((pre, next) => {
+      const value = entries[next].values();
+      const formatedValue = formatPath((Array.isArray(value) ? value.slice(-1)[0] : value));
+      return {
+        ...pre,
+        [next]: formatedValue,
+      };
+    }, {});
 };

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -5,7 +5,7 @@ import type { IPlugin, Json } from 'build-scripts';
 import htmlPlugin from 'vite-plugin-index-html';
 import checkEntryFile from './checkEntryFile';
 import lifecyclePlugin from './lifecyclePlugin';
-import { getEntryForSPA } from './entryHelper';
+import { getEntryFiles, getEntries } from './entryHelper';
 
 const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, modifyUserConfig, context, log }, options = {}) => {
   const { uniqueName, umd, library, omitSetLibraryName = false, type } = options as Json;
@@ -66,15 +66,14 @@ const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, modi
       if (mpa || Object.keys(entries).length > 1) {
         log.warn('[plugin-icestark]: MPA is not supported currently.');
       } else {
-        // Get the last file as the actual entry
-        const entryFile = getEntryForSPA(entries);
         modifyUserConfig('vite.plugins', [
           htmlPlugin({
-            entry: entryFile,
+            // @ts-ignore
+            entry: getEntries(entries),
             template: path.resolve(rootDir, 'public/index.html'),
             preserveEntrySignatures: 'exports-only'
           }),
-          lifecyclePlugin(entryFile)
+          lifecyclePlugin(getEntryFiles(entries))
         ], { deepmerge: true });
       }
     }

--- a/packages/plugin-icestark/src/lifecyclePlugin.ts
+++ b/packages/plugin-icestark/src/lifecyclePlugin.ts
@@ -6,14 +6,14 @@ import type { ParserPlugin } from '@babel/parser';
  * Webpack's entry would be { index: ['react-dev-utils/webpackHotDevClient.js', '/src/app''] }
  * in dev mode.
  */
-const lifecyclePlugin = (entry: string): Plugin => {
+const lifecyclePlugin = (entries: string[]): Plugin => {
 
   return ({
     name: 'vite-plugin-icestark-lifecycle',
     enforce: 'pre',
 
     async transform(code, id) {
-      const isEntryFile = id.includes(entry);
+      const isEntryFile = entries.some(entry => id.includes(entry));
 
       if (!isEntryFile) {
         return;

--- a/packages/plugin-icestark/tests/entryHelper.spec.ts
+++ b/packages/plugin-icestark/tests/entryHelper.spec.ts
@@ -1,0 +1,55 @@
+import { getEntryFiles, getEntries } from '../src/entryHelper';
+
+describe('entry-helper', () => {
+  test('start', () => {
+    const entries = {
+      index: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+        ]
+      }
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+    })
+  })
+
+  test('start-single-string', () => {
+    const entries = {
+      index: {
+        values: () => '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+      }
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+    })
+  })
+
+  test('multi-entries', () => {
+    const entries = {
+      index: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+        ]
+      },
+      test: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/test'
+        ]
+      },
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app', '/demo-project/icestark-demo/ice-browser-var/child/src/test'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app',
+      test: '/demo-project/icestark-demo/ice-browser-var/child/src/test'
+    })
+  })
+})

--- a/packages/vite-plugin-index-html/CHANGELOG.md
+++ b/packages/vite-plugin-index-html/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+- [fix] unexpected entry with too long root dir.
+- [fix] support for Win32 platforms is provided.
+
 ## 2.0.0
 
 Breakchanges: `preserveEntrySignatures` no longer used as default to meet Vite's output format. You should configure `preserveEntrySignatures` explicitly to preserve entry signatures.

--- a/packages/vite-plugin-index-html/package.json
+++ b/packages/vite-plugin-index-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-index-html",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vite Plugin that simplifies creation of HTML files to serve your bundles",
   "main": "lib/index.js",
   "keywords": [

--- a/packages/vite-plugin-index-html/src/utils.ts
+++ b/packages/vite-plugin-index-html/src/utils.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 /**
  * Check if link is absolute url
  * @param url
@@ -12,4 +14,37 @@ export const isAbsoluteUrl = (url: string): boolean => {
  */
 export const addTrailingSlash = (str: string): string => {
   return str.substr(-1) === '/' ? str : `${str}/`;
+};
+
+/**
+ * format win32 path
+ * @param pathStr
+ * @returns
+ */
+export const formatPath = (pathStr: string): string => {
+  return process.platform === 'win32' ? pathStr.split(path.sep).join('/') : pathStr;
+};
+
+export const getEntryUrl = (entries: string | Record<string, string>) => {
+  if (typeof entries === 'string') {
+    return entries;
+  }
+
+  const theFirstKeyGotten = Object.keys(entries)[0];
+  return entries[theFirstKeyGotten];
+};
+
+/**
+ * Currently single entry is supported.
+ * @param entries
+ * @returns
+ */
+export const isSingleEntry = (entries: string | Record<string, string>) => {
+  if (
+    typeof entries === 'object'
+    && Object.keys(entries).length > 1
+  ) {
+    return false;
+  }
+  return true;
 };

--- a/packages/vite-plugin-index-html/tests/utils.ts
+++ b/packages/vite-plugin-index-html/tests/utils.ts
@@ -1,0 +1,25 @@
+import { getTheFirstEntry, isSingleEntry } from '../src/utils';
+
+describe('vite-plugin-index-html-utils', () => {
+  test('entry', () => {
+    let entry: string | Record<string, string> = './src/main.tsx';
+
+    expect(isSingleEntry(entry)).toBeTruthy();
+    expect(getTheFirstEntry(entry)).toBe('./src/main.tsx');
+
+    entry = {
+      index: './src/main.tsx'
+    }
+
+    expect(isSingleEntry(entry)).toBeTruthy();
+    expect(getTheFirstEntry(entry)).toBe('./src/main.tsx');
+
+    entry = {
+      index: './src/main.tsx',
+      test: './src/test.tsx'
+    }
+
+    expect(isSingleEntry(entry)).toBeFalsy();
+  })
+
+});


### PR DESCRIPTION
- [x] output of assets should be prefixed index instead of app, which break changed by version 2.5.0.
- [x] support for Win32 platforms. related to https://github.com/ice-lab/icestark/issues/471