### PR TITLE
feat: enable ignoreModuleCheck to support compat rax

### DIFF
--- a/.changeset/quick-mails-draw.md
+++ b/.changeset/quick-mails-draw.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-jsx-plus': patch
+---
+
+Enable ignoreModuleCheck to support compat rax.

--- a/packages/plugin-jsx-plus/package.json
+++ b/packages/plugin-jsx-plus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ice/plugin-jsx-plus",
   "version": "1.0.0",
-  "description": "",
+  "description": "JSX Plus support for ice.js",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/plugin-jsx-plus/src/index.ts
+++ b/packages/plugin-jsx-plus/src/index.ts
@@ -12,7 +12,7 @@ const babelPlugins = [
   'babel-plugin-transform-jsx-condition',
   'babel-plugin-transform-jsx-memo',
   'babel-plugin-transform-jsx-slot',
-  ['babel-plugin-transform-jsx-fragment', { moduleName: 'react' }],
+  ['babel-plugin-transform-jsx-fragment', { moduleName: 'react', ignoreModuleCheck: true }],
   'babel-plugin-transform-jsx-class',
 ];
 


### PR DESCRIPTION
忽略 babel-plugin-transform-jsx-fragment 的 module check, 以避免在 rax-compat 场景下 mismatch 的问题