### PR TITLE
fix: when mpa mode build, args is not support

### DIFF
--- a/packages/plugin-mpa/src/index.ts
+++ b/packages/plugin-mpa/src/index.ts
@@ -28,7 +28,7 @@ const plugin: IPlugin = (api) => {
   // support --mpa-entry to specify mpa entry
   registerCliOption({
     name: 'mpa-entry',
-    commands: ['start'],
+    commands: ['start', 'build'],
   });
 
   if (mpa) {


### PR DESCRIPTION
当开启多页面模式打包时，build-scripts会提示 cli option 'mpaEntry' is not supported when run command 'build'， 没有提前配置build, dev模式正常