### PR TITLE
fix: prebundle esm module error

### DIFF
--- a/.changeset/famous-peas-visit.md
+++ b/.changeset/famous-peas-visit.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+feat: export types

--- a/.changeset/forty-zoos-talk.md
+++ b/.changeset/forty-zoos-talk.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: prebundle esm module error

--- a/.changeset/plenty-pans-flow.md
+++ b/.changeset/plenty-pans-flow.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+feat: add generator.addTargetExport API

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -31,7 +31,7 @@
     "@ice/appear": "0.1.4",
     "@ice/bundles": "0.1.4",
     "create-ice": "1.8.2",
-    "@ice/app": "3.1.1-beta.7",
+    "@ice/app": "3.1.1-beta.8",
     "@ice/jsx-runtime": "0.2.0",
     "@ice/miniapp-html-styles": "1.0.0",
     "@ice/miniapp-loader": "1.0.0",
@@ -60,9 +60,11 @@
   },
   "changesets": [
     "chatty-balloons-argue",
+    "famous-peas-visit",
     "flat-poets-dream",
     "forty-zoos-talk",
     "lemon-owls-beg",
+    "plenty-pans-flow",
     "wild-chairs-mix"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -31,7 +31,7 @@
     "@ice/appear": "0.1.4",
     "@ice/bundles": "0.1.4",
     "create-ice": "1.8.2",
-    "@ice/app": "3.1.1-beta.6",
+    "@ice/app": "3.1.1-beta.7",
     "@ice/jsx-runtime": "0.2.0",
     "@ice/miniapp-html-styles": "1.0.0",
     "@ice/miniapp-loader": "1.0.0",
@@ -45,7 +45,7 @@
     "@ice/plugin-jsx-plus": "1.0.0",
     "@ice/plugin-miniapp": "1.0.1",
     "@ice/plugin-moment-locales": "1.0.0",
-    "@ice/plugin-pha": "1.1.3-beta.6",
+    "@ice/plugin-pha": "1.1.3-beta.7",
     "@ice/plugin-rax-compat": "0.1.3",
     "@ice/plugin-request": "1.0.0",
     "@ice/plugin-store": "1.0.2",
@@ -54,13 +54,14 @@
     "@ice/runtime": "1.1.1",
     "@ice/shared": "1.0.0",
     "@ice/style-import": "1.0.0",
-    "@ice/webpack-config": "1.0.7-beta.6",
+    "@ice/webpack-config": "1.0.7-beta.7",
     "@ice/webpack-modify": "1.0.0",
     "ice-website-v3": "0.0.0"
   },
   "changesets": [
     "chatty-balloons-argue",
     "flat-poets-dream",
+    "forty-zoos-talk",
     "lemon-owls-beg",
     "wild-chairs-mix"
   ]

--- a/packages/bundles/package.json
+++ b/packages/bundles/package.json
@@ -38,7 +38,6 @@
     "@types/less": "^3.0.3",
     "@types/lodash": "^4.14.181",
     "@types/webpack-bundle-analyzer": "^4.4.1",
-    "acorn": "8.8.0",
     "cacache": "16.0.7",
     "copy-webpack-plugin": "10.2.4",
     "css-loader": "6.7.1",

--- a/packages/bundles/scripts/tasks.ts
+++ b/packages/bundles/scripts/tasks.ts
@@ -23,7 +23,7 @@ export const taskExternals = {
 };
 
 const commonDeps = ['terser', 'tapable', 'cssnano', 'terser-webpack-plugin', 'webpack', 'schema-utils',
-'lodash', 'postcss-preset-env', 'loader-utils', 'find-up', 'common-path-prefix', 'acorn', 'magic-string'];
+  'lodash', 'postcss-preset-env', 'loader-utils', 'find-up', 'common-path-prefix', 'magic-string'];
 
 const webpackDevServerDeps = ['bonjour-service', 'colorette', 'compression', 'connect-history-api-fallback',
 'default-gateway', 'express', 'graceful-fs', 'http-proxy-middleware',
@@ -58,7 +58,7 @@ const tasks = [
     'less-loader', 'postcss-loader', 'sass-loader', 'css-loader',
     'postcss-preset-env', 'postcss-nested', 'postcss-modules', 'postcss-plugin-rpx2vw',
     'webpack-bundle-analyzer', 'es-module-lexer', 'terser', 'trusted-cert', 'magic-string',
-    'eslint-webpack-plugin', 'copy-webpack-plugin', 'cacache', 'ora', 'unplugin', 'acorn',
+    'eslint-webpack-plugin', 'copy-webpack-plugin', 'cacache', 'ora', 'unplugin',
     // Dependencies of react-refresh-webpack-plugin.
     'loader-utils', 'source-map', 'find-up', 'common-path-prefix',
     // Dependencies of webpack-dev-server.

--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.1-beta.8
+
+### Patch Changes
+
+- 14b11542: fix: prebundle esm module error
+
 ## 3.1.1-beta.7
 
 ### Patch Changes

--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.1-beta.9
+
+### Patch Changes
+
+- 7e38619b: feat: add generator.addTargetExport API
+- Updated dependencies [7e38619b]
+  - @ice/runtime@1.1.2-beta.0
+
 ## 3.1.1-beta.8
 
 ### Patch Changes

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/app",
-  "version": "3.1.1-beta.7",
+  "version": "3.1.1-beta.8",
   "description": "provide scripts and configuration used by web framework ice",
   "type": "module",
   "main": "./esm/index.js",

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/app",
-  "version": "3.1.1-beta.8",
+  "version": "3.1.1-beta.9",
   "description": "provide scripts and configuration used by web framework ice",
   "type": "module",
   "main": "./esm/index.js",
@@ -39,7 +39,7 @@
     "@babel/types": "7.18.10",
     "@ice/bundles": "0.1.4",
     "@ice/route-manifest": "1.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/runtime": "^1.1.2-beta.0",
     "@ice/webpack-config": "1.0.7-beta.7",
     "@swc/helpers": "0.4.14",
     "@types/express": "^4.17.14",

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -71,7 +71,6 @@
     "@types/babel__traverse": "^7.17.1",
     "@types/cross-spawn": "^6.0.2",
     "@types/ejs": "^3.1.0",
-    "@types/estree": "^0.0.51",
     "@types/less": "^3.0.3",
     "@types/micromatch": "^4.0.2",
     "@types/multer": "^1.4.7",

--- a/packages/ice/src/esbuild/external.ts
+++ b/packages/ice/src/esbuild/external.ts
@@ -6,7 +6,7 @@ interface PluginOptions {
   externalDependencies: boolean;
   format: BuildOptions['format'];
   externals?: string[];
-  ignores: string[];
+  ignores?: string[];
 }
 
 const externalPlugin = (options: PluginOptions): Plugin => {

--- a/packages/ice/src/esbuild/transformImport.ts
+++ b/packages/ice/src/esbuild/transformImport.ts
@@ -1,19 +1,14 @@
 import path from 'path';
 import type { TransformOptions } from 'esbuild';
 import { esbuild } from '@ice/bundles';
-import acorn from '@ice/bundles/compiled/acorn/index.js';
 import MagicString from '@ice/bundles/compiled/magic-string/index.js';
 import esModuleLexer from '@ice/bundles/compiled/es-module-lexer/index.js';
 import type { ImportSpecifier } from '@ice/bundles/compiled/es-module-lexer/index.js';
-import type { Node } from 'estree';
 import type { UnpluginOptions } from 'unplugin';
 import type { PreBundleDepsMetaData } from '../service/preBundleDeps.js';
 import formatPath from '../utils/formatPath.js';
 
 const { init, parse } = esModuleLexer;
-const { parse: parseJS } = acorn;
-
-type ImportNameSpecifier = { importedName: string; localName: string };
 
 /**
  * Redirect original dependency path to the prebundle dependency path.
@@ -90,104 +85,6 @@ async function transformWithESBuild(
   } as TransformOptions;
 
   return await esbuild.transform(input, transformOptions);
-}
-
-function transformCjsImport(
-  importExp: string,
-  importUrl: string,
-  depId: string,
-  importIndex: number,
-): string | undefined {
-  const node = (
-    parseJS(importExp, {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-    }) as any
-  ).body[0] as Node;
-
-  if (
-    node.type === 'ImportDeclaration' ||
-    node.type === 'ExportNamedDeclaration'
-  ) {
-    if (!node.specifiers.length) {
-      return `import "${importUrl}"`;
-    }
-
-    const importNames: ImportNameSpecifier[] = [];
-    const exportNames: string[] = [];
-    let defaultExports = '';
-    for (const spec of node.specifiers) {
-      if (
-        spec.type === 'ImportSpecifier' &&
-        spec.imported.type === 'Identifier'
-      ) {
-        const importedName = spec.imported.name;
-        const localName = spec.local.name;
-        importNames.push({ importedName, localName });
-      } else if (spec.type === 'ImportDefaultSpecifier') {
-        importNames.push({
-          importedName: 'default',
-          localName: spec.local.name,
-        });
-      } else if (spec.type === 'ImportNamespaceSpecifier') {
-        importNames.push({ importedName: '*', localName: spec.local.name });
-      } else if (
-        spec.type === 'ExportSpecifier' &&
-        spec.exported.type === 'Identifier'
-      ) {
-        // for ExportSpecifier, local name is same as imported name
-        const importedName = spec.local.name;
-        // we want to specify exported name as variable and re-export it
-        const exportedName = spec.exported.name;
-        if (exportedName === 'default') {
-          defaultExports = makeLegalIdentifier(`__ice__cjsExportDefault_${importIndex}`);
-          importNames.push({ importedName, localName: defaultExports });
-        } else {
-          importNames.push({ importedName, localName: exportedName });
-          exportNames.push(exportedName);
-        }
-      }
-    }
-
-    // If there is multiple import for same id in one file,
-    // importIndex will prevent the cjsModuleName to be duplicate
-    const cjsModuleName = makeLegalIdentifier(`__ice__cjsImport${importIndex}_${depId}`);
-    const lines: string[] = [`import ${cjsModuleName} from "${importUrl}"`];
-    importNames.forEach(({ importedName, localName }) => {
-      if (importedName === '*') {
-        lines.push(`const ${localName} = ${cjsModuleName}`);
-      } else if (importedName === 'default') {
-        lines.push(
-          `const ${localName} = ${cjsModuleName}.__esModule ? ${cjsModuleName}.default : ${cjsModuleName}`,
-        );
-      } else {
-        lines.push(`const ${localName} = ${cjsModuleName}["${importedName}"]`);
-      }
-    });
-    if (defaultExports) {
-      lines.push(`export default ${defaultExports}`);
-    }
-    if (exportNames.length) {
-      lines.push(`export { ${exportNames.join(', ')} }`);
-    }
-
-    return lines.join('; ');
-  }
-}
-
-// Fork from https://github.com/rollup/plugins/blob/master/packages/pluginutils/src/makeLegalIdentifier.ts
-// avoid the import name is not valid in import statement
-const reservedWords = 'break case class catch const continue debugger default delete do else export extends finally for function if import in instanceof let new return super switch this throw try typeof var void while with yield enum await implements package protected static interface private public';
-const builtins = 'arguments Infinity NaN undefined null true false eval uneval isFinite isNaN parseFloat parseInt decodeURI decodeURIComponent encodeURI encodeURIComponent escape unescape Object Function Boolean Symbol Error EvalError InternalError RangeError ReferenceError SyntaxError TypeError URIError Number Math Date String RegExp Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array Map Set WeakMap WeakSet SIMD ArrayBuffer DataView JSON Promise Generator GeneratorFunction Reflect Proxy Intl';
-const forbiddenIdentifiers = new Set(`${reservedWords} ${builtins}`.split(' '));
-function makeLegalIdentifier(str: string) {
-  let identifier = str
-    .replace(/-(\w)/g, (_, letter) => letter.toUpperCase())
-    .replace(/[^$_a-zA-Z0-9]/g, '_');
-  if (/\d/.test(identifier[0]) || forbiddenIdentifiers.has(identifier)) {
-    identifier = `_${identifier}`;
-  }
-  return identifier || '_';
 }
 
 export default transformImportPlugin;

--- a/packages/ice/src/service/preBundleDeps.ts
+++ b/packages/ice/src/service/preBundleDeps.ts
@@ -49,7 +49,7 @@ interface PreBundleDepsOptions {
  * Only when the server bundle format type is esm,
  * we will pre bundle dependencies which maybe have import css file directly.
  *
- * Why? CSS file can not be resolve in ESM(server render will run in ESM), so we will external the css file.
+ * CSS files can not be resolve in ESM(server render will run in ESM), so we will external item.
  */
 export default async function preBundleDeps(
   depsInfo: Record<string, DepScanData>,

--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -24,8 +24,8 @@ import formatPath from '../utils/formatPath.js';
 import { createLogger } from '../utils/logger.js';
 import { getExpandedEnvs } from '../utils/runtimeEnv.js';
 import { scanImports } from './analyze.js';
-import type { DepsMetaData } from './preBundleCJSDeps.js';
-import preBundleCJSDeps from './preBundleCJSDeps.js';
+import type { PreBundleDepsMetaData } from './preBundleDeps.js';
+import preBundleDeps from './preBundleDeps.js';
 
 const logger = createLogger('server-compiler');
 
@@ -77,7 +77,7 @@ export function createServerCompiler(options: Options) {
     transformEnv = true,
     isServer = true,
   } = {}) => {
-    let depsMetadata: DepsMetaData;
+    let preBundleDepsMetadata: PreBundleDepsMetaData;
     let swcOptions = merge({}, {
       // Only get the `compilationConfig` from task config.
       compilationConfig: getCompilationConfig(),
@@ -127,7 +127,7 @@ export function createServerCompiler(options: Options) {
     }
 
     if (preBundle) {
-      depsMetadata = await createDepsMetadata({
+      preBundleDepsMetadata = await createPreBundleDepsMetadata({
         task,
         alias,
         ignores,
@@ -189,8 +189,8 @@ export function createServerCompiler(options: Options) {
           plugins: [
             ...transformPlugins,
             // Plugin transformImportPlugin need after transformPlugins in case of it has onLoad lifecycle.
-            dev && preBundle && depsMetadata && transformImportPlugin(
-              depsMetadata,
+            dev && preBundle && preBundleDepsMetadata && transformImportPlugin(
+              preBundleDepsMetadata,
               path.join(rootDir, task.config.outputDir, SERVER_OUTPUT_DIR),
             ),
           ].filter(Boolean),
@@ -255,7 +255,7 @@ interface CreateDepsMetadataOptions {
 /**
  *  Create dependencies metadata only when server entry is bundled to esm.
  */
-async function createDepsMetadata(
+async function createPreBundleDepsMetadata(
   { rootDir, task, plugins, alias, ignores, define, external }: CreateDepsMetadataOptions,
 ) {
   const serverEntry = getServerEntry(rootDir, task.config?.server?.entry);
@@ -279,7 +279,8 @@ async function createDepsMetadata(
   // For examples: react, react-dom, @ice/runtime
   const preBundleDepsInfo = filterPreBundleDeps(deps);
   const cacheDir = path.join(rootDir, CACHE_DIR);
-  const ret = await preBundleCJSDeps({
+  const ret = await preBundleDeps(preBundleDepsInfo, {
+    rootDir,
     depsInfo: preBundleDepsInfo,
     cacheDir,
     taskConfig: task.config,

--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -281,7 +281,6 @@ async function createPreBundleDepsMetadata(
   const cacheDir = path.join(rootDir, CACHE_DIR);
   const ret = await preBundleDeps(preBundleDepsInfo, {
     rootDir,
-    depsInfo: preBundleDepsInfo,
     cacheDir,
     taskConfig: task.config,
     alias,

--- a/packages/ice/src/utils/getServerCompilerPlugin.ts
+++ b/packages/ice/src/utils/getServerCompilerPlugin.ts
@@ -49,6 +49,8 @@ function getServerCompilerPlugin(serverCompiler: ServerCompiler, options: Option
         incremental,
       },
       {
+        // The server bundle will external all the dependencies when the format type is esm,
+        // so we need to prebundle all the dependencies first to avoid errors of importing non-js file in ESM.
         preBundle: format === 'esm' && (ssr || ssg),
         swc: {
           keepExports: (!ssg && !ssr) ? ['pageConfig'] : null,

--- a/packages/ice/tests/preBundleCJSDeps.test.ts
+++ b/packages/ice/tests/preBundleCJSDeps.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { afterAll, expect, it } from 'vitest';
 import fse from 'fs-extra';
-import preBundleCJSDeps from '../src/service/preBundleCJSDeps';
+import preBundleDeps from '../src/service/preBundleDeps';
 import { scanImports } from '../src/service/analyze';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,16 +12,16 @@ const cacheDir = path.join(rootDir, '.cache');
 
 it('prebundle cjs deps', async () => {
   const deps = await scanImports([path.join(__dirname, './fixtures/scan/app.ts')], { alias, rootDir });
-  await preBundleCJSDeps({
-    depsInfo: deps,
+  await preBundleDeps(deps, {
     cacheDir,
     alias,
+    rootDir,
     taskConfig: { mode: 'production' },
   });
-
-  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', 'react.js'))).toBeTruthy();
-  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime_client.js'))).toBeTruthy();
-  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime.js'))).toBeTruthy();
+  debugger;
+  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', 'react.mjs'))).toBeTruthy();
+  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime_client.mjs'))).toBeTruthy();
+  expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime.mjs'))).toBeTruthy();
 });
 
 afterAll(async () => {

--- a/packages/ice/tests/preBundleCJSDeps.test.ts
+++ b/packages/ice/tests/preBundleCJSDeps.test.ts
@@ -18,7 +18,6 @@ it('prebundle cjs deps', async () => {
     rootDir,
     taskConfig: { mode: 'production' },
   });
-  debugger;
   expect(fse.pathExistsSync(path.join(cacheDir, 'deps', 'react.mjs'))).toBeTruthy();
   expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime_client.mjs'))).toBeTruthy();
   expect(fse.pathExistsSync(path.join(cacheDir, 'deps', '@ice_runtime.mjs'))).toBeTruthy();

--- a/packages/ice/tests/transformImport.test.ts
+++ b/packages/ice/tests/transformImport.test.ts
@@ -4,7 +4,7 @@ import { afterAll, expect, it } from 'vitest';
 import fse from 'fs-extra';
 import esbuild from 'esbuild';
 import { createUnplugin } from 'unplugin';
-import preBundleCJSDeps from '../src/service/preBundleCJSDeps';
+import preBundleDeps from '../src/service/preBundleDeps';
 import { scanImports } from '../src/service/analyze';
 import transformImport from '../src/esbuild/transformImport';
 import externalPlugin from '../src/esbuild/external';
@@ -18,13 +18,13 @@ const outdir = path.join(rootDir, 'build');
 
 it('transform module import', async () => {
   const deps = await scanImports([appEntry], { alias, rootDir });
-  const { metadata } = await preBundleCJSDeps({
-    depsInfo: deps,
+  const { metadata } = await preBundleDeps(deps, {
+    rootDir,
     cacheDir,
     alias,
     taskConfig: { mode: 'production' },
   });
-  const transformImportPlugin = createUnplugin(() => transformImport(metadata, path.join(outdir, 'server'))).esbuild;
+  const transformImportPlugin = createUnplugin(() => transformImport(metadata!, path.join(outdir, 'server'))).esbuild;
   await esbuild.build({
     alias,
     bundle: true,
@@ -36,8 +36,8 @@ it('transform module import', async () => {
     ],
   });
   const buildContent = await fse.readFile(path.join(outdir, 'app.js'));
-  expect(buildContent.includes('../../.cache/deps/@ice_runtime_client.js')).toBeTruthy();
-  expect(buildContent.includes('../../.cache/deps/@ice_runtime.js')).toBeTruthy();
+  expect(buildContent.includes('../../.cache/deps/@ice_runtime_client.mjs')).toBeTruthy();
+  expect(buildContent.includes('../../.cache/deps/@ice_runtime.mjs')).toBeTruthy();
 });
 
 afterAll(async () => {

--- a/packages/miniapp-react-dom/CHANGELOG.md
+++ b/packages/miniapp-react-dom/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ice/miniapp-react-dom
+
+## 1.0.1-beta.0
+
+### Patch Changes
+
+- @ice/miniapp-runtime@1.0.2-beta.0

--- a/packages/miniapp-react-dom/package.json
+++ b/packages/miniapp-react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/miniapp-react-dom",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.0",
   "description": "like react-dom, but for miniapps.",
   "type": "module",
   "types": "./esm/index.d.ts",
@@ -23,7 +23,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@ice/miniapp-runtime": "^1.0.0",
+    "@ice/miniapp-runtime": "^1.0.2-beta.0",
     "@ice/shared": "^1.0.0",
     "react-reconciler": "0.27.0",
     "scheduler": "^0.20.1"

--- a/packages/miniapp-runtime/CHANGELOG.md
+++ b/packages/miniapp-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.2-beta.0
+
+### Patch Changes
+
+- Updated dependencies [7e38619b]
+  - @ice/runtime@1.1.2-beta.0
+
 ## v1.0.1
 
 - [refactor] use static create method to create instance of EventSource which extends Map to avoid es5 environment error

--- a/packages/miniapp-runtime/package.json
+++ b/packages/miniapp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/miniapp-runtime",
-  "version": "1.0.1",
+  "version": "1.0.2-beta.0",
   "description": "ice runtime for miniapps.",
   "type": "module",
   "types": "./esm/index.d.ts",
@@ -25,7 +25,7 @@
   "sideEffects": false,
   "dependencies": {
     "@ice/shared": "^1.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/runtime": "^1.1.2-beta.0",
     "miniapp-history": "^0.1.7"
   },
   "devDependencies": {

--- a/packages/plugin-auth/package.json
+++ b/packages/plugin-auth/package.json
@@ -38,8 +38,8 @@
     "!esm/**/*.map"
   ],
   "devDependencies": {
-    "@ice/app": "^3.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "^3.1.1-beta.9",
+    "@ice/runtime": "^1.1.2-beta.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "regenerator-runtime": "^0.13.9"

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -38,8 +38,8 @@
     "@ice/stark-app": "^1.2.0"
   },
   "devDependencies": {
-    "@ice/app": "^3.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "^3.1.1-beta.9",
+    "@ice/runtime": "^1.1.2-beta.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0"
   },

--- a/packages/plugin-miniapp/CHANGELOG.md
+++ b/packages/plugin-miniapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.2-beta.0
+
+### Patch Changes
+
+- @ice/miniapp-runtime@1.0.2-beta.0
+- @ice/miniapp-react-dom@1.0.1-beta.0
+
 ## 1.0.1
 
 - [fix] rename platform to target

--- a/packages/plugin-miniapp/package.json
+++ b/packages/plugin-miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-miniapp",
-  "version": "1.0.1",
+  "version": "1.0.2-beta.0",
   "description": "ice.js plugin for miniapp.",
   "license": "MIT",
   "type": "module",
@@ -18,8 +18,8 @@
   "dependencies": {
     "@ice/bundles": "^0.1.0",
     "@ice/miniapp-loader": "^1.0.0",
-    "@ice/miniapp-react-dom": "^1.0.0",
-    "@ice/miniapp-runtime": "^1.0.0",
+    "@ice/miniapp-react-dom": "^1.0.1-beta.0",
+    "@ice/miniapp-runtime": "^1.0.2-beta.0",
     "@ice/shared": "^1.0.0",
     "acorn-walk": "^8.2.0",
     "chalk": "^4.0.0",
@@ -30,7 +30,7 @@
     "sax": "^1.2.4"
   },
   "devDependencies": {
-    "@ice/app": "^3.0.0",
+    "@ice/app": "^3.1.1-beta.9",
     "webpack": "^5.73.0"
   },
   "repository": {

--- a/packages/plugin-request/package.json
+++ b/packages/plugin-request/package.json
@@ -52,8 +52,8 @@
     "axios": "^0.27.2"
   },
   "devDependencies": {
-    "@ice/app": "^3.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "^3.1.1-beta.9",
+    "@ice/runtime": "^1.1.2-beta.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "regenerator-runtime": "^0.13.9"

--- a/packages/plugin-store/package.json
+++ b/packages/plugin-store/package.json
@@ -43,8 +43,8 @@
     "micromatch": "^4.0.5"
   },
   "devDependencies": {
-    "@ice/app": "^3.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "^3.1.1-beta.9",
+    "@ice/runtime": "^1.1.2-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@types/react": "^18.0.0",

--- a/packages/plugin-store/src/runtime.tsx
+++ b/packages/plugin-store/src/runtime.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import type { RuntimePlugin, AppProvider, RouteWrapper } from '@ice/runtime/esm/types';
-import { Link } from '@ice/runtime';
 import { PAGE_STORE_INITIAL_STATES, PAGE_STORE_PROVIDER } from './constants.js';
 import type { StoreConfig } from './types.js';
-
-console.log('=====>', Link);
 
 const EXPORT_CONFIG_NAME = 'storeConfig';
 

--- a/packages/plugin-store/src/runtime.tsx
+++ b/packages/plugin-store/src/runtime.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import type { RuntimePlugin, AppProvider, RouteWrapper } from '@ice/runtime/esm/types';
+import { Link } from '@ice/runtime';
 import { PAGE_STORE_INITIAL_STATES, PAGE_STORE_PROVIDER } from './constants.js';
 import type { StoreConfig } from './types.js';
+
+console.log('=====>', Link);
 
 const EXPORT_CONFIG_NAME = 'storeConfig';
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ice/runtime
 
+## 1.1.2-beta.0
+
+### Patch Changes
+
+- 7e38619b: feat: export types
+
 ## v1.1.1
 
 - [chore] update usage of @ice/jsx-runtime
@@ -7,7 +13,7 @@
 ## v1.1.0
 
 - [feat] suspense ssr
-- [feat] support render js bundle as entry 
+- [feat] support render js bundle as entry
 - [fix] compatible with empty meta element
 
 ## v1.0.5

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.1.1",
+  "version": "1.1.2-beta.0",
   "description": "Runtime module for ice.js",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,7 +785,6 @@ importers:
       '@types/less': ^3.0.3
       '@types/lodash': ^4.14.181
       '@types/webpack-bundle-analyzer': ^4.4.1
-      acorn: 8.8.0
       ansi-html-community: ^0.0.8
       bonjour-service: ^1.0.13
       cacache: 16.0.7
@@ -880,7 +879,6 @@ importers:
       '@types/less': 3.0.3
       '@types/lodash': 4.14.185
       '@types/webpack-bundle-analyzer': 4.4.2_ncbsfugu56ddhgadp34k4kpsue
-      acorn: 8.8.0
       bonjour-service: 1.0.14
       cacache: 16.0.7
       colorette: 2.0.19
@@ -972,7 +970,6 @@ importers:
       '@types/babel__traverse': ^7.17.1
       '@types/cross-spawn': ^6.0.2
       '@types/ejs': ^3.1.0
-      '@types/estree': ^0.0.51
       '@types/express': ^4.17.14
       '@types/less': ^3.0.3
       '@types/micromatch': ^4.0.2
@@ -1047,7 +1044,6 @@ importers:
       '@types/babel__traverse': 7.18.2
       '@types/cross-spawn': 6.0.2
       '@types/ejs': 3.1.1
-      '@types/estree': 0.0.51
       '@types/less': 3.0.3
       '@types/micromatch': 4.0.2
       '@types/multer': 1.4.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,7 +963,7 @@ importers:
       '@babel/types': 7.18.10
       '@ice/bundles': 0.1.4
       '@ice/route-manifest': 1.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/runtime': ^1.1.2-beta.0
       '@ice/webpack-config': 1.0.7-beta.7
       '@swc/helpers': 0.4.14
       '@types/babel__generator': ^7.6.4
@@ -1089,7 +1089,7 @@ importers:
 
   packages/miniapp-react-dom:
     specifiers:
-      '@ice/miniapp-runtime': ^1.0.0
+      '@ice/miniapp-runtime': ^1.0.2-beta.0
       '@ice/shared': ^1.0.0
       react: ^18.0.0
       react-reconciler: 0.27.0
@@ -1104,7 +1104,7 @@ importers:
 
   packages/miniapp-runtime:
     specifiers:
-      '@ice/runtime': ^1.0.0
+      '@ice/runtime': ^1.1.2-beta.0
       '@ice/shared': ^1.0.0
       '@types/react': ^18.0.0
       history: ^5.3.0
@@ -1132,13 +1132,13 @@ importers:
 
   packages/plugin-auth:
     specifiers:
-      '@ice/app': ^3.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': ^3.1.1-beta.9
+      '@ice/runtime': ^1.1.2-beta.0
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       regenerator-runtime: ^0.13.9
     devDependencies:
-      '@ice/app': 3.1.0
+      '@ice/app': link:../ice
       '@ice/runtime': link:../runtime
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
@@ -1166,8 +1166,8 @@ importers:
 
   packages/plugin-icestark:
     specifiers:
-      '@ice/app': ^3.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': ^3.1.1-beta.9
+      '@ice/runtime': ^1.1.2-beta.0
       '@ice/stark': ^2.7.4
       '@ice/stark-app': ^1.2.0
       '@types/react': ^18.0.0
@@ -1176,7 +1176,7 @@ importers:
       '@ice/stark': 2.7.4
       '@ice/stark-app': 1.5.0
     devDependencies:
-      '@ice/app': 3.1.0
+      '@ice/app': link:../ice
       '@ice/runtime': link:../runtime
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
@@ -1210,11 +1210,11 @@ importers:
 
   packages/plugin-miniapp:
     specifiers:
-      '@ice/app': ^3.0.0
+      '@ice/app': ^3.1.1-beta.9
       '@ice/bundles': ^0.1.0
       '@ice/miniapp-loader': ^1.0.0
-      '@ice/miniapp-react-dom': ^1.0.0
-      '@ice/miniapp-runtime': ^1.0.0
+      '@ice/miniapp-react-dom': ^1.0.1-beta.0
+      '@ice/miniapp-runtime': ^1.0.2-beta.0
       '@ice/shared': ^1.0.0
       acorn-walk: ^8.2.0
       chalk: ^4.0.0
@@ -1238,7 +1238,7 @@ importers:
       regenerator-runtime: 0.11.1
       sax: 1.2.4
     devDependencies:
-      '@ice/app': 3.1.0
+      '@ice/app': link:../ice
       webpack: 5.75.0
 
   packages/plugin-moment-locales:
@@ -1305,8 +1305,8 @@ importers:
 
   packages/plugin-request:
     specifiers:
-      '@ice/app': ^3.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': ^3.1.1-beta.9
+      '@ice/runtime': ^1.1.2-beta.0
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       ahooks: ^3.0.0
@@ -1316,7 +1316,7 @@ importers:
       ahooks: 3.7.1
       axios: 0.27.2
     devDependencies:
-      '@ice/app': 3.1.0
+      '@ice/app': link:../ice
       '@ice/runtime': link:../runtime
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
@@ -1324,8 +1324,8 @@ importers:
 
   packages/plugin-store:
     specifiers:
-      '@ice/app': ^3.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': ^3.1.1-beta.9
+      '@ice/runtime': ^1.1.2-beta.0
       '@ice/store': ^2.0.3
       '@types/micromatch': ^4.0.2
       '@types/react': ^18.0.0
@@ -1340,7 +1340,7 @@ importers:
       fast-glob: 3.2.12
       micromatch: 4.0.5
     devDependencies:
-      '@ice/app': 3.1.0_biqbaboplfbrettd7655fr4n2y
+      '@ice/app': link:../ice
       '@ice/runtime': link:../runtime
       '@types/micromatch': 4.0.2
       '@types/react': 18.0.21
@@ -5214,52 +5214,6 @@ packages:
       - supports-color
     dev: true
 
-  /@ice/app/3.1.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-ST34PqQoC0sCynX7QeWfYCup8gQMdGbFSfRU4DWfD3EObi2PiwvwVAmoyeYKjxVzCmnNyeaWd4NHkTBSuTHHIQ==}
-    engines: {node: '>=14.19.0', npm: '>=3.0.0'}
-    hasBin: true
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-    dependencies:
-      '@babel/generator': 7.18.10
-      '@babel/parser': 7.18.10
-      '@babel/traverse': 7.18.10
-      '@babel/types': 7.18.10
-      '@ice/bundles': 0.1.4
-      '@ice/route-manifest': 1.0.0
-      '@ice/runtime': 1.1.1_biqbaboplfbrettd7655fr4n2y
-      '@ice/webpack-config': 1.0.6
-      '@swc/helpers': 0.4.14
-      '@types/express': 4.17.16
-      address: 1.2.2
-      build-scripts: 2.1.0
-      chalk: 4.1.2
-      commander: 9.4.0
-      consola: 2.15.3
-      core-js: 3.26.0
-      cross-spawn: 7.0.3
-      detect-port: 1.5.1
-      dotenv: 16.0.2
-      dotenv-expand: 8.0.3
-      ejs: 3.1.8
-      fast-glob: 3.2.12
-      find-up: 5.0.0
-      fs-extra: 10.1.0
-      micromatch: 4.0.5
-      mrmime: 1.0.1
-      open: 8.4.0
-      path-to-regexp: 6.2.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      resolve.exports: 1.1.0
-      semver: 7.3.8
-      temp: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@ice/bundles/0.1.4:
     resolution: {integrity: sha512-SHDuVamOoh/Q/Y5WdRz5/S1og6CtUKbSSuNgLldUqD1Uox1WNNVsW7XVunXAMXkaSHpgD9Sim+/+zvZe5t5K+g==}
     dependencies:
@@ -5289,15 +5243,6 @@ packages:
     peerDependencies:
       react: ^16 || ^17 || ^18
     dependencies:
-      style-unit: 3.0.5
-    dev: true
-
-  /@ice/jsx-runtime/0.2.0_react@18.2.0:
-    resolution: {integrity: sha512-yUfoWloQq2mdyCTsTTWwxtx0dmiwC4Xe2QEaQCg/yFqQKz7hOFBOrju6RodMl7K0fdpj6k1UBfjLd9gPyUBAbw==}
-    peerDependencies:
-      react: ^16 || ^17 || ^18
-    dependencies:
-      react: 18.2.0
       style-unit: 3.0.5
     dev: true
 
@@ -5363,22 +5308,6 @@ packages:
       history: 5.3.0
       htmlparser2: 8.0.1
       react-router-dom: 6.4.1
-    dev: true
-
-  /@ice/runtime/1.1.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-a8aDgunbV9X9WD1wvJQ/NT0rHlZv4IbzBBRIOzZO6Ruev9gDtHm1UXm/Wnriy6tnelnKeh/S1l/z3tcrwXi4CQ==}
-    peerDependencies:
-      react: ^18.1.0
-      react-dom: ^18.1.0
-    dependencies:
-      '@ice/jsx-runtime': 0.2.0_react@18.2.0
-      ejs: 3.1.8
-      fs-extra: 10.1.0
-      history: 5.3.0
-      htmlparser2: 8.0.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-router-dom: 6.4.1_biqbaboplfbrettd7655fr4n2y
     dev: true
 
   /@ice/sandbox/1.1.4:
@@ -18925,6 +18854,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.4.1_react@18.2.0
+    dev: false
 
   /react-router/5.3.4_react@17.0.2:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}


### PR DESCRIPTION
预打包依赖过程，由于预打包依赖的格式是 cjs，如果依赖中的依赖是被 external 的，那么预构建产物中将会是 require('xxx')。Server Bundle 如果是在 ESM 下运行的话，就会直接报错

https://github.com/evanw/esbuild/issues/1921#issuecomment-1152991694