### PR TITLE
feat: force to use dev port which user set

### DIFF
--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [fix] lock version of `@ice/bundles`, `@ice/webpack-config` and `@ice/route-manifest`
 - [feat] support external config for server
 - [feat] redirect imports for data loader
+- [feat]: force to use port which user set in commandArgs
 
 ## v3.0.0
 

--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -43,7 +43,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
     .option('--mode <mode>', 'set mode', 'development')
     .option('--config <config>', 'custom config path')
     .option('-h, --host <host>', 'dev server host', '0.0.0.0')
-    .option('-p, --port <port>', 'dev server port', 3000)
+    .option('-p, --port <port>', 'dev server port')
     .option('--no-open', "don't open browser on startup")
     .option('--no-mock', "don't start mock service")
     .option('--rootDir <rootDir>', 'project root directory', cwd)
@@ -52,7 +52,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
     .option('--force', 'force remove cache directory', false)
     .action(async ({ rootDir, ...commandArgs }) => {
       process.env.NODE_ENV = 'development';
-      commandArgs.port = await detectPort(commandArgs.port);
+      const DEFAULT_PORT = 3000;
+      commandArgs.port = typeof commandArgs.port === 'undefined' ? await detectPort(DEFAULT_PORT) : commandArgs.port;
       const service = await createService({ rootDir, command: 'start', commandArgs });
       service.run();
     });


### PR DESCRIPTION
detect-port 对 80 端口判断有问题，即使 80 端口没占用，还是会用其他端口代替。因此这个 PR 是调整 commandArgs.port 的优先级，用户设定 port 优先级高，即使端口被占用则让他自己退出进程