### PR TITLE
fix: 兼容由于文件分隔符的差异导致ignore-style-plugin在windows电脑环境下调试无法生效的问题

### DIFF
--- a/packages/plugin-ignore-style/src/index.ts
+++ b/packages/plugin-ignore-style/src/index.ts
@@ -24,7 +24,10 @@ const plugin: IPlugin = ({ onGetWebpackConfig, modifyUserConfig, log, context },
     onGetWebpackConfig((config) => {
       config.module
         .rule('ignore-style')
-        .test(new RegExp(externalRule))
+        .test((path) => {
+          const reg = new RegExp(externalRule);
+          return reg.test(path) || reg.test(path.replace(/\\/g, '/'));
+        })
         .before('jsx')
         .use('null-loader').loader(require.resolve('./null-loader'));
     });

--- a/packages/plugin-ignore-style/src/index.ts
+++ b/packages/plugin-ignore-style/src/index.ts
@@ -1,5 +1,6 @@
 import type { IPlugin } from 'build-scripts';
 import type { Plugin } from 'vite';
+import * as path from 'path';
 
 interface Options {
   libraryName: string;
@@ -24,9 +25,10 @@ const plugin: IPlugin = ({ onGetWebpackConfig, modifyUserConfig, log, context },
     onGetWebpackConfig((config) => {
       config.module
         .rule('ignore-style')
-        .test((path) => {
+        .test((pathStr) => {
           const reg = new RegExp(externalRule);
-          return reg.test(path) || reg.test(path.replace(/\\/g, '/'));
+          // return reg.test(pathStr) || reg.test(pathStr.replace(/\\/g, '/'));
+          return reg.test(pathStr.split(path.sep).join('/'));
         })
         .before('jsx')
         .use('null-loader').loader(require.resolve('./null-loader'));


### PR DESCRIPTION
在使用antd和procomponents时，按照官方文档操作使用ignore-style-plugin处理procomponents中对antd组件样式的重复引用，windows环境下无法生效，最终定位到是由于windows文件分隔符为\，而插件中处理libraryName的正则默认是/，导致null-loader没有拦截到procomponents中对antd样式的引用。