### PR TITLE
fix: bump version of @swc/helpers

### DIFF
--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.5
+
+- [fix] bump @swc/helpers version (0.4.12-> 0.4.14) for module cannot resolve of `@swc/helpers/src/_object_destructuring_empty.mjs`
+
 ## v3.0.4
 
 - [feat] support incremental compile for server bundle

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -41,7 +41,7 @@
     "@ice/route-manifest": "1.0.0",
     "@ice/runtime": "^1.0.0",
     "@ice/webpack-config": "1.0.4",
-    "@swc/helpers": "0.4.12",
+    "@swc/helpers": "0.4.14",
     "@types/express": "^4.17.14",
     "address": "^1.1.2",
     "build-scripts": "^2.0.1-0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,7 +918,7 @@ importers:
       '@ice/route-manifest': 1.0.0
       '@ice/runtime': ^1.0.0
       '@ice/webpack-config': 1.0.4
-      '@swc/helpers': 0.4.12
+      '@swc/helpers': 0.4.14
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
       '@types/cross-spawn': ^6.0.2
@@ -969,7 +969,7 @@ importers:
       '@ice/route-manifest': link:../route-manifest
       '@ice/runtime': link:../runtime
       '@ice/webpack-config': link:../webpack-config
-      '@swc/helpers': 0.4.12
+      '@swc/helpers': 0.4.14
       '@types/express': 4.17.14
       address: 1.2.1
       build-scripts: 2.0.1-0
@@ -5957,8 +5957,8 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@swc/helpers/0.4.12:
-    resolution: {integrity: sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==}
+  /@swc/helpers/0.4.14:
+    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.4.0
     dev: false


### PR DESCRIPTION
Bump @swc/helpers version (0.4.12-> 0.4.14) for module cannot resolve of `@swc/helpers/src/_object_destructuring_empty.mjs`