### PR TITLE
Fix/object input

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+- [fix] output of assets should be prefixed `index` instead of `app`, which break changed by version 2.5.0.
+
 ## 2.5.0
 
 - [feat] use `vite-plugin-index-html` as a substitute in Vite mode.

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/core": "^7.15.5",
     "@babel/types": "^7.11.5",
+    "@builder/app-helpers": "^2.4.2",
     "@ice/stark": "^2.0.0",
     "@ice/stark-app": "^1.2.0",
     "cheerio": "^1.0.0-rc.10",

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-icestark",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/entryHelper.ts
+++ b/packages/plugin-icestark/src/entryHelper.ts
@@ -19,14 +19,18 @@ export const getEntryFiles = (entries: object): string[] => {
       const value = entries[next].values();
       return [
         ...pre,
-        ...(Array.isArray(value) ? value : [value])
+        ...(Array.isArray(value) ? value.slice(-1) : [value])
       ];
     }, []);
 };
 
-/**
- * Get the latest value when running spa
- */
-export const getEntryForSPA = (entries: object) => {
-  return getEntryFiles(entries).slice(-1)[0];
+export const getEntries = (entries: object) => {
+  return Object.keys(entries)
+    .reduce((pre, next) => {
+      const value = entries[next].values();
+      return {
+        ...pre,
+        [next]: Array.isArray(value) ? value.slice(-1)[0] : value
+      };
+    }, {});
 };

--- a/packages/plugin-icestark/src/entryHelper.ts
+++ b/packages/plugin-icestark/src/entryHelper.ts
@@ -1,3 +1,4 @@
+import { formatPath } from '@builder/app-helpers';
 /*
 {
   index: [
@@ -17,9 +18,10 @@ export const getEntryFiles = (entries: object): string[] => {
     .reduce((pre, next) => {
       // The type of `entries` is ChainedMap, get values by values()
       const value = entries[next].values();
+      const formatedValue = formatPath((Array.isArray(value) ? value.slice(-1)[0] : value));
       return [
         ...pre,
-        ...(Array.isArray(value) ? value.slice(-1) : [value])
+        formatedValue
       ];
     }, []);
 };
@@ -28,9 +30,10 @@ export const getEntries = (entries: object) => {
   return Object.keys(entries)
     .reduce((pre, next) => {
       const value = entries[next].values();
+      const formatedValue = formatPath((Array.isArray(value) ? value.slice(-1)[0] : value));
       return {
         ...pre,
-        [next]: Array.isArray(value) ? value.slice(-1)[0] : value
+        [next]: formatedValue,
       };
     }, {});
 };

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -5,7 +5,7 @@ import type { IPlugin, Json } from 'build-scripts';
 import htmlPlugin from 'vite-plugin-index-html';
 import checkEntryFile from './checkEntryFile';
 import lifecyclePlugin from './lifecyclePlugin';
-import { getEntryForSPA } from './entryHelper';
+import { getEntryFiles, getEntries } from './entryHelper';
 
 const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, modifyUserConfig, context, log }, options = {}) => {
   const { uniqueName, umd, library, omitSetLibraryName = false, type } = options as Json;
@@ -66,15 +66,14 @@ const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, modi
       if (mpa || Object.keys(entries).length > 1) {
         log.warn('[plugin-icestark]: MPA is not supported currently.');
       } else {
-        // Get the last file as the actual entry
-        const entryFile = getEntryForSPA(entries);
         modifyUserConfig('vite.plugins', [
           htmlPlugin({
-            entry: { index: entryFile },
+            // @ts-ignore
+            entry: getEntries(entries),
             template: path.resolve(rootDir, 'public/index.html'),
             preserveEntrySignatures: 'exports-only'
           }),
-          lifecyclePlugin(entryFile)
+          lifecyclePlugin(getEntryFiles(entries))
         ], { deepmerge: true });
       }
     }

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -70,7 +70,7 @@ const plugin: IPlugin = async ({ onGetWebpackConfig, getValue, applyMethod, modi
         const entryFile = getEntryForSPA(entries);
         modifyUserConfig('vite.plugins', [
           htmlPlugin({
-            entry: entryFile,
+            entry: { index: entryFile },
             template: path.resolve(rootDir, 'public/index.html'),
             preserveEntrySignatures: 'exports-only'
           }),

--- a/packages/plugin-icestark/src/lifecyclePlugin.ts
+++ b/packages/plugin-icestark/src/lifecyclePlugin.ts
@@ -6,14 +6,14 @@ import type { ParserPlugin } from '@babel/parser';
  * Webpack's entry would be { index: ['react-dev-utils/webpackHotDevClient.js', '/src/app''] }
  * in dev mode.
  */
-const lifecyclePlugin = (entry: string): Plugin => {
+const lifecyclePlugin = (entries: string[]): Plugin => {
 
   return ({
     name: 'vite-plugin-icestark-lifecycle',
     enforce: 'pre',
 
     async transform(code, id) {
-      const isEntryFile = id.includes(entry);
+      const isEntryFile = entries.some(entry => id.includes(entry));
 
       if (!isEntryFile) {
         return;

--- a/packages/plugin-icestark/tests/entryHelper.spec.ts
+++ b/packages/plugin-icestark/tests/entryHelper.spec.ts
@@ -1,0 +1,55 @@
+import { getEntryFiles, getEntries } from '../src/entryHelper';
+
+describe('entry-helper', () => {
+  test('start', () => {
+    const entries = {
+      index: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+        ]
+      }
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+    })
+  })
+
+  test('start-single-string', () => {
+    const entries = {
+      index: {
+        values: () => '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+      }
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+    })
+  })
+
+  test('multi-entries', () => {
+    const entries = {
+      index: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/app'
+        ]
+      },
+      test: {
+        values: () => [
+          '/icestark-demo/ice-browser-var/child/node_modules/_react-dev-utils@10.2.1@react-dev-utils/webpackHotDevClient.js',
+          '/demo-project/icestark-demo/ice-browser-var/child/src/test'
+        ]
+      },
+    };
+
+    expect(getEntryFiles(entries)).toEqual(['/demo-project/icestark-demo/ice-browser-var/child/src/app', '/demo-project/icestark-demo/ice-browser-var/child/src/test'])
+    expect(getEntries(entries)).toEqual({
+      index: '/demo-project/icestark-demo/ice-browser-var/child/src/app',
+      test: '/demo-project/icestark-demo/ice-browser-var/child/src/test'
+    })
+  })
+})


### PR DESCRIPTION
- [x] output of assets should be prefixed `index` instead of `app`, which break changed by version 2.5.0.