### PR TITLE
feat: add setting for block cookie setting i18n locale

### DIFF
--- a/packages/plugin-i18n/src/index.ts
+++ b/packages/plugin-i18n/src/index.ts
@@ -4,7 +4,7 @@ import { I18nConfig } from './types';
 import { LOCALE_COOKIE_KEY } from './constants';
 
 export default async function (
-  { onGetWebpackConfig, getValue, applyMethod }: IPluginAPI, 
+  { onGetWebpackConfig, getValue, applyMethod }: IPluginAPI,
   i18nConfig: I18nConfig,
 ) {
   checkI18nConfig(i18nConfig);
@@ -20,8 +20,8 @@ export default async function (
 
   // copy templates to .ice/i18n dir
   applyMethod(
-    'addPluginTemplate', 
-    path.join(__dirname, 'templates'), 
+    'addPluginTemplate',
+    path.join(__dirname, 'templates'),
     { LOCALE_COOKIE_KEY, i18nConfig, i18nRouting }
   );
   applyMethod(
@@ -39,12 +39,23 @@ export default async function (
   // export API
   // import { useLocale, getAllLocales, getDefaultLocale, getLocale } from 'ice';
   applyMethod(
-    'addExport', 
-    { 
-      source: './plugins/i18n', 
+    'addExport',
+    {
+      source: './plugins/i18n',
       importSource: '$$ice/plugins/i18n',
       exportMembers: ['useLocale', 'getAllLocales', 'getDefaultLocale', 'getLocale', 'setLocale']
-    });
+    }
+  );
+
+  // set I18nAppConfig to IAppConfig
+  applyMethod(
+    'addAppConfigTypes',
+    {
+      source: '../plugins/i18n/pluginRuntime/types',
+      specifier: '{ I18nAppConfig }',
+      exportName: 'i18n?: I18nAppConfig'
+    }
+  );
 }
 
 function checkI18nConfig(i18nConfig: I18nConfig) {

--- a/packages/plugin-i18n/src/runtime.tsx
+++ b/packages/plugin-i18n/src/runtime.tsx
@@ -12,7 +12,7 @@ import getRedirectIndexRoute from './utils/getRedirectIndexRoute';
 export default ({ modifyRoutes, buildConfig, addProvider, appConfig }) => {
   const { i18n: i18nConfig } = buildConfig;
   const { i18nRouting, autoRedirect } = i18nConfig;
-  const { router: appConfigRouter = {}, i18nConfig: i18nAppConfig = {} } = appConfig;
+  const { router: appConfigRouter = {}, i18n: i18nAppConfig = {} } = appConfig;
   const { blockCookie = false } = i18nAppConfig;
   const { history = {}, basename } = appConfigRouter;
 

--- a/packages/plugin-i18n/src/templates/index.tsx.ejs
+++ b/packages/plugin-i18n/src/templates/index.tsx.ejs
@@ -90,7 +90,16 @@ export function setLocale(locale: string) {
 }
 
 function setLocaleToCookies(locale: string) {
-  cookies.set(LOCALE_COOKIE_KEY, locale, { path: '/' });
+  <% if (i18nRouting !== false) {%>
+  const { i18nConfig = {} } = getAppConfig();
+  const { blockCookie = false } = i18nConfig;
+  const cookieBlocked = typeof blockCookie === 'function' ? blockCookie() : blockCookie;
+  if (!cookieBlocked) {
+  <% } %>
+    cookies.set(LOCALE_COOKIE_KEY, locale, { path: '/' });
+  <% if (i18nRouting !== false) {%>
+  }
+  <% } %>
 }
 
 export function getLocaleFromCookies() {

--- a/packages/plugin-i18n/src/templates/index.tsx.ejs
+++ b/packages/plugin-i18n/src/templates/index.tsx.ejs
@@ -91,7 +91,7 @@ export function setLocale(locale: string) {
 
 function setLocaleToCookies(locale: string) {
   <% if (i18nRouting !== false) {%>
-  const { i18nConfig = {} } = getAppConfig();
+  const { i18n: i18nConfig = {} } = getAppConfig();
   const { blockCookie = false } = i18nConfig;
   const cookieBlocked = typeof blockCookie === 'function' ? blockCookie() : blockCookie;
   if (!cookieBlocked) {

--- a/packages/plugin-i18n/src/types.ts
+++ b/packages/plugin-i18n/src/types.ts
@@ -8,3 +8,7 @@ export interface I18nConfig {
   // 国际化路由
   i18nRouting?: false;
 }
+
+export interface I18nAppConfig {
+  blockCookie?: boolean | Function;
+}


### PR DESCRIPTION
Add a setting option in appConfig which can block cookie setting when app loaded or execute setLocale method. This feature is to meet the needs of cookie privacy protection compliance in some countries and regions.