### PR TITLE
feat: modify textContent to support styleElement in weex

### DIFF
--- a/packages/runtime/src/domRender.ts
+++ b/packages/runtime/src/domRender.ts
@@ -17,7 +17,7 @@ export default function __ICE__CREATE_ELEMENT(options: CreateElementOptions, con
 
   let node: Element | Text;
   if (text) {
-    node = document.createTextNode(text);
+    container.textContent = text;
   } else {
     node = document.createElement(tagName);
 
@@ -28,9 +28,9 @@ export default function __ICE__CREATE_ELEMENT(options: CreateElementOptions, con
     children.forEach((child) => {
       __ICE__CREATE_ELEMENT(child, node);
     });
-  }
 
-  container.appendChild(node);
+    container.appendChild(node);
+  }
 
   return node;
 }


### PR DESCRIPTION
textContent 替换 textNode 子节点实现，以兼容 weex 下 styleElement 无法通过插入 textNode 来 work 的行为。