### PR TITLE
fix: modify basename when render as a child app

### DIFF
--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [fix] rebuild server entry when document changed
 - [fix] set ssr default value to `false`
 - [fix] server compiler options when bundle server entry
+- [fix] support define expression of basename
 
 ## v3.0.5
 

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -182,7 +182,8 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     hasExportAppData,
     runtimeModules,
     coreEnvKeys,
-    basename: platformTaskConfig.config.basename || '/',
+    // Stringify basename because `config` basename in task config only support type string.
+    basename: JSON.stringify(platformTaskConfig.config.basename || '/'),
     memoryRouter: platformTaskConfig.config.memoryRouter,
     hydrate: !csr,
     importCoreJs: polyfill === 'entry',

--- a/packages/ice/templates/core/entry.client.tsx.ejs
+++ b/packages/ice/templates/core/entry.client.tsx.ejs
@@ -1,4 +1,4 @@
-<% if (importCoreJs) { -%>import 'core-js';<% } -%>
+<% if (importCoreJs) { -%>import 'core-js';<% } %>
 import { createElement, Fragment } from 'react';
 import { runClientApp, getAppConfig } from '<%- iceRuntimePath %>';
 import { commons, statics } from './runtimeModules';
@@ -10,7 +10,7 @@ import routes from './routes';
 <% if(dataLoaderImport.imports) {-%><%-dataLoaderImport.imports%><% } -%>
 const getRouterBasename = () => {
   const appConfig = getAppConfig(app);
-  return appConfig?.router?.basename ?? '<%- basename %>' ?? '';
+  return appConfig?.router?.basename ?? <%- basename %> ?? '';
 }
 // Add react fragment for split chunks of app.
 // Otherwise chunk of route component will pack @ice/jsx-runtime and depend on framework bundle.

--- a/packages/ice/templates/core/entry.server.ts.ejs
+++ b/packages/ice/templates/core/entry.server.ts.ejs
@@ -19,7 +19,7 @@ const runtimeModules = { commons, statics };
 
 const getRouterBasename = () => {
   const appConfig = runtime.getAppConfig(app);
-  return appConfig?.router?.basename ?? '<%- basename %>' ?? '';
+  return appConfig?.router?.basename ?? <%- basename %> ?? '';
 }
 
 const setRuntimeEnv = (renderMode) => {

--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- [fix] modify basename when render as a child app.
+
 ## 1.0.0
 
 - [feat] plugin for micro-fontends, support both `Framework app` and `Sub app`.

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-icestark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -42,7 +42,7 @@ export function mount(props) {
   root = render({ runtimeOptions: props });
 }
 export function unmount(props) {
-  root.unmount();
+  root?.then((res) => res.unmount());
   if (app?.icestark?.unmount) {
     app?.icestark?.unmount(props);
   }

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -22,9 +22,16 @@ const plugin: Plugin<PluginOptions> = ({ type, library }) => ({
       return config;
     });
     if (type === 'child') {
+      // Modify basename when render as a child app.
+      generator.modifyRenderData((data) => {
+        return {
+          ...data,
+          basename: `(typeof window !== 'undefined' && window.ICESTARK?.basename || ${data.basename})`,
+        };
+      });
       generator.addEntryCode(() => {
         return `
-if (!window.ICESTARK) {
+if (!window.ICESTARK?.root) {
   render();
 }
 let root;


### PR DESCRIPTION
Basename must be modified when render as a child app, framework app will pass basename by `window.ICESTARK.basename`