### PR TITLE
fix: remoteRuntime container missing

### DIFF
--- a/packages/plugin-react-app/src/userConfig/remoteRuntime/configApp.ts
+++ b/packages/plugin-react-app/src/userConfig/remoteRuntime/configApp.ts
@@ -22,8 +22,7 @@ export default (api: IPluginAPI, { remoteName, bootstrap, remoteEntry, compilePa
       babelPlugins: Array.isArray(modifyConfig.babelPlugins) ? modifyConfig.babelPlugins.concat(remotePlugins) : remotePlugins,
       moduleFederation: {
         name: 'app',
-        remoteType: 'window',
-        remotes: [remoteName],
+        remotes: { [remoteName]: `${remoteName}@/${runtimePublicPath}/${remoteEntry}` },
         shared: [
           'react',
           'react-dom',


### PR DESCRIPTION
#5210 fix remoteRuntime while using preBuilt bundles 
解决 container missing 问题，
但似乎第一次构建的时候并非使用预构建产物，且第二次构建也会编译npm包。
![image](https://user-images.githubusercontent.com/41666009/173034131-867b133c-92ba-45de-b0b1-e130a93d39e9.png)
shared的缘故？