### PR TITLE
fix:webpack5 replace hash to fullhash.

### DIFF
--- a/packages/build-user-config/src/userConfig/hash.js
+++ b/packages/build-user-config/src/userConfig/hash.js
@@ -6,7 +6,7 @@ module.exports = (config, hash, context) => {
   // default is false
   if (hash) {
     // can not use [chunkhash] or [contenthash] for chunk in dev mode
-    const hashStr = typeof hash === 'boolean' || command === 'start' ? 'hash:6' : hash;
+    const hashStr = typeof hash === 'boolean' || command === 'start' ? 'fullhash:6' : hash;
     const fileName = config.output.get('filename');
     let pathArray = fileName.split('/');
     pathArray.pop(); // pop filename


### PR DESCRIPTION
Replace `hash` to `fullhash` to fix webpack5 hash waring.

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/5842406/179500906-b08dbc60-81d2-4462-b6b4-5192992ebf4e.png">

Webpack doc:  https://webpack.js.org/configuration/output/#outputpath


