### PR TITLE
fix: rax-compat usestate bug

### DIFF
--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -21,6 +21,7 @@ import {
   createContext as _createContext,
 } from 'react';
 import is from './is';
+import { isFunction } from './type';
 
 /**
  * Compat useState for rax export.
@@ -36,6 +37,9 @@ export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _use
   });
   // @NOTE: Rax will not re-render if set a same value.
   function updateState(newState: S) {
+    if (isFunction(newState)) {
+      newState = newState(stateHook[0].eagerState);
+    }
     // Filter shallow-equal value set.
     if (!is(newState, stateHook[0].eagerState)) {
       stateHook[1]({

--- a/packages/rax-compat/tests/hooks.test.tsx
+++ b/packages/rax-compat/tests/hooks.test.tsx
@@ -4,7 +4,7 @@
 
 import { expect, it, describe, vi } from 'vitest';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import {
   useState,
   useEffect,
@@ -41,6 +41,22 @@ describe('hooks', () => {
     }
 
     render(<App />);
+  });
+
+  it('useState update value', () => {
+    const { result, rerender } = renderHook(() => useState(0));
+    expect(result.current[0]).toEqual(0);
+
+    result.current[1](1);
+    rerender();
+    expect(result.current[0]).toEqual(1);
+
+    result.current[1]((count) => {
+      expect(count).toEqual(1);
+      return count + 10;
+    });
+    rerender();
+    expect(result.current[0]).toEqual(11);
   });
 
   it('useEffect', () => {


### PR DESCRIPTION
调用 `useState` 返回更新函数，需要支持函数入参的写法。
```js
const [state, setState] = useState(0);

setState(0);

setState(count => count + 1);


```