### PR TITLE
Fix/miniapp bugs

### DIFF
--- a/packages/ice/src/commands/start.ts
+++ b/packages/ice/src/commands/start.ts
@@ -199,10 +199,13 @@ async function invokeCompilerWatch({
     spinner,
     hooksAPI,
   });
+  const { userConfig, rootDir } = context;
+  const { outputDir } = userConfig;
+  const absoluteOutputDir = path.resolve(rootDir, outputDir);
   let messages: { errors: string[]; warnings: string[] };
   compiler.watch({
-    aggregateTimeout: 300,
-    poll: undefined,
+    aggregateTimeout: 200,
+    ignored: ['**/node_modules/**', `${absoluteOutputDir}/**`],
   }, async (err, stats) => {
     if (err) {
       if (!err.message) {

--- a/packages/plugin-miniapp/src/index.ts
+++ b/packages/plugin-miniapp/src/index.ts
@@ -10,9 +10,10 @@ interface MiniappOptions {
   nativeConfig?: Record<string, any>;
 }
 
-const plugin: Plugin<MiniappOptions> = ({ nativeConfig = {} }) => ({
+const plugin: Plugin<MiniappOptions> = (miniappOptions = {}) => ({
   name: '@ice/plugin-miniapp',
   setup: ({ registerTask, onHook, context, dataCache, generator }) => {
+    const { nativeConfig = {} } = miniappOptions;
     const { commandArgs, rootDir, command } = context;
     const { platform } = commandArgs;
     if (MINIAPP_PLATFORMS.includes(platform)) {

--- a/packages/plugin-miniapp/src/miniapp/index.ts
+++ b/packages/plugin-miniapp/src/miniapp/index.ts
@@ -5,6 +5,7 @@
  * */
 import * as path from 'path';
 import { createRequire } from 'node:module';
+import fs from 'fs-extra';
 import fg from 'fast-glob';
 import type { Config } from '@ice/app/esm/types';
 import getMiniappPlatformConfig from '../platforms/index.js';
@@ -48,6 +49,7 @@ const getMiniappTask = ({
     projectConfigJson,
     nativeConfig,
   });
+  const isPublicDirExist = fs.existsSync(path.join(rootDir, 'public'));
   const defaultLogging = command === 'start' ? 'summary' : 'summary assets';
   return {
     mode,
@@ -114,7 +116,7 @@ const getMiniappTask = ({
       maxEntrypointSize: 2 * 1000 * 1000,
     },
     devServer: {}, // No need to use devServer in miniapp
-    enableCopyPlugin: true,
+    enableCopyPlugin: isPublicDirExist, // Only when public dir exists should copy-webpack-plugin be enabled
     swcOptions: {
       // compatible with former design that miniapp represents ali miniapp
       keepPlatform: platform === 'ali-miniapp' ? 'miniapp' : platform,

--- a/packages/plugin-miniapp/src/miniapp/index.ts
+++ b/packages/plugin-miniapp/src/miniapp/index.ts
@@ -61,6 +61,7 @@ const getMiniappTask = ({
       globalObject,
       enabledLibraryTypes: [],
     },
+    cacheDir: path.join(rootDir, 'node_modules', '.cache'),
     sourceMap: command === 'start' ? 'cheap-module-source-map' : false,
     alias: {
       ice: path.join(rootDir, runtimeDir, 'index.ts'),

--- a/website/docs/guide/miniapp/start.md
+++ b/website/docs/guide/miniapp/start.md
@@ -24,9 +24,16 @@ ice.js 支持小程序开发。由于小程序端大部分能力及配置均与 
   }
 ```
 
-## 配置小程序开发插件
+## 配置小程序开发插件及运行时依赖
 
-在 `ice.config.mts` 中配置 `@ice/plugin-miniapp` 插件：
+安装小程序开发插件 `@ice/plugin-miniapp` 和小程序运行时依赖 `@ice/miniapp-runtime`：
+
+```shell
+$ npm install @ice/plugin-miniapp -D
+$ npm install @ice/miniapp-runtime -S
+```
+
+在 `ice.config.mts` 中配置插件：
 
 ```js title=ice.config.mts
 import miniapp from '@ice/plugin-miniapp';
@@ -34,6 +41,19 @@ import miniapp from '@ice/plugin-miniapp';
 export default defineConfig({
   plugins: [miniapp()],
 });
+```
+
+## 添加 `miniappManifest`
+
+在 `src/app.tsx` 中导出 `miniappManifest`，在其中配置 `routes` 数组用以指定小程序中的页面（详见[小程序-路由](./router)）:
+
+```js
+export const miniappManifest = {
+  routes: [
+    // 初始化项目中仅有 index 一个页面
+    'index' 
+  ]
+};
 ```
 
 ## 调试与构建


### PR DESCRIPTION
- [x] fix: not ignore outputDir in watch mode
- [x] fix: miss cachrDir  
- [x] fix: compatible with no params passed to miniapp plugin
- [x] docs: update miniapp quick start article 
- [x] fix: only when public dir exists should copy-webpack-plugin be enabled 