### PR TITLE
Fix/component transform

### DIFF
--- a/.changeset/breezy-tips-boil.md
+++ b/.changeset/breezy-tips-boil.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+fix: Only the dom needs to be transformed, not the components

--- a/packages/rax-compat/src/compat/element.ts
+++ b/packages/rax-compat/src/compat/element.ts
@@ -18,7 +18,10 @@ export function createJSXElementFactory(factory: typeof ElementFactory) {
     delete rest.onDisappear;
 
     // Compat for props.
-    rest = transformProps(rest);
+    // Only the dom needs to be transformed, not the components.
+    if (typeof type === 'string') {
+      rest = transformProps(rest);
+    }
 
     // Compat for style unit.
     if (rest.style) {


### PR DESCRIPTION
close https://github.com/alibaba/ice/issues/5999

rax-compat 不应该修改组件的 props，否则会匹配不上，只处理 dom element 的 props。