### PR TITLE
fix: should not build html file when distType has not html

### DIFF
--- a/.changeset/cuddly-rocks-warn.md
+++ b/.changeset/cuddly-rocks-warn.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: should not build html when distType has not html

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -70,13 +70,15 @@ export async function renderToEntry(
   const { value } = result;
 
   let jsOutput;
-  const { distType } = renderOptions;
-  if (value && distType && distType.includes('javascript')) {
+  const {
+    distType = ['html'],
+  } = renderOptions;
+  if (value && distType.includes('javascript')) {
     jsOutput = await renderHTMLToJS(value);
   }
 
   let htmlOutput;
-  if (distType && distType.includes('html')) {
+  if (distType.includes('html')) {
     htmlOutput = result;
   }
 

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -70,14 +70,18 @@ export async function renderToEntry(
   const { value } = result;
 
   let jsOutput;
-
   const { distType } = renderOptions;
   if (value && distType && distType.includes('javascript')) {
     jsOutput = await renderHTMLToJS(value);
   }
 
+  let htmlOutput;
+  if (distType && distType.includes('html')) {
+    htmlOutput = result;
+  }
+
   return {
-    ...result,
+    ...htmlOutput,
     jsOutput,
   };
 }


### PR DESCRIPTION
修复 distType 只包含 javascript 的时候不应该打出 html 文件的问题。

close https://github.com/alibaba/ice/issues/5972