### PR TITLE
fix: make sure config.splitChunks is not overwritten

### DIFF
--- a/packages/ice/src/config.ts
+++ b/packages/ice/src/config.ts
@@ -348,8 +348,12 @@ const userConfig = [
     name: 'splitChunks',
     validation: 'boolean',
     defaultValue: true,
-    setConfig: (config: Config, splitChunks: UserConfig['splitChunks']) => {
-      config.splitChunks = splitChunks;
+    setConfig: (config: Config, splitChunks: UserConfig['splitChunks'], context: UserConfigContext) => {
+      const { originalUserConfig } = context;
+      // Make sure config.splitChunks is not overwritten when codeSplitting is set.
+      if (!('codeSplitting' in originalUserConfig)) {
+        config.splitChunks = splitChunks;
+      }
     },
   },
   {


### PR DESCRIPTION
Make sure config.splitChunks is not overwritten when codeSplitting is set

Relate to #5957 