### PR TITLE
chore: optimize error display

### DIFF
--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -21,7 +21,8 @@ export async function loadRouteModule(route: RouteModule, routeModulesCache: Rou
     routeModulesCache[id] = routeModule;
     return routeModule;
   } catch (error) {
-    console.error(`Failed to load route module: ${id}.\n${error}`);
+    console.error(`Failed to load route module: ${id}.`);
+    console.error(error);
   }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1195765/211760098-26d5e8f5-41e9-42bb-b539-4294030efff8.png)

如上图：error 对象在字符串中嵌套打印会丢失 stacktrace，导致报错信息有限，不利于排查问题~