### PR TITLE
Fix/custom appworker

### DIFF
--- a/.changeset/gentle-trains-cross.md
+++ b/.changeset/gentle-trains-cross.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-pha': major
+---
+
+[fix] app-worker is not compiled when set a custom name

--- a/packages/plugin-pha/CHANGELOG.md
+++ b/packages/plugin-pha/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.4
+
+- [fix] app-worker is not compiled when set a custom name
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/plugin-pha/CHANGELOG.md
+++ b/packages/plugin-pha/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 1.1.4
-
-- [fix] app-worker is not compiled when set a custom name
-
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/plugin-pha/src/generateManifest.ts
+++ b/packages/plugin-pha/src/generateManifest.ts
@@ -39,7 +39,7 @@ export async function getAppWorkerPath({
   getAppConfig,
   rootDir,
 }) {
-  const appConfig = getAppConfig(['phaManifest']);
+  const appConfig = await getAppConfig(['phaManifest']);
   let manifest = appConfig.phaManifest;
   return getAppWorkerUrl(manifest, path.join(rootDir, 'src'));
 }


### PR DESCRIPTION
在配置了 dataLoader 的场景下，没有 await，拿了一个 promise 的 manifest 字段，怎么样都是 undefined，默认兜底拿 app-worker 了，自定义名称失效了。

这个也是一个问题：
close https://github.com/alibaba/ice/issues/5913