### PR TITLE
fix: compatible with rax-app devServer when config webpack5

### DIFF
--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+
+- [fix] compatible with rax-app devServer when config `webpack5`
+
 ## 2.2.1
 
 - [fix] compatible with dev server

--- a/packages/build-user-config/package.json
+++ b/packages/build-user-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/user-config",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Includes methods which are releated to set base user config for framework",
   "homepage": "",
   "license": "MIT",

--- a/packages/build-user-config/src/userConfig/mock.js
+++ b/packages/build-user-config/src/userConfig/mock.js
@@ -5,8 +5,11 @@ module.exports = (config, mock, context) => {
   const { commandArgs, command, webpack } = context;
   const isWebpack4 = /^4\./.test(webpack.version);
   if (!commandArgs.disableMock && command === 'start' && mock) {
+    // __FRAMEWORK_VERSION__ only defined in ice.js
+    // FIXME: remove process.env.__FRAMEWORK_VERSION__ when rax-app update @builder/pack
+    const hookName = process.env.__FRAMEWORK_VERSION__ ? 'setupMiddlewares' : 'onBeforeSetupMiddleware';
     // Compat with webpack4
-    const beforeHookName = isWebpack4 ? 'before' : 'setupMiddlewares';
+    const beforeHookName = isWebpack4 ? 'before' : hookName;
     const originalDevServeBefore = config.devServer.get(beforeHookName);
     // replace devServer before function
     config.merge({ devServer: {


### PR DESCRIPTION
兼容 rax-app 在 webpack 5下使用低版本 4.x 的 webpack-dev-server 