### PR TITLE
fix: app data loader

### DIFF
--- a/examples/with-data-loader/src/app.tsx
+++ b/examples/with-data-loader/src/app.tsx
@@ -1,5 +1,13 @@
+import { defineDataLoader } from 'ice';
+
 export default {
   app: {
     rootId: 'app',
   },
 };
+
+export const dataLoader = defineDataLoader(async () => {
+  return {
+    id: 123,
+  };
+});

--- a/examples/with-data-loader/src/pages/home.tsx
+++ b/examples/with-data-loader/src/pages/home.tsx
@@ -1,8 +1,11 @@
-import { useData, defineDataLoader } from 'ice';
+import { useData, defineDataLoader, useAppData } from 'ice';
 import styles from './index.module.css';
 
 export default function Home() {
   const data = useData();
+  const appData = useAppData();
+
+  console.log(appData);
 
   return (
     <>

--- a/packages/runtime/src/AppData.tsx
+++ b/packages/runtime/src/AppData.tsx
@@ -20,7 +20,7 @@ async function getAppData(appExport: AppExport, requestContext?: RequestContext)
   const hasGlobalLoader = typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__;
   const globalLoader = hasGlobalLoader ? (window as any).__ICE_DATA_LOADER__ : null;
 
-  if (globalLoader && globalLoader.hasLoad('__app')) {
+  if (globalLoader) {
     return await globalLoader.getData('__app');
   }
 

--- a/packages/runtime/src/dataLoader.ts
+++ b/packages/runtime/src/dataLoader.ts
@@ -157,6 +157,7 @@ async function init(loadersConfig: Loaders, options: LoaderOptions) {
       }
 
       // Call dataLoader.
+      // In CSR, all dataLoader is called by global data loader to avoid bundle dataLoader in page bundle duplicate.
       const requestContext = getRequestContext(window.location);
       return await callDataLoader(dataLoader, requestContext);
     },

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -58,7 +58,7 @@ export async function loadRoutesData(
     matches.map(async (match) => {
       const { id } = match.route;
 
-      if (globalLoader && globalLoader.hasLoad(id)) {
+      if (globalLoader) {
         routesData[id] = await globalLoader.getData(id);
         return;
       }

--- a/packages/runtime/tests/routes.test.tsx
+++ b/packages/runtime/tests/routes.test.tsx
@@ -166,7 +166,6 @@ describe('routes', () => {
   it('load data from __ICE_DATA_LOADER__', async () => {
     windowSpy.mockImplementation(() => ({
       __ICE_DATA_LOADER__: {
-        hasLoad: () => true,
         getData: async (id) => ({ id: `${id}_data` }),
       },
     }));

--- a/packages/runtime/tests/runClientApp.test.tsx
+++ b/packages/runtime/tests/runClientApp.test.tsx
@@ -277,7 +277,6 @@ describe('run client app', () => {
     windowSpy.mockImplementation(() => ({
       ...mockData,
       __ICE_DATA_LOADER__: {
-        hasLoad: () => true,
         getData: async () => {
           useGlobalLoader = true;
           return { msg: '-globalData' };


### PR DESCRIPTION
- 修复 app 的 dataLoader 没有被调用的问题（原因是，dataLoader 构建时移除了，需要通过 data-loader.js 发起请求）
