### PR TITLE
fix: do not clean contributor png when deploy website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           BRANCH: gh-pages
           FOLDER: website/build
+          clean-exclude: ice.png


### PR DESCRIPTION
Do not remove ice.png when deploy website