### PR TITLE
fix: error when use plugin without config theme

### DIFF
--- a/packages/plugin-fusion/CHANGELOG.md
+++ b/packages/plugin-fusion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- [fix] error occur when use plugin without config `theme`
+
 ## 1.0.0
 
 - [feat] support use fusion component in ice.js framework.

--- a/packages/plugin-fusion/package.json
+++ b/packages/plugin-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-fusion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "plugin for ICE while use fusion component",
   "license": "MIT",
   "type": "module",

--- a/packages/plugin-fusion/src/index.ts
+++ b/packages/plugin-fusion/src/index.ts
@@ -71,7 +71,7 @@ const plugin: Plugin<PluginOptions> = (options = {}) => ({
           silent: true,
         });
         if (iconFile) {
-          config.transformPlugins = [...(config.transformPlugins || []), importIcon(iconFile, theme['css-prefix'] || 'next-')];
+          config.transformPlugins = [...(config.transformPlugins || []), importIcon(iconFile, theme?.['css-prefix'] || 'next-')];
         }
         // Modify webpack config of scss rule for fusion theme.
         config.configureWebpack ??= [];


### PR DESCRIPTION
Fix error when use plugin without config `theme`