### PR TITLE
fix: data-loader using serverCompiler with renderer client

### DIFF
--- a/examples/with-data-loader/src/pages/home.tsx
+++ b/examples/with-data-loader/src/pages/home.tsx
@@ -24,8 +24,6 @@ export function pageConfig() {
 export const dataLoader = defineDataLoader(async () => {
   const result = await fetch('https://api.github.com/repos/ice-lab/ice-next');
   const data = await result.json();
-  const { target } = import.meta;
-  const { renderer } = import.meta;
-  console.log('target, renderer:', target, renderer);
+  console.log('target, renderer:', import.meta.target, import.meta.renderer);
   return data;
 });

--- a/examples/with-data-loader/src/pages/home.tsx
+++ b/examples/with-data-loader/src/pages/home.tsx
@@ -24,6 +24,8 @@ export function pageConfig() {
 export const dataLoader = defineDataLoader(async () => {
   const result = await fetch('https://api.github.com/repos/ice-lab/ice-next');
   const data = await result.json();
-
+  const { target } = import.meta;
+  const { renderer } = import.meta;
+  console.log('target, renderer:', target, renderer);
   return data;
 });

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -109,7 +109,7 @@ async function webpackCompiler(options: {
 
     // Add webpack plugin of data-loader.
     if (useDataLoader) {
-      webpackConfig.plugins.push(new DataLoaderPlugin({ serverCompiler, rootDir, dataCache, getAllPlugin }));
+      webpackConfig.plugins.push(new DataLoaderPlugin({ serverCompiler, target, rootDir, dataCache, getAllPlugin }));
     }
   }
 

--- a/packages/ice/src/webpack/DataLoaderPlugin.ts
+++ b/packages/ice/src/webpack/DataLoaderPlugin.ts
@@ -4,7 +4,7 @@ import type { Compiler } from 'webpack';
 import webpack from '@ice/bundles/compiled/webpack/index.js';
 import type { Context } from 'build-scripts';
 import type { ServerCompiler, PluginData } from '../types/plugin.js';
-import { RUNTIME_TMP_DIR } from '../constant.js';
+import { IMPORT_META_RENDERER, IMPORT_META_TARGET, RUNTIME_TMP_DIR } from '../constant.js';
 import { getRoutePathsFromCache } from '../utils/getRoutePaths.js';
 import { getSupportedBrowsers } from '../utils/getSupportedBrowsers.js';
 
@@ -14,20 +14,23 @@ const { RawSource } = webpack.sources;
 export default class DataLoaderPlugin {
   private serverCompiler: ServerCompiler;
   private rootDir: string;
+  private target: string;
   private dataCache: Map<string, string>;
   private getAllPlugin: Context['getAllPlugin'];
 
   public constructor(options: {
     serverCompiler: ServerCompiler;
     rootDir: string;
+    target: string;
     dataCache: Map<string, string>;
     getAllPlugin?: Context['getAllPlugin'];
   }) {
-    const { serverCompiler, rootDir, dataCache, getAllPlugin } = options;
+    const { serverCompiler, rootDir, dataCache, getAllPlugin, target } = options;
     this.serverCompiler = serverCompiler;
     this.rootDir = rootDir;
     this.dataCache = dataCache;
     this.getAllPlugin = getAllPlugin;
+    this.target = target;
   }
 
   public apply(compiler: Compiler) {
@@ -64,6 +67,11 @@ export default class DataLoaderPlugin {
                 getRoutePaths: () => {
                   return getRoutePathsFromCache(this.dataCache);
                 },
+              },
+              runtimeDefineVars: {
+                [IMPORT_META_TARGET]: JSON.stringify(this.target),
+                // `data-loader.js` runs in the browser.
+                [IMPORT_META_RENDERER]: JSON.stringify('client'),
               },
               preBundle: false,
               externalDependencies: false,

--- a/tests/integration/with-data-loader.test.ts
+++ b/tests/integration/with-data-loader.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test, describe } from 'vitest';
+import { buildFixture } from '../utils/build';
+
+// @ts-ignore
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const example = 'with-data-loader';
+
+describe(`build ${example}`, () => {
+  test('data-loader build file', async () => {
+    await buildFixture(example);
+    const content = fs.readFileSync(path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`), 'utf-8');
+    expect(content.includes('console.log("target, renderer:","web","client")')).toBe(true);
+  });
+});


### PR DESCRIPTION
- data-loader.js 产物使用 serverCompiler 进行编译，但是是运行在 client 端的文件