### PR TITLE
fix: not get the real component when enable i18n

### DIFF
--- a/examples/basic-i18n/src/pages/UserInfo/index.tsx
+++ b/examples/basic-i18n/src/pages/UserInfo/index.tsx
@@ -1,0 +1,13 @@
+function UserInfo({ name }) {
+  return (
+    <div>name: {name}</div>
+  );
+}
+
+UserInfo.getInitialProps = () => {
+  return {
+    name: 'Jack'
+  };
+};
+
+export default UserInfo;

--- a/examples/basic-i18n/src/routes.ts
+++ b/examples/basic-i18n/src/routes.ts
@@ -5,6 +5,7 @@ import Home from '@/pages/Home';
 import About from '@/pages/About';
 import NotFound from '@/pages/NotFound';
 import Login from '@/pages/Login';
+import UserInfo from '@/pages/UserInfo';
 
 const routerConfig: IRouterConfig[] = [
   {
@@ -34,6 +35,11 @@ const routerConfig: IRouterConfig[] = [
         path: '/',
         exact: true,
         component: Home,
+      },
+      {
+        path: '/abc/:id',
+        exact: true,
+        component: UserInfo,
       },
       {
         component: NotFound,

--- a/packages/plugin-ice-ssr/CHANGELOG.md
+++ b/packages/plugin-ice-ssr/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [fix] not call the getStaticPaths method from the dynamic import route component
 - [fix] not call the getInitialProps method from the dynamic import route component
+- [fix] not get the route component when the request url has locale prefix
 
 ## 3.1.2
 

--- a/packages/plugin-ice-ssr/src/server.ts.ejs
+++ b/packages/plugin-ice-ssr/src/server.ts.ejs
@@ -155,6 +155,7 @@ export async function renderStatic(
       const result = await getComponentByPath(
         routes,
         initialContext.pathname,
+        buildConfig.i18n,
       );
       component = result.component;
       getInitialProps = result.getInitialProps;
@@ -244,11 +245,26 @@ export function generateHtml({
   return $.html();
 }
 
-export async function getComponentByPath(routes, currPath)  {
+export async function getComponentByPath(routes, reqPath, i18nConfig)  {
   <% if (enableRouter) { %>
+    let routePath = reqPath;
+    // For matchPath method doesn't match the route with basename, so need to remove basename first.
+    if (appConfig?.router?.basename) {
+      routePath = routePath.replace(appConfig.router.basename, '');
+    }
+    // For matchPath method doesn't match the route with locale, so need to remove locale prefix first.
+    if (Array.isArray(i18nConfig.locales)) {
+      for (let locale of i18nConfig.locales) {
+        const localePrefix = `/${locale}`;
+        if (routePath.startsWith(localePrefix)) {
+          routePath = routePath.replace(localePrefix, '');
+          break;
+        }
+      }
+    }
     async function findMatchRoute(routeList) {
       let matchedRoute = routeList.find(route => {
-        return matchPath(currPath, route);
+        return matchPath(routePath, route);
       });
       if (matchedRoute?.component?.__LOADABLE__) {
         matchedRoute.component = loadable(matchedRoute.component.dynamicImport);


### PR DESCRIPTION
## 背景

对于带有 /${locale} 的地址，在 matchRoute 时无法拿到路由组件