### PR TITLE
fix: wrong matching logic in pluginIndexHtml

### DIFF
--- a/packages/vite-plugin-index-html/src/utils.ts
+++ b/packages/vite-plugin-index-html/src/utils.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 
+const { posix } = path;
+
 /**
  * Check if link is absolute url
  * @param url
@@ -48,3 +50,13 @@ export const isSingleEntry = (entries: string | Record<string, string>) => {
   }
   return true;
 };
+
+export function getRelativePath(rootDir: string, _path: string): string {
+  const _rootDir = formatPath(rootDir);
+  let relativePath = formatPath(_path);
+
+  if (_path.includes(_rootDir)) {
+    relativePath = `/${posix.relative(_rootDir, relativePath)}`;
+  }
+  return relativePath;
+}


### PR DESCRIPTION
## 问题

我在使用 icestark 的 vite demo 时，发现 react 子应用加载会报错，后来发现是 vite-plugin-index-html 在打包时，没有删除  <script type="module" src="/src/main.tsx"></script>；
 
我看了下，是 icestark-vite-react 的 vite.config.ts 文件中配置的是  src/main.tsx；而 “index.html” 中的是 /src/main.tsx，  导致 vite-plugin-index-html 中的字符串匹配失败（如下图）；
 
![image.png](https://s2.loli.net/2021/12/31/f23NEOCXRL7jMdP.png);

## 解决

这里_entry 和 src 都可能填写绝对或相对地址，所以俩变量哪边的 length 更大就不好说了，这导致正则和 includes 都不好使了，我这里把这个 _entry 补了下，当它是前面不是 `./` 或者  `/` 的时候，在前面拼一下 `./`，这样至少 length 不会比 src 少，includes 可以成功；

另外我顺便抽离了 getRelativePath 方法到 utils.ts 里了，同时改了方法名，getRelativedPath 貌似是错别字；

> 我这个修改方法，没覆盖所有场景(绝对或相对地址)，后面我再抽时间写个方法优化下吧；

