### PR TITLE
Fix data

### DIFF
--- a/packages/plugin-pha/CHANGELOG.md
+++ b/packages/plugin-pha/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- [fix] fix lanUrlForTerminal when dev start
+
 ## 1.0.2
 
 - [fix] fix dev lanUrlForTerminal err

--- a/packages/plugin-pha/package.json
+++ b/packages/plugin-pha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-pha",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ice.js plugin for PHA.",
   "license": "MIT",
   "type": "module",

--- a/packages/plugin-pha/src/index.ts
+++ b/packages/plugin-pha/src/index.ts
@@ -52,13 +52,11 @@ const plugin: Plugin<PluginOptions> = (options) => ({
       getAppConfig = restAPI.getAppConfig;
       getRoutesConfig = restAPI.getRoutesConfig;
 
-      const urlForTerminal = urls.lanUrlForTerminal || urls.localUrlForTerminal;
-
       // Need absolute path for pha dev.
-      publicPath = command === 'start' ? getDevPath(urlForTerminal) : (taskConfig.publicPath || '/');
+      publicPath = command === 'start' ? getDevPath(urls.lanUrlForTerminal || urls.localUrlForTerminal) : (taskConfig.publicPath || '/');
 
       // process.env.DEPLOY_PATH is defined by cloud environment such as DEF plugin.
-      urlPrefix = command === 'start' ? urlForTerminal : process.env.DEPLOY_PATH;
+      urlPrefix = command === 'start' ? urls.lanUrlForTerminal : process.env.DEPLOY_PATH;
 
       compiler = async (options) => {
         const { entry, outfile, minify = false } = options;

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/runtime
 
+## v1.0.3
+
+- [revert] window context merge order
+
 ## v1.0.2
 
 - [fix] window context merge order

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -159,7 +159,7 @@ export function Data(props: DataProps) {
     // Should merge global context when there are multiple <Data />.
     <ScriptElement
       suppressHydrationWarning={documentOnly}
-      dangerouslySetInnerHTML={{ __html: `window.__ICE_APP_CONTEXT__=Object.assign(window.__ICE_APP_CONTEXT__ || {}, ${JSON.stringify(windowContext)})` }}
+      dangerouslySetInnerHTML={{ __html: `window.__ICE_APP_CONTEXT__=Object.assign(${JSON.stringify(windowContext)}, window.__ICE_APP_CONTEXT__ || {});` }}
     />
   );
 }


### PR DESCRIPTION
背景：

搭建 GCP 场景下存在两种 Data 引入方式
- 第一种，Data + SSR(内含 Data) + PreLoader Scripts
- 第二种，SSR（内含 Data ） + Scripts（内含 Data ）

两种情况下 Data 和 SSR 的先后顺序不一致，

之前只考虑了第一种情况，修改了 Data 中的 merge 逻辑，导致第二种情况无法正常工作。

正确的做法是，统一第一种方式中的顺序为：  SSR +  Data + PreLoader Scripts

始终保持 SSR 的数据在前
