### PR TITLE
fix: compatible with webpack4 hash type

### DIFF
--- a/packages/build-user-config/CHANGELOG.md
+++ b/packages/build-user-config/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.5
+
+- [fix] compatible with webpack4 hash type
 
 ## 2.2.4
 

--- a/packages/build-user-config/package.json
+++ b/packages/build-user-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/user-config",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Includes methods which are releated to set base user config for framework",
   "homepage": "",
   "license": "MIT",

--- a/packages/build-user-config/src/userConfig/hash.js
+++ b/packages/build-user-config/src/userConfig/hash.js
@@ -5,8 +5,12 @@ module.exports = (config, hash, context) => {
   const { command } = context;
   // default is false
   if (hash) {
+    // eslint-disable-next-line global-require
+    const webpack = require('webpack');
+    const webpack4 = webpack.version.startsWith('4');
+    const defaultHash = webpack4 ? 'hash:6' : 'fullhash:6';
     // can not use [chunkhash] or [contenthash] for chunk in dev mode
-    const hashStr = typeof hash === 'boolean' || command === 'start' ? 'fullhash:6' : hash;
+    const hashStr = typeof hash === 'boolean' || command === 'start' ? defaultHash : hash;
     const fileName = config.output.get('filename');
     let pathArray = fileName.split('/');
     pathArray.pop(); // pop filename
@@ -14,9 +18,11 @@ module.exports = (config, hash, context) => {
     const outputPath = pathArray.length ? pathArray.join('/') : '';
     config.output.filename(formatPath(path.join(outputPath, `[name].[${hashStr}].js`)));
     if (config.plugins.get('MiniCssExtractPlugin')) {
-      config.plugin('MiniCssExtractPlugin').tap((args) => [Object.assign(...args, {
-        filename: formatPath(path.join(outputPath, `[name].[${hashStr}].css`)),
-      })]);
+      config.plugin('MiniCssExtractPlugin').tap((args) => [
+        Object.assign(...args, {
+          filename: formatPath(path.join(outputPath, `[name].[${hashStr}].css`)),
+        }),
+      ]);
     }
   }
 };

--- a/packages/build-user-config/src/userConfig/hash.js
+++ b/packages/build-user-config/src/userConfig/hash.js
@@ -7,8 +7,7 @@ module.exports = (config, hash, context) => {
   if (hash) {
     // eslint-disable-next-line global-require
     const webpack = require('webpack');
-    const webpack4 = webpack.version.startsWith('4');
-    const defaultHash = webpack4 ? 'hash:6' : 'fullhash:6';
+    const defaultHash = webpack.version.startsWith('4') ? 'hash:6' : 'fullhash:6';
     // can not use [chunkhash] or [contenthash] for chunk in dev mode
     const hashStr = typeof hash === 'boolean' || command === 'start' ? defaultHash : hash;
     const fileName = config.output.get('filename');


### PR DESCRIPTION
 rax-app 依赖 @builder/user-config，而部分 rax-app 的项目还是依赖 webpack4，导致无法正确计算出 hash 值

Close #5477