### PR TITLE
feat: add forceLocal of extract-css-assets plugin

### DIFF
--- a/packages/plugin-css-assets-local/src/index.js
+++ b/packages/plugin-css-assets-local/src/index.js
@@ -2,7 +2,7 @@ const ExtractCssAssetsWebpackPlugin = require('extract-css-assets-webpack-plugin
 
 module.exports = ({ context, log, onGetWebpackConfig }, options = {}) => {
   const { command } = context;
-  const { outputPath, relativeCssPath, activeInDev } = options;
+  const { outputPath, relativeCssPath, forceLocal, activeInDev } = options;
   // it is increase dev build time by set default activeCommands ['build']
   const activeCommands = activeInDev ? ['start', 'build'] : ['build'];
   if (activeCommands.indexOf(command) > -1) {
@@ -13,6 +13,7 @@ module.exports = ({ context, log, onGetWebpackConfig }, options = {}) => {
         .use(ExtractCssAssetsWebpackPlugin, [{
           outputPath: outputPath || 'assets',
           relativeCssPath: relativeCssPath || '../',
+          forceLocal: forceLocal || false,
         }]);
     });
   }

--- a/packages/webpack-plugin-extract-css-assets/README.md
+++ b/packages/webpack-plugin-extract-css-assets/README.md
@@ -10,6 +10,7 @@
 
 - `outputPath` 默认值： `""` 提取后的文件目录前缀
 - `relativeCssPath` 默认值： `""` 提取的文件后相对于 css 的路径
+- `forceLocal` 默认值： `falsy` 是否 publicPath 为 http 网络路径时也强制生效
 
 ## Usage
 
@@ -101,4 +102,4 @@ body {
 
 ## 注意事项
 
-- 当 `output.publicPath` 设置为 http 网络路径时，插件不工作。
+- 当 `output.publicPath` 设置为 http 网络路径，并且 `forceLocal` 未设置为 `true` 时，插件不工作。

--- a/packages/webpack-plugin-extract-css-assets/README.md
+++ b/packages/webpack-plugin-extract-css-assets/README.md
@@ -10,7 +10,7 @@
 
 - `outputPath` 默认值： `""` 提取后的文件目录前缀
 - `relativeCssPath` 默认值： `""` 提取的文件后相对于 css 的路径
-- `forceLocal` 默认值： `falsy` 是否 publicPath 为 http 网络路径时也强制生效
+- `forceLocal` 默认值： `false` 是否 publicPath 为 http 网络路径时也强制生效
 
 ## Usage
 

--- a/packages/webpack-plugin-extract-css-assets/src/index.ts
+++ b/packages/webpack-plugin-extract-css-assets/src/index.ts
@@ -12,6 +12,7 @@ class ExtractCssAssetsPlugin {
       {
         outputPath: '',
         relativeCssPath: '',
+        forceLocal: false,
         requsetOptions: {
           timeout: 5000,
         },

--- a/packages/webpack-plugin-extract-css-assets/src/process-assets.ts
+++ b/packages/webpack-plugin-extract-css-assets/src/process-assets.ts
@@ -20,6 +20,7 @@ export default postcss.plugin(
   ({ outputOptions, options }: {outputOptions: any; options: any}, opts: any = {}) => {
     // 所有 css 中的网络请求
     const networkRequestMap = {};
+    const isForceLocal = options.forceLocal || false;
     const publicPath = outputOptions.publicPath || '';
     const isUrlPublicPath = /^(https?:)?\/\//.test(publicPath);
     return (root) => {
@@ -33,7 +34,7 @@ export default postcss.plugin(
                 if (urlReg.test(value)) {
                   const { url, urlIdentity } = getDeclUrl(value);
 
-                  if (isUrlPublicPath && url.startsWith(publicPath)) {
+                  if (!isForceLocal && isUrlPublicPath && url.startsWith(publicPath)) {
                     // 已经是 publicPath 名下的网络资源可以不用本地化
                     return;
                   }
@@ -49,7 +50,7 @@ export default postcss.plugin(
             if (decl.prop === 'background-image' || decl.prop === 'background') {
               if (urlReg.test(decl.value)) {
                 const { url, urlIdentity } = getDeclUrl(decl.value);
-                if (isUrlPublicPath && url.startsWith(publicPath)) {
+                if (!isForceLocal && isUrlPublicPath && url.startsWith(publicPath)) {
                   // 已经是 publicPath 名下的网络资源可以不用本地化
                   return;
                 }
@@ -130,7 +131,7 @@ export default postcss.plugin(
                       if (urlReg.test(value)) {
                         const { urlIdentity, url } = getDeclUrl(value);
 
-                        if (isUrlPublicPath && url.startsWith(publicPath)) {
+                        if (!isForceLocal && isUrlPublicPath && url.startsWith(publicPath)) {
                           // 已经是 publicPath 名下的网络资源可以不用本地化
                           return value;
                         }
@@ -167,7 +168,7 @@ export default postcss.plugin(
                 ) {
                   if (urlReg.test(decl.value)) {
                     const { urlIdentity, url } = getDeclUrl(decl.value);
-                    if (isUrlPublicPath && url.startsWith(publicPath)) {
+                    if (!isForceLocal && isUrlPublicPath && url.startsWith(publicPath)) {
                       // 已经是 publicPath 名下的网络资源可以不用本地化
                       return;
                     }


### PR DESCRIPTION
修改了 plugin-css-assets-local 和 webpack-plugin-extract-css-assets 两个包。
加入了 forceLocal 选项，表示是否强制为本地，默认值为 false。
当 forceLocal 为 true 时，则无论 output.publicPath 是否为 http 网络路径，插件都会工作。