### PR TITLE
fix: useState parameter initialState can be function, which should be…

### DIFF
--- a/.changeset/smart-ducks-live.md
+++ b/.changeset/smart-ducks-live.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+Fix: useState parameter initialState can be function, which should be self executed when initilzing

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -30,6 +30,11 @@ import { isFunction } from './type';
  * @returns [ value, dispatch ]
  */
 export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _useState> | any {
+  // If the initial state is the result of an expensive computation,
+  // you may provide a function instead for lazy initial state.
+  if (isFunction(initialState)) {
+    initialState = initialState();
+  }
   // The eagerState should be saved for filter shallow-equal value set.
   const stateHook = _useState({
     state: initialState,

--- a/packages/rax-compat/tests/hooks.test.tsx
+++ b/packages/rax-compat/tests/hooks.test.tsx
@@ -43,6 +43,22 @@ describe('hooks', () => {
     render(<App />);
   });
 
+  it('useState can be function', () => {
+    function App() {
+      const [value] = useState(() => 'useState');
+      useEffect(() => {
+        setTimeout(() => {
+          expect(value).toBe('useState');
+        }, 1);
+        // Expect useEffect to execute once
+        // eslint-disable-next-line
+      }, []);
+      return <div>{value}</div>;
+    }
+
+    render(<App />);
+  });
+
   it('useState update value', () => {
     const { result, rerender } = renderHook(() => useState(0));
     expect(result.current[0]).toEqual(0);


### PR DESCRIPTION
<img width="935" alt="image" src="https://user-images.githubusercontent.com/3922719/223729348-d70a2d1d-17bc-4d09-9374-7d16ef9a8714.png">


rax-compat 的实现中, 将 initialValue 包装在一个对象中的做法, 绕过了 function 自执行的逻辑, 导致这种用法的情况下异常