### PR TITLE
fix: dev url when enable hash router

### DIFF
--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.3
+
+- [fix] incorrect dev url when enable hash router
+
 ## v3.0.2
 
 - [fix] rule of page chunk name

--- a/packages/ice/src/commands/start.ts
+++ b/packages/ice/src/commands/start.ts
@@ -156,12 +156,13 @@ async function startDevServer({
   devServerConfig = merge(webpackConfigs[0].devServer, devServerConfig);
   const protocol = devServerConfig.https ? 'https' : 'http';
   let urlPathname = getRouterBasename(webTaskConfig, appConfig) || '/';
-
+  const enabledHashRouter = appConfig.router?.type === 'hash';
   const urls = prepareURLs(
     protocol,
     devServerConfig.host,
     devServerConfig.port as number,
     urlPathname.endsWith('/') ? urlPathname : `${urlPathname}/`,
+    enabledHashRouter,
   );
   const compiler = await webpackCompiler({
     context,

--- a/packages/ice/src/esbuild/removeTopLevelCode.ts
+++ b/packages/ice/src/esbuild/removeTopLevelCode.ts
@@ -5,6 +5,7 @@ import { parse, type ParserOptions } from '@babel/parser';
 import babelTraverse from '@babel/traverse';
 import babelGenerate from '@babel/generator';
 import removeTopLevelCode from '../utils/babelPluginRemoveCode.js';
+import formatPath from '../utils/formatPath.js';
 
 // @ts-ignore @babel/traverse is not a valid export in esm
 const traverse = babelTraverse.default || babelTraverse;
@@ -26,7 +27,7 @@ const removeCodePlugin = (keepExports: string[], transformInclude: (id: string) 
     name: 'esbuild-remove-top-level-code',
     setup(build) {
       build.onLoad({ filter: /\.(js|jsx|ts|tsx)$/ }, async ({ path: id }) => {
-        if (!transformInclude(id)) {
+        if (!transformInclude(formatPath(id))) {
           return;
         }
         const source = fs.readFileSync(id, 'utf-8');

--- a/packages/ice/src/plugins/web/index.ts
+++ b/packages/ice/src/plugins/web/index.ts
@@ -125,21 +125,22 @@ const plugin: Plugin = () => ({
 
     onHook('after.start.compile', async ({ isSuccessful, isFirstCompile, urls, devUrlInfo }) => {
       const { port, open } = commandArgs;
-      const { devPath, hashChar } = devUrlInfo;
+      const { devPath } = devUrlInfo;
       if (isSuccessful && isFirstCompile) {
         let logoutMessage = '\n';
         logoutMessage += chalk.green(' Starting the development server at:');
         if (process.env.CLOUDIDE_ENV) {
-          logoutMessage += `\n   - IDE server: https://${process.env.WORKSPACE_UUID}-${port}.${process.env.WORKSPACE_HOST}${hashChar}${devPath}`;
+          logoutMessage += `\n   - IDE server: https://${process.env.WORKSPACE_UUID}-${port}.${process.env.WORKSPACE_HOST}${devPath}`;
         } else {
+          console.log('devPath', devPath, urls);
           logoutMessage += `\n
-    - Local  : ${chalk.underline.white(`${urls.localUrlForBrowser}${hashChar}${devPath}`)}
-    - Network: ${chalk.underline.white(`${urls.lanUrlForTerminal}${hashChar}${devPath}`)}`;
+    - Local  : ${chalk.underline.white(`${urls.localUrlForBrowser}${devPath}`)}
+    - Network: ${chalk.underline.white(`${urls.lanUrlForTerminal}${devPath}`)}`;
         }
         consola.log(`${logoutMessage}\n`);
 
         if (open) {
-          openBrowser(`${urls.localUrlForBrowser}${hashChar}${devPath}`);
+          openBrowser(`${urls.localUrlForBrowser}${devPath}`);
         }
       }
     });

--- a/packages/ice/src/plugins/web/index.ts
+++ b/packages/ice/src/plugins/web/index.ts
@@ -132,7 +132,6 @@ const plugin: Plugin = () => ({
         if (process.env.CLOUDIDE_ENV) {
           logoutMessage += `\n   - IDE server: https://${process.env.WORKSPACE_UUID}-${port}.${process.env.WORKSPACE_HOST}${devPath}`;
         } else {
-          console.log('devPath', devPath, urls);
           logoutMessage += `\n
     - Local  : ${chalk.underline.white(`${urls.localUrlForBrowser}${devPath}`)}
     - Network: ${chalk.underline.white(`${urls.lanUrlForTerminal}${devPath}`)}`;

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -82,8 +82,6 @@ async function webpackCompiler(options: {
       consola.warn(messages.warnings.join('\n'));
     }
     if (command === 'start') {
-      const appConfig = (await hooksAPI.getAppConfig()).default;
-      const hashChar = appConfig?.router?.type === 'hash' ? '#/' : '';
       // compiler.hooks.done is AsyncSeriesHook which does not support async function
       await applyHook('after.start.compile', {
         stats,
@@ -91,7 +89,6 @@ async function webpackCompiler(options: {
         isFirstCompile,
         urls,
         devUrlInfo: {
-          hashChar,
           devPath,
         },
         messages,

--- a/packages/ice/src/types/plugin.ts
+++ b/packages/ice/src/types/plugin.ts
@@ -84,7 +84,6 @@ interface AfterCommandCompileOptions {
 
 interface DevServerInfo {
   devPath: string;
-  hashChar: string;
 }
 
 export interface HookLifecycle {

--- a/packages/ice/src/utils/prepareURLs.ts
+++ b/packages/ice/src/utils/prepareURLs.ts
@@ -8,7 +8,6 @@
 // This file is based on  https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/prepareURLs.js
 // It's been rewrite to ts and ICE specific logic
 
-import url from 'url';
 import address from 'address';
 import type { Urls } from '../types/plugin.js';
 

--- a/packages/ice/src/utils/prepareURLs.ts
+++ b/packages/ice/src/utils/prepareURLs.ts
@@ -16,21 +16,24 @@ export default function prepareUrls(
   protocol: string,
   host: string,
   port: number,
-  pathname = '/',
+  pathname: string,
+  enabledHashRouter: boolean,
 ): Urls {
   const formatUrl = (hostname: string): string =>
     url.format({
       protocol,
       hostname,
       port,
-      pathname,
+      pathname: enabledHashRouter ? undefined : pathname,
+      hash: enabledHashRouter ? `${pathname || '/'}` : undefined,
     });
   const prettyPrintUrl = (hostname: string): string =>
     url.format({
       protocol,
       hostname,
       port: port.toString(),
-      pathname,
+      pathname: enabledHashRouter ? undefined : pathname,
+      hash: enabledHashRouter ? `${pathname || '/'}` : undefined,
     });
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::';

--- a/packages/ice/src/utils/prepareURLs.ts
+++ b/packages/ice/src/utils/prepareURLs.ts
@@ -19,22 +19,18 @@ export default function prepareUrls(
   pathname: string,
   enabledHashRouter: boolean,
 ): Urls {
-  const formatUrl = (hostname: string): string =>
-    url.format({
-      protocol,
-      hostname,
-      port,
-      pathname: enabledHashRouter ? undefined : pathname,
-      hash: enabledHashRouter ? `${pathname || '/'}` : undefined,
-    });
-  const prettyPrintUrl = (hostname: string): string =>
-    url.format({
-      protocol,
-      hostname,
-      port: port.toString(),
-      pathname: enabledHashRouter ? undefined : pathname,
-      hash: enabledHashRouter ? `${pathname || '/'}` : undefined,
-    });
+  const formatUrl = (hostname: string): string => {
+    const url = new URL(`${protocol}://${hostname}:${port}`);
+    url.pathname = enabledHashRouter ? '' : pathname;
+    url.hash = enabledHashRouter ? `${pathname || '/'}` : '';
+    return url.href;
+  };
+  const prettyPrintUrl = (hostname: string): string => {
+    const url = new URL(`${protocol}://${hostname}:${port}`);
+    url.pathname = enabledHashRouter ? '' : pathname;
+    url.hash = enabledHashRouter ? `${pathname || '/'}` : '';
+    return url.href;
+  };
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::';
   let prettyHost: string;


### PR DESCRIPTION
Close https://github.com/alibaba/ice/issues/5640

- 使用 `URL` 代替已经 deprecated 的 `url.format()`



