### PR TITLE
feat: add compatible toString() function

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- [feat] add compatible `toString()` function for <= IE 11
+
 ## 0.1.1
 
 - [feat] add path-to-regexp@1.x dependency

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "runtime dependencies for plugin runtime",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/runtime/src/axiosUtils.ts
+++ b/packages/runtime/src/axiosUtils.ts
@@ -1,3 +1,5 @@
+const toString = Object.prototype.toString;
+
 /**
  * Determine if a value is an Array
  *


### PR DESCRIPTION
toString() 方法在 IE 11 下会报错，需要增加兼容性处理
https://github.com/axios/axios/blob/v1.x/lib/utils.js