### PR TITLE
fix: do not remove origin output css when config cssChunkNames

### DIFF
--- a/packages/plugin-fusion/CHANGELOG.md
+++ b/packages/plugin-fusion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.23
+
+- [fix] return sourceMap with custom loader of `unicodeLoader`
+
 ## 0.1.22
 
 - [fix] remove alias config of `~` for vite

--- a/packages/plugin-fusion/package.json
+++ b/packages/plugin-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-fusion",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "plugin for build scripts while use fusion component",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/plugin-fusion/src/webpackLoaders/unicodeLoader.js
+++ b/packages/plugin-fusion/src/webpackLoaders/unicodeLoader.js
@@ -1,7 +1,9 @@
 const convertCharStr2CSS = require('../utils/convertCharStr');
 
-module.exports = (source) => {
-  return source.replace(/content:\s*(?:'|")([\u0080-\uffff])(?:'|")/g, (str, $1) => {
+function unicodeLoader(source, sourceMap) {
+  const callback = this.async();
+  callback(null, source.replace(/content:\s*(?:'|")([\u0080-\uffff])(?:'|")/g, (str, $1) => {
     return `content: "${convertCharStr2CSS($1)}"`;
-  });
-};
+  }), sourceMap) ;
+}
+module.exports = unicodeLoader;

--- a/packages/vite-service/CHANGELOG.md
+++ b/packages/vite-service/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.1.5
+
+- [fix] do not remove origin css when config `cssChunkNames`.
+
 ## 2.1.4
 
 - [fix] avoid top-level warning of esbuild.

--- a/packages/vite-service/package.json
+++ b/packages/vite-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/vite-service",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "vite implementation",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/vite-service/src/plugins/cssChunk.ts
+++ b/packages/vite-service/src/plugins/cssChunk.ts
@@ -66,7 +66,7 @@ export const cssChunk = (chunkName: ChunkName): Plugin => {
               const cssName = parseCssName(cssChunkName, cssIndex);
               const renamedCss = formatPath(path.join(cssDir, cssName));
               if (cssLink !== renamedCss) {
-                fse.moveSync(sourceCss, path.join(outputDir, cssDir, cssName));
+                fse.writeFileSync(path.join(outputDir, cssDir, cssName), fse.readFileSync(sourceCss, 'utf-8'));
                 // replace css link
                 htmlContent = htmlContent.replace(/<link[\s\S]*href=["']([^'"]*)["'][^>]*>/g, (str, matched) => {
                   return matched === `${base}${cssLink}` ? str.replace(matched, `${base}${renamedCss}`) : str;


### PR DESCRIPTION
入口的 css 在一些主动分包场景下会有对应依赖关系，不能直接删除