### PR TITLE
feat(build-plugin-fusion): update postcss

### DIFF
--- a/packages/plugin-fusion/CHANGELOG.md
+++ b/packages/plugin-fusion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.23
+
+- [feat] update postcss version
+
 ## 0.1.22
 
 - [fix] remove alias config of `~` for vite

--- a/packages/plugin-fusion/package.json
+++ b/packages/plugin-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-fusion",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "plugin for build scripts while use fusion component",
   "main": "lib/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "find-root": "^1.1.0",
     "ice-skin-loader": "^0.3.0",
     "lodash": "^4.17.15",
-    "postcss": "^7.0.32",
+    "postcss": "^8.4.6",
     "postcss-plugin-rpx2vw": "^0.0.2",
     "resolve-sass-import": "^0.1.0",
     "semver": "^6.1.0",


### PR DESCRIPTION
from 7.x to 8.x

主要是因为一些第三方工具依赖 postcss >= 8, 升级之后 dedupe 可以减少安装时间和硬盘占用