### PR TITLE
Feat/pha: support plugin-pha interface optional

### DIFF
--- a/.changeset/eleven-spiders-yell.md
+++ b/.changeset/eleven-spiders-yell.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-pha': major
+---
+
+fix: support plugin-pha interface optional

--- a/.changeset/eleven-spiders-yell.md
+++ b/.changeset/eleven-spiders-yell.md
@@ -1,5 +1,5 @@
 ---
-'@ice/plugin-pha': major
+'@ice/plugin-pha': patch
 ---
 
 fix: support plugin-pha interface optional

--- a/packages/plugin-pha/src/index.ts
+++ b/packages/plugin-pha/src/index.ts
@@ -17,8 +17,8 @@ export type Compiler = (options: {
 }, buildOptions: Parameters<ServerCompiler>[1]) => Promise<string>;
 
 interface PluginOptions {
-  template: boolean;
-  preload: boolean;
+  template?: boolean;
+  preload?: boolean;
 }
 
 function getDevPath(url: string): string {


### PR DESCRIPTION
插件调用参数无法仅添加preload：true，因为类型要求所有key必填