### PR TITLE
fix: redirect incorrect i18n page

### DIFF
--- a/examples/basic-i18n/build.json
+++ b/examples/basic-i18n/build.json
@@ -5,7 +5,8 @@
       {
         "locales": [
           "zh-CN",
-          "en-US"
+          "en-US",
+          "zh-HK"
         ],
         "defaultLocale": "zh-CN",
         "autoRedirect": true

--- a/examples/basic-i18n/src/locales/locales.ts
+++ b/examples/basic-i18n/src/locales/locales.ts
@@ -1,4 +1,5 @@
 export const LOCALES = {
   ENGLISH: 'en-US',
-  ZH_CN: 'zh-CN'
+  ZH_CN: 'zh-CN',
+  zh_HK: 'zh-HK',
 };

--- a/examples/basic-i18n/src/locales/messages.ts
+++ b/examples/basic-i18n/src/locales/messages.ts
@@ -23,6 +23,18 @@ export const messages = {
     basicLayout: '主布局',
     userLayout: '用户布局',
     notFound: '未找到页面',
-    userLogin: '用户登录页'
+    userLogin: '用户登录页',
+  },
+  [LOCALES.zh_HK]: {
+    homeTitle: '首頁',
+    aboutTitle: '關於',
+    currentLocale: '當前語言',
+    defaultLocale: '默認語言',
+    configuredLocales: '配置的語言',
+    localeSwitcher: '語言切換',
+    basicLayout: '主佈局',
+    userLayout: '用戶佈局',
+    notFound: '未找到頁面',
+    userLogin: '用戶登錄頁',
   },
 };

--- a/packages/plugin-i18n/src/runtime.tsx
+++ b/packages/plugin-i18n/src/runtime.tsx
@@ -61,7 +61,7 @@ function Provider() {
 function setInitICELocaleToCookie(locale: string, cookieBlocked: boolean) {
   const cookies = new Cookies();
   if (!cookieBlocked) {
-    cookies.set(LOCALE_COOKIE_KEY, locale);
+    cookies.set(LOCALE_COOKIE_KEY, locale, { path: '/' });
   }
 }
 

--- a/packages/plugin-i18n/src/runtime.tsx
+++ b/packages/plugin-i18n/src/runtime.tsx
@@ -60,8 +60,7 @@ function Provider() {
 
 function setInitICELocaleToCookie(locale: string, cookieBlocked: boolean) {
   const cookies = new Cookies();
-  const iceLocale = cookies.get(LOCALE_COOKIE_KEY);
-  if (!iceLocale && !cookieBlocked) {
+  if (!cookieBlocked) {
     cookies.set(LOCALE_COOKIE_KEY, locale);
   }
 }

--- a/packages/plugin-i18n/src/templates/index.tsx.ejs
+++ b/packages/plugin-i18n/src/templates/index.tsx.ejs
@@ -96,7 +96,7 @@ function setLocaleToCookies(locale: string) {
   const cookieBlocked = typeof blockCookie === 'function' ? blockCookie() : blockCookie;
   if (!cookieBlocked) {
 <% } %>
-    cookies.set(LOCALE_COOKIE_KEY, locale);
+    cookies.set(LOCALE_COOKIE_KEY, locale, { path: '/' });
 <% if (i18nRouting !== false) {%>
   }
 <% } %>

--- a/packages/plugin-i18n/src/templates/index.tsx.ejs
+++ b/packages/plugin-i18n/src/templates/index.tsx.ejs
@@ -90,16 +90,16 @@ export function setLocale(locale: string) {
 }
 
 function setLocaleToCookies(locale: string) {
-  <% if (i18nRouting !== false) {%>
+<% if (i18nRouting !== false) {%>
   const { i18n: i18nConfig = {} } = getAppConfig();
   const { blockCookie = false } = i18nConfig;
   const cookieBlocked = typeof blockCookie === 'function' ? blockCookie() : blockCookie;
   if (!cookieBlocked) {
-  <% } %>
-    cookies.set(LOCALE_COOKIE_KEY, locale, { path: '/' });
-  <% if (i18nRouting !== false) {%>
+<% } %>
+    cookies.set(LOCALE_COOKIE_KEY, locale);
+<% if (i18nRouting !== false) {%>
   }
-  <% } %>
+<% } %>
 }
 
 export function getLocaleFromCookies() {

--- a/packages/plugin-i18n/src/templates/index.tsx.ejs
+++ b/packages/plugin-i18n/src/templates/index.tsx.ejs
@@ -55,7 +55,7 @@ export function getAllLocales(): string[] {
 }
 
 <% if (i18nRouting !== false) {%>
-function getDetectedLocaleFromPath(locales: string[], defaultLocale: string) {
+function getDetectedLocaleFromPath(locales: string[]) {
   const appConfig = getAppConfig();
   if (history === null) {
     if (process.env.NODE_ENV !== 'production') {
@@ -65,7 +65,7 @@ function getDetectedLocaleFromPath(locales: string[], defaultLocale: string) {
   }
   const { location: { pathname } } = history;
 
-  return getDetectedLocaleFromPathname({ pathname, locales, defaultLocale, basename: appConfig?.router?.basename });
+  return getDetectedLocaleFromPathname({ pathname, locales, basename: appConfig?.router?.basename });
 }
 <% } %>
 
@@ -75,7 +75,7 @@ function getDetectedLocaleFromPath(locales: string[], defaultLocale: string) {
 export function getLocale(): string {
   return (
     <% if (i18nRouting !== false) {%>
-    getDetectedLocaleFromPath(locales, defaultLocale) ||
+    getDetectedLocaleFromPath(locales) ||
     <% } %>
     cookies.get(LOCALE_COOKIE_KEY) ||
     defaultLocale

--- a/packages/plugin-i18n/src/utils/getDetectedLocaleFromPathname.ts
+++ b/packages/plugin-i18n/src/utils/getDetectedLocaleFromPathname.ts
@@ -1,20 +1,14 @@
 import replaceBasename from './replaceBasename';
 
+interface GetDetectedLocalFromPathnameParams {
+  pathname: string;
+  locales: string[];
+  basename?: string;
+}
 /**
  * 开启国际化路由时，通过 pathname 获取当前语言
  */
-function getDetectedLocaleFromPathname(
-  {
-    pathname,
-    locales,
-    defaultLocale,
-    basename,
-  }: {
-    pathname: string;
-    locales: string[];
-    defaultLocale: string;
-    basename?: string;
-  }) {
+function getDetectedLocaleFromPathname({ pathname, locales, basename }: GetDetectedLocalFromPathnameParams) {
   const normalizedPathname = replaceBasename(pathname, basename);
   const pathnameParts = normalizedPathname.split('/').filter(pathnamePart => pathnamePart);
 

--- a/packages/plugin-i18n/src/utils/getLocaleData.ts
+++ b/packages/plugin-i18n/src/utils/getLocaleData.ts
@@ -54,7 +54,7 @@ function getDetectedLocale(
 
   // 检测获取Locale的优先级为：path前缀 > cookie > 浏览器语言设置 > 默认语言
   const detectedLocale =
-    (i18nRouting === false ? undefined : getDetectedLocaleFromPathname({ pathname, locales, basename, defaultLocale })) ||
+    (i18nRouting === false ? undefined : getDetectedLocaleFromPathname({ pathname, locales, basename })) ||
     getLocaleFromCookie(locales, cookies) ||
     getPreferredLocale(locales, headers) ||
     defaultLocale;


### PR DESCRIPTION

## 背景

<img width="853" alt="image" src="https://user-images.githubusercontent.com/44047106/185851995-7d1437a0-11f9-49b1-81ac-a1f8c94756b2.png">

i18n 下路由跳转时候依赖 cookies 上 `ice_locale` 的值，因此需要初次访问页面的时候设置当前页面的 locale 到 cookie 中