### PR TITLE
fix: make sure server env variable is always false

### DIFF
--- a/.changeset/tame-cherries-invite.md
+++ b/.changeset/tame-cherries-invite.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+fix: make sure ssr / ssg env variable is always false in csr

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -102,6 +102,9 @@ function getDefineVars(
   return {
     ...define,
     ...runtimeDefineVars,
+    // Make sure ICE_CORE_SSR and ICE_CORE_SSG is always false in csr mode.
+    'process.env.ICE_CORE_SSR': 'false',
+    'process.env.ICE_CORE_SSG': 'false',
   };
 }
 


### PR DESCRIPTION
Fix: #5966

Recommand to use `import.meta.rerender` for distinguish between csr, ssr and ssg.