### PR TITLE
docs: fix import defineAppConfigh from ice

### DIFF
--- a/website/docs/guide/advanced/update-from-icejs2.md
+++ b/website/docs/guide/advanced/update-from-icejs2.md
@@ -309,7 +309,7 @@ const appConfing = {};
 为了获得良好类型提示，推荐写法为：
 
 ```ts
-import { defineAppConfig } from '@ice/app';
+import { defineAppConfig } from 'ice';
 
 export default defineAppConfig(() => ({
   app: {


### PR DESCRIPTION
十分抱歉，上个 PR 过于心急其实把正确的给改错了...
原因是我删掉了本地生成的临时 .ice 文件夹，导致报错告诉我找不到 ice...，便以为应该从 @ice/app 中引入 defineAppConfig

十分抱歉，十分抱歉