### PR TITLE
refactor(miniapp): use static create method to create instance of EventSource

### DIFF
--- a/packages/miniapp-runtime/CHANGELOG.md
+++ b/packages/miniapp-runtime/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v1.0.1
+
+- [refactor] use static create method to create instance of EventSource which extends Map to avoid es5 environment error
+
+## v1.0.0
+
+- [feat] provide runtime for ice miniapp

--- a/packages/miniapp-runtime/package.json
+++ b/packages/miniapp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/miniapp-runtime",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ice runtime for miniapps.",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/packages/miniapp-runtime/src/dom/element.ts
+++ b/packages/miniapp-runtime/src/dom/element.ts
@@ -132,7 +132,7 @@ export class Element extends Node {
   public setAttribute(qualifiedName: string, value: any): void {
     process.env.NODE_ENV !== 'production' && warn(
       isString(value) && value.length > PROPERTY_THRESHOLD,
-      `元素 ${this.nodeName} 的 ${qualifiedName} 属性值数据量过大，可能会影响渲染性能。考虑降低图片转为 base64 的阈值或在 CSS 中使用 base64。`,
+      `元素 ${this.nodeName} 的 ${qualifiedName} 属性值数据量过大，可能会影响渲染性能。考虑在 CSS 中使用 base64。`,
     );
 
     const isPureView = this.nodeName === VIEW && !isHasExtractProp(this) && !this.isAnyEventBinded();

--- a/packages/miniapp-runtime/src/dom/event-source.ts
+++ b/packages/miniapp-runtime/src/dom/event-source.ts
@@ -6,6 +6,11 @@ interface IEventSource extends Map<string | undefined | null, Node> {
 }
 
 class EventSource extends Map {
+  static create(): IEventSource {
+    const inst = new Map();
+    inst['__proto__'] = EventSource.prototype;
+    return inst as IEventSource;
+  }
   removeNode(child: Node) {
     const { sid, uid } = child;
     this.delete(sid);
@@ -19,4 +24,4 @@ class EventSource extends Map {
   }
 }
 
-export const eventSource: IEventSource = new EventSource();
+export const eventSource: IEventSource = EventSource.create();


### PR DESCRIPTION
背景介绍：dev 模式下 node_modules 代码不会被编译，在支付宝小程序环境中下面的代码将出现 `Constructor Map requires 'new'` 的报错（详见 https://stackoverflow.com/questions/66438435/error-typeerror-constructor-map-requires-new-in-es5 ）：

```js
class EventSource extends Map {
  //...
}
const eventSource = new EventSource();
```

因此修改此处代码