### PR TITLE
fix: remove code of ObjectProperties

### DIFF
--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.6
+
+- [fix] remove code when dead code is `ObjectProperties`
+
 ## v3.0.5
 
 - [fix] bump @swc/helpers version (0.4.12-> 0.4.14) for module cannot resolve of `@swc/helpers/src/_object_destructuring_empty.mjs`

--- a/packages/ice/src/utils/babelPluginRemoveCode.ts
+++ b/packages/ice/src/utils/babelPluginRemoveCode.ts
@@ -23,9 +23,12 @@ const removeUnreferencedCode = (nodePath: NodePath<t.Program>) => {
                 binding.path.remove();
               }
             } else if (binding.path.node.id.type === 'ObjectPattern') {
-              binding.path.node.id.properties = binding.path.node.id.properties.filter((property) =>
-                ((property as t.ObjectProperty)?.value !== binding.identifier &&
-                  (property as t.RestElement)?.argument !== binding.identifier));
+              binding.path.node.id.properties = binding.path.node.id.properties.filter((property) => {
+                const { value, key } = property as t.ObjectProperty;
+                const argument = (property as t.RestElement)?.argument;
+                return value !== binding.identifier && argument !== binding.identifier &&
+                  (key?.type !== 'Identifier' || (key as t.Identifier)?.name !== binding.identifier.name);
+              });
               if (binding.path.node.id.properties.length === 0) {
                 binding.path.remove();
               }

--- a/packages/ice/tests/fixtures/removeCode/properties.ts
+++ b/packages/ice/tests/fixtures/removeCode/properties.ts
@@ -1,0 +1,7 @@
+const c = {};
+const { a = '', b = '' } = c;
+const d = () => {
+  console.log(a, b);
+}
+
+export default d;

--- a/packages/ice/tests/removeTopLevelCode.test.ts
+++ b/packages/ice/tests/removeTopLevelCode.test.ts
@@ -98,4 +98,11 @@ describe('remove top level code', () => {
     const content = generate(ast).code;
     expect(content.replace(/\n/g, '').replace(/\s+/g, ' ')).toBe('');
   });
+
+  it('remove nested reference code', () => {
+    const ast = parse(fs.readFileSync(path.join(__dirname, './fixtures/removeCode/properties.ts'), 'utf-8'), parserOptions);
+    traverse(ast, removeTopLevelCodePlugin(['pageConfig']));
+    const content = generate(ast).code;
+    expect(content.replace(/\n/g, '').replace(/\s+/g, ' ')).toBe('');
+  });
 });


### PR DESCRIPTION
Remove code when dead code is `ObjectProperties`