### PR TITLE
Fix/rax-compat jsx runtime

### DIFF
--- a/examples/rax-inline-style/src/components/HybridReactComponent/index.tsx
+++ b/examples/rax-inline-style/src/components/HybridReactComponent/index.tsx
@@ -1,0 +1,10 @@
+export default function HybridReactComponent(props) {
+  return (
+    <div style={{
+      width: '400rpx',
+      height: '200rpx',
+      background: 'red',
+    }}
+    >HybridReactComponent in 400rpx * 200rpx red box.</div>
+  );
+}

--- a/examples/rax-inline-style/src/components/HybridReactComponent/index.tsx
+++ b/examples/rax-inline-style/src/components/HybridReactComponent/index.tsx
@@ -1,4 +1,4 @@
-export default function HybridReactComponent(props) {
+export default function HybridReactComponent() {
   return (
     <div style={{
       width: '400rpx',

--- a/examples/rax-inline-style/src/document.tsx
+++ b/examples/rax-inline-style/src/document.tsx
@@ -1,5 +1,4 @@
 /* @jsx createElement */
-import { createElement } from 'rax';
 import { Meta, Title, Links, Main, Scripts } from 'ice';
 
 function Document() {

--- a/examples/rax-inline-style/src/pages/index.jsx
+++ b/examples/rax-inline-style/src/pages/index.jsx
@@ -3,6 +3,7 @@ import View from 'rax-view';
 import Text from 'rax-text';
 import Logo from '@/components/Logo';
 import Title from '@/components/Title';
+import HybridReactComponent from '@/components/HybridReactComponent';
 import './index.css';
 
 export default function Home() {
@@ -25,6 +26,7 @@ export default function Home() {
       <Title />
       <Text className="homeInfo">More information about Rax</Text>
       <Text className="homeInfo">Visit https://rax.js.org</Text>
+      <HybridReactComponent />
     </View>
   );
 }

--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -10,7 +10,7 @@ import type { AppConfig } from '@ice/runtime/esm/types';
 import type { ServerCompiler, GetAppConfig, GetRoutesConfig, ExtendsPluginAPI, GetDataloaderConfig } from '../types/plugin.js';
 import webpackCompiler from '../service/webpackCompiler.js';
 import formatWebpackMessages from '../utils/formatWebpackMessages.js';
-import { IMPORT_META_RENDERER, IMPORT_META_TARGET, RUNTIME_TMP_DIR, SERVER_OUTPUT_DIR } from '../constant.js';
+import { IMPORT_META_RENDERER, IMPORT_META_TARGET, RUNTIME_TMP_DIR, SERVER_OUTPUT_DIR, WEB } from '../constant.js';
 import emptyDir from '../utils/emptyDir.js';
 import type { UserConfig } from '../types/userConfig.js';
 import warnOnHashRouterEnabled from '../utils/warnOnHashRouterEnabled.js';
@@ -43,7 +43,7 @@ const build = async (
     userConfig,
   } = options;
   const { applyHook, commandArgs, rootDir } = context;
-  const { target } = commandArgs;
+  const { target = WEB } = commandArgs;
 
   if (appConfig?.router?.type === 'hash') {
     warnOnHashRouterEnabled(userConfig);

--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -79,12 +79,22 @@ export function createServerCompiler(options: Options) {
     let depsMetadata: DepsMetaData;
     let swcOptions = merge({}, {
       // Only get the `compilationConfig` from task config.
-      compilationConfig: {
-        ...(task.config?.swcOptions?.compilationConfig || {}),
-        // Force inline when use swc as a transformer.
-        sourceMaps: sourceMap && 'inline',
-      },
+      compilationConfig: getCompilationConfig(),
     }, swc);
+    function getCompilationConfig() {
+      const customCompilationConfig = task.config?.swcOptions?.compilationConfig || {};
+      const getConfig = typeof customCompilationConfig === 'function'
+        ? customCompilationConfig
+        : () => customCompilationConfig;
+
+      return (source, id) => {
+        return {
+          ...getConfig(source, id),
+          // Force inline when use swc as a transformer.
+          sourceMaps: sourceMap && 'inline',
+        };
+      };
+    }
     const enableSyntaxFeatures = syntaxFeatures && Object.keys(syntaxFeatures).some(key => syntaxFeatures[key]);
     const transformPlugins = getCompilerPlugins({
       ...task.config,

--- a/packages/plugin-rax-compat/CHANGELOG.md
+++ b/packages/plugin-rax-compat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- [refactor] Using rax-compat/jsx-runtime to support rax components
+
 ## 0.1.2
 
 - [fix] get css path by onLoad lifecycle.

--- a/packages/plugin-rax-compat/package.json
+++ b/packages/plugin-rax-compat/package.json
@@ -8,7 +8,8 @@
     ".": {
       "import": "./esm/index.js",
       "default": "./esm/index.js"
-    }
+    },
+    "./*": "./*"
   },
   "main": "./esm/index.js",
   "types": "./esm/index.d.ts",
@@ -25,6 +26,7 @@
     "css": "^2.2.1",
     "lodash.merge": "^4.6.2",
     "rax-compat": "^0.1.0",
+    "style-unit": "^3.0.5",
     "stylesheet-loader": "^0.9.1"
   },
   "devDependencies": {

--- a/packages/plugin-rax-compat/package.json
+++ b/packages/plugin-rax-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ice/plugin-rax-compat",
-  "version": "0.1.2",
-  "description": "",
+  "version": "0.1.3",
+  "description": "Provide rax compat support for ice.js",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -67,7 +67,7 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
     onGetConfig((config) => {
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {
-        compilationConfig: (source: string, id: string) => {
+        compilationConfig: (source: string) => {
           const isRaxComponent = /from\s['"]rax['"]/.test(source);
           if (isRaxComponent) {
             return {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -22,6 +22,9 @@ const alias = {
   'rax-find-dom-node': require.resolve('rax-compat/find-dom-node'),
   'rax-is-valid-element': require.resolve('rax-compat/is-valid-element'),
   'rax-unmount-component-at-node': require.resolve('rax-compat/unmount-component-at-node'),
+
+  'rax-compat/runtime/jsx-dev-runtime': require.resolve('rax-compat/runtime/jsx-dev-runtime'),
+  'rax-compat/runtime/jsx-runtime': require.resolve('rax-compat/runtime/jsx-runtime'),
 };
 
 const ruleSetStylesheet = {
@@ -64,16 +67,19 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
     onGetConfig((config) => {
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {
-        compilationConfig: {
-          jsc: {
-            transform: {
-              react: {
-                runtime: 'classic',
-                pragma: 'createElement',
-                pragmaFrag: 'Fragment',
+        compilationConfig: (source: string, id: string) => {
+          const isRaxComponent = /from\s['"]rax['"]/.test(source);
+          if (isRaxComponent) {
+            return {
+              jsc: {
+                transform: {
+                  react: {
+                    importSource: 'rax-compat/runtime',
+                  },
+                },
               },
-            },
-          },
+            };
+          }
         },
       });
 

--- a/packages/rax-compat/CHANGELOG.md
+++ b/packages/rax-compat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## v0.1.2
+## 0.1.6
 
-- Fix: support event transform.
+- [feat] provide jsx-runtime for JSX transform automatic.
+
+## 0.1.2
+
+- [fix] support event transform.

--- a/packages/rax-compat/package.json
+++ b/packages/rax-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-compat",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Rax compatible mode, running rax project on the react runtime.",
   "files": [
     "esm",

--- a/packages/rax-compat/package.json
+++ b/packages/rax-compat/package.json
@@ -21,6 +21,8 @@
     "./find-dom-node": "./esm/find-dom-node.js",
     "./is-valid-element": "./esm/is-valid-element.js",
     "./unmount-component-at-node": "./esm/unmount-component-at-node.js",
+    "./runtime/jsx-dev-runtime": "./esm/runtime/jsx-dev-runtime.js",
+    "./runtime/jsx-runtime": "./esm/runtime/jsx-runtime.js",
     "./es2017": "./es2017/index.js"
   },
   "sideEffects": [

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -12,7 +12,6 @@ import VisibilityChange from '@ice/appear';
 import { isFunction, isObject, isNumber } from './type';
 import transformProps from './props';
 
-
 // https://github.com/alibaba/rax/blob/master/packages/driver-dom/src/index.js
 // opacity -> opa
 // fontWeight -> ntw
@@ -68,26 +67,13 @@ const InputCompat = forwardRef((props: any, inputRef: any) => {
   });
 });
 
-/**
- * Compat createElement for rax export.
- * Reference: https://github.com/alibaba/rax/blob/master/packages/rax/src/createElement.js#L13
- * @param type
- * @param props
- * @param children
- * @returns Element
- */
-export function createElement<P extends {
-  ref: RefObject<any>;
-  children: any;
-  style?: object;
-  onAppear?: Function;
-  onDisappear?: Function;
-}>(
-  type: FunctionComponent<P> | string,
-  props?: Attributes & P | null,
-  ...children: ReactNode[]): ReactElement {
+export function compatInstanceCreation(type: FunctionComponent | string, props: any, ...children: ReactNode[]): {
+  type: FunctionComponent | string;
+  props: any;
+  children: ReactNode[];
+} {
   // Get a shallow copy of props, to avoid mutating the original object.
-  let rest: Attributes & P = Object.assign({}, props);
+  let rest = Object.assign({}, props);
   const { onAppear, onDisappear } = rest;
 
   // Delete props that are not allowed in react.
@@ -114,17 +100,47 @@ export function createElement<P extends {
 
   // Compat for visibility events.
   if (isFunction(onAppear) || isFunction(onDisappear)) {
-    return _createElement(
-      VisibilityChange,
-      {
+    return {
+      type: VisibilityChange,
+      props: {
         onAppear,
         onDisappear,
-        children: _createElement(type, rest, ...children),
       },
-    );
+      children: [_createElement(type, rest, ...children)],
+    };
   } else {
-    return _createElement(type, rest, ...children);
+    return {
+      type,
+      props: rest,
+      children,
+    };
   }
+}
+
+/**
+ * Compat createElement for rax export.
+ * Reference: https://github.com/alibaba/rax/blob/master/packages/rax/src/createElement.js#L13
+ * @param type
+ * @param props
+ * @param children
+ * @returns Element
+ */
+export function createElement<P extends {
+  ref: RefObject<any>;
+  children: any;
+  style?: object;
+  onAppear?: Function;
+  onDisappear?: Function;
+}>(
+  type: FunctionComponent<P> | string,
+  props?: Attributes & P | null,
+  ...children: ReactNode[]): ReactElement {
+  const {
+    type: compatType,
+    props: compatProps,
+    children: compatChildren,
+  } = compatInstanceCreation(type, props, ...children);
+  return _createElement(compatType, compatProps, ...compatChildren);
 }
 
 const isDimensionalProp = cached((prop: string) => !NON_DIMENSIONAL_REG.test(prop));

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -70,7 +70,7 @@ const InputCompat = forwardRef((props: any, inputRef: any) => {
 export function compatInstanceCreation(type: FunctionComponent | string, props: any, ...children: ReactNode[]): {
   type: FunctionComponent | string;
   props: any;
-  children: ReactNode[];
+  children?: ReactNode[];
 } {
   // Get a shallow copy of props, to avoid mutating the original object.
   let rest = Object.assign({}, props);
@@ -105,8 +105,8 @@ export function compatInstanceCreation(type: FunctionComponent | string, props: 
       props: {
         onAppear,
         onDisappear,
+        children: _createElement(type, rest, ...children),
       },
-      children: [_createElement(type, rest, ...children)],
     };
   } else {
     return {

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -151,7 +151,7 @@ export function createElement<P extends {
       .forEach((child) => childrenToRender.push(child));
     delete compatProps.children;
   }
-  return _createElement(compatType, compatProps, ...toArray(compatChildren));
+  return _createElement(compatType, compatProps, ...childrenToRender);
 }
 
 function toArray(item: any): any[] {

--- a/packages/rax-compat/src/possible-standard-names.ts
+++ b/packages/rax-compat/src/possible-standard-names.ts
@@ -1,5 +1,5 @@
 // Select part from https://github.com/facebook/react/blob/main/packages/react-dom/src/shared/possibleStandardNames.js#L11
-const possibleStandardNames = {
+const possibleStandardNames: Record<string, string> = {
   autofocus: 'autoFocus',
   autoplay: 'autoPlay',
   classname: 'className',

--- a/packages/rax-compat/src/runtime/impl.ts
+++ b/packages/rax-compat/src/runtime/impl.ts
@@ -6,20 +6,20 @@ const ReactSharedInternals = React['__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE
 const { ReactCurrentOwner } = ReactSharedInternals;
 const REACT_ELEMENT_TYPE = Symbol.for('react.element');
 const { hasOwnProperty } = Object.prototype;
+const __DEV__ = process.env.NODE_ENV !== 'production';
 
 export function jsxs(type: any, props: object, key: string, source: object, self: any) {
   return jsx(type, props, key, source, self);
 }
 
 export function jsx(type: any, props: object, key: string, source: object, self: any) {
-  const ref = hasValidRef(props) ? props['ref'] : null;
-  if (!hasOwnProperty.call(props, 'key') && key !== undefined) {
-    props['key'] = key;
-  }
+  const hasValidKey = !hasOwnProperty.call(props, 'key') && key !== undefined;
+  const propsWithKey = Object.assign({}, props, hasValidKey ? { key } : null);
   const {
     type: compatType,
     props: compatProps,
-  } = compatInstanceCreation(type, props);
+  } = compatInstanceCreation(type, propsWithKey);
+  const ref = hasValidRef(compatProps) ? compatProps.ref : null;
   return ReactElement(compatType, key, ref, self, source, ReactCurrentOwner.current, compatProps);
 }
 
@@ -36,7 +36,7 @@ function ReactElement(type, key, ref, self, source, owner, props) {
     _owner: owner,
   };
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (__DEV__) {
     // @ts-ignore
     const store = element._store = {};
     Object.defineProperty(store, 'validated', {

--- a/packages/rax-compat/src/runtime/impl.ts
+++ b/packages/rax-compat/src/runtime/impl.ts
@@ -13,7 +13,14 @@ export function jsxs(type: any, props: object, key: string, source: object, self
 
 export function jsx(type: any, props: object, key: string, source: object, self: any) {
   const ref = hasValidRef(props) ? props['ref'] : null;
-  return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
+  if (!hasOwnProperty.call(props, 'key') && key !== undefined) {
+    props['key'] = key;
+  }
+  const {
+    type: compatType,
+    props: compatProps,
+  } = compatInstanceCreation(type, props);
+  return ReactElement(compatType, key, ref, self, source, ReactCurrentOwner.current, compatProps);
 }
 
 function ReactElement(type, key, ref, self, source, owner, props) {

--- a/packages/rax-compat/src/runtime/impl.ts
+++ b/packages/rax-compat/src/runtime/impl.ts
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import Fragment from '../fragment.js';
+import { compatInstanceCreation } from '../create-element.js';
+
+const ReactSharedInternals = React['__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED'];
+const { ReactCurrentOwner } = ReactSharedInternals;
+const REACT_ELEMENT_TYPE = Symbol.for('react.element');
+const { hasOwnProperty } = Object.prototype;
+
+export function jsxs(type: any, props: object, key: string, source: object, self: any) {
+  return jsx(type, props, key, source, self);
+}
+
+export function jsx(type: any, props: object, key: string, source: object, self: any) {
+  const ref = hasValidRef(props) ? props['ref'] : null;
+  return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
+}
+
+function ReactElement(type, key, ref, self, source, owner, props) {
+  const element = {
+    // This tag allows us to uniquely identify this as a React Element
+    $$typeof: REACT_ELEMENT_TYPE,
+    // Built-in properties that belong on the element
+    type: type,
+    key: key,
+    ref: ref,
+    props: props,
+    // Record the component responsible for creating this element.
+    _owner: owner,
+  };
+
+  if (process.env.NODE_ENV !== 'production') {
+    // @ts-ignore
+    const store = element._store = {};
+    Object.defineProperty(store, 'validated', {
+      configurable: false,
+      enumerable: false,
+      writable: true,
+      value: false,
+    }); // self and source are DEV only properties.
+
+    Object.defineProperty(element, '_self', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: self,
+    }); // Two elements created in two different places should be considered
+    // equal for testing purposes and therefore we hide it from enumeration.
+
+    Object.defineProperty(element, '_source', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: source,
+    });
+
+    if (Object.freeze) {
+      Object.freeze(element.props);
+      Object.freeze(element);
+    }
+  }
+
+  return element;
+}
+
+function hasValidRef(props: any) {
+  if (hasOwnProperty.call(props, 'ref')) {
+    const getter = Object.getOwnPropertyDescriptor(props, 'ref').get;
+
+    if (getter && getter['isReactWarning']) {
+      return false;
+    }
+  }
+  return props.ref !== undefined;
+}
+
+export { Fragment };

--- a/packages/rax-compat/src/runtime/jsx-dev-runtime.ts
+++ b/packages/rax-compat/src/runtime/jsx-dev-runtime.ts
@@ -1,0 +1,15 @@
+
+import { jsxs, jsx } from './impl.js';
+export { Fragment } from './impl.js';
+export function jsxDEV(
+  type: any,
+  props: object,
+  key: string,
+  isStaticChildren: boolean,
+  source: object,
+  self: any,
+) {
+  return isStaticChildren
+    ? jsxs(type, props, key, source, self)
+    : jsx(type, props, key, source, self);
+}

--- a/packages/rax-compat/src/runtime/jsx-runtime.ts
+++ b/packages/rax-compat/src/runtime/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export { jsx, jsxs, Fragment } from './impl.js';

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -38,7 +38,7 @@ interface ConfigurationCtx<T = typeof webpack> extends Config {
 type Experimental = Configuration['experiments'];
 interface SwcOptions {
   removeExportExprs?: string[];
-  compilationConfig?: SwcCompilationConfig;
+  compilationConfig?: SwcCompilationConfig | ((source: string, id: string) => SwcCompilationConfig);
   keepPlatform?: 'node' | 'web' | 'weex' | 'miniapp' | 'wechat-miniprogram' | 'bytedance-microapp' | 'baidu-smartprogram' | 'kuaishou-miniprogram';
   keepExports?: string[];
   getRoutePaths?: Function;

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -91,7 +91,9 @@ const compilationPlugin = (options: Options): UnpluginOptions => {
 
       merge(programmaticOptions, commonOptions);
 
-      if (compilationConfig) {
+      if (typeof compilationConfig === 'function') {
+        merge(programmaticOptions, compilationConfig(source, fileId));
+      } else if (compilationConfig) {
         merge(programmaticOptions, compilationConfig);
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1255,6 +1255,7 @@ importers:
       css: ^2.2.1
       lodash.merge: ^4.6.2
       rax-compat: ^0.1.0
+      style-unit: ^3.0.5
       stylesheet-loader: ^0.9.1
       webpack: ^5.73.0
     dependencies:
@@ -1266,6 +1267,7 @@ importers:
       css: 2.2.4
       lodash.merge: 4.6.2
       rax-compat: link:../rax-compat
+      style-unit: 3.0.5
       stylesheet-loader: 0.9.1
     devDependencies:
       '@ice/app': link:../ice


### PR DESCRIPTION
1. 修复 rax-compat 插件下 react createElement 没有劫持实现 compatStyle 的 bug
2. 修复 rax-compat 插件下必须引入 createElemenet 变量的问题, 在实现上由 plugin-rax-compat 注入判断, 并修改 swcOptions.jsc.react.runtime 的值

Close #5789 