### PR TITLE
fix: prettier format

### DIFF
--- a/packages/icejs/src/getBuiltInPlugins.ts
+++ b/packages/icejs/src/getBuiltInPlugins.ts
@@ -28,13 +28,13 @@ const getBuiltInPlugins: IGetBuiltInPlugins = (userConfig) => {
     'build-plugin-miniapp',
 
     // for ice/react plugins
-    'build-plugin-ice-router',
     'build-plugin-ice-helpers',
     'build-plugin-ice-logger',
     'build-plugin-ice-config',
     'build-plugin-ice-mpa',
     'build-plugin-ice-request',
-    'build-plugin-helmet'
+    'build-plugin-helmet',
+    'build-plugin-ice-router',
   ];
 
   if (userConfig.ssr) {


### PR DESCRIPTION
调整内置插件的顺序，防止生成的样板代码在prettier format 后，模块的导入和导出顺序错乱，导致业务引用模块时报错。

![image](https://user-images.githubusercontent.com/16146970/175241588-066c676f-3feb-4696-bfbd-d14deec6dfaa.png)

![image](https://user-images.githubusercontent.com/16146970/175241620-af5c746b-30d1-4666-b575-e768d48508b9.png)
