### PR TITLE
fix: removed server output before hook called

### DIFF
--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -1,4 +1,6 @@
+import * as path from 'path';
 import consola from 'consola';
+import fse from 'fs-extra';
 import { getWebpackConfig } from '@ice/webpack-config';
 import type { Context, TaskConfig } from 'build-scripts';
 import webpack from '@ice/bundles/compiled/webpack/index.js';
@@ -9,7 +11,7 @@ import type { AppConfig } from '@ice/runtime/esm/types';
 import type { ServerCompiler, GetAppConfig, GetRoutesConfig, ExtendsPluginAPI } from '../types/plugin.js';
 import webpackCompiler from '../service/webpackCompiler.js';
 import formatWebpackMessages from '../utils/formatWebpackMessages.js';
-import { RUNTIME_TMP_DIR } from '../constant.js';
+import { RUNTIME_TMP_DIR, SERVER_OUTPUT_DIR } from '../constant.js';
 import emptyDir from '../utils/emptyDir.js';
 import type { UserConfig } from '../types/userConfig.js';
 import warnOnHashRouterEnabled from '../utils/warnOnHashRouterEnabled.js';
@@ -119,7 +121,15 @@ const build = async (
     appConfig,
   });
 
+  await removeServerOutput(outputDir, userConfig.ssr);
+
   return { compiler };
 };
+
+async function removeServerOutput(outputDir: string, ssr: boolean) {
+  if (!ssr) {
+    await fse.remove(path.join(outputDir, SERVER_OUTPUT_DIR));
+  }
+}
 
 export default build;

--- a/packages/ice/src/plugins/web/index.ts
+++ b/packages/ice/src/plugins/web/index.ts
@@ -122,8 +122,6 @@ const plugin: Plugin = () => ({
         renderMode,
         routeType: appConfig?.router?.type,
       });
-
-      await removeServerOutput(outputDir, ssr);
     });
 
     onHook('after.start.compile', async ({ isSuccessful, isFirstCompile, urls, devUrlInfo }) => {
@@ -148,11 +146,5 @@ const plugin: Plugin = () => ({
     });
   },
 });
-
-async function removeServerOutput(outputDir: string, ssr: boolean) {
-  if (!ssr) {
-    await fse.remove(path.join(outputDir, SERVER_OUTPUT_DIR));
-  }
-}
 
 export default plugin;

--- a/packages/ice/src/plugins/web/index.ts
+++ b/packages/ice/src/plugins/web/index.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import fse from 'fs-extra';
 import consola from 'consola';
 import chalk from 'chalk';
 import type { RenderMode } from '@ice/runtime';


### PR DESCRIPTION
问题：在其他插件的 `after.build.compile` hook （如 pha 插件）未被调用前已经把 server 端的产物删掉，导致无法消费 server 的产物