### PR TITLE
fix: external node builtin modules

### DIFF
--- a/.changeset/hip-moles-cheat.md
+++ b/.changeset/hip-moles-cheat.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: external node builtin modules

--- a/packages/ice/src/esbuild/externalNodeBuiltin.ts
+++ b/packages/ice/src/esbuild/externalNodeBuiltin.ts
@@ -1,0 +1,18 @@
+import { isNodeBuiltin } from 'mlly';
+import type { Plugin, PluginBuild } from 'esbuild';
+
+const externalBuiltinPlugin = (): Plugin => {
+  return {
+    name: 'esbuild-external-node-builtin',
+    setup(build: PluginBuild) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        const id = args.path;
+        if (isNodeBuiltin(id)) {
+          return { path: id, external: true };
+        }
+      });
+    },
+  };
+};
+
+export default externalBuiltinPlugin;

--- a/packages/ice/src/service/config.ts
+++ b/packages/ice/src/service/config.ts
@@ -8,6 +8,7 @@ import dynamicImport from '../utils/dynamicImport.js';
 import formatPath from '../utils/formatPath.js';
 import { RUNTIME_TMP_DIR, CACHE_DIR } from '../constant.js';
 import { createLogger } from '../utils/logger.js';
+import externalBuiltinPlugin from '../esbuild/externalNodeBuiltin.js';
 
 type GetOutfile = (entry: string, exportNames: string[]) => string;
 
@@ -45,11 +46,12 @@ class Config {
       const { error } = await serverCompiler({
         entryPoints: [entry],
         format: 'esm',
-        platform: 'node',
-        // Don't add banner for config file, it will cause name conflict when bundled by server entry.
-        banner: undefined,
         outfile,
-        plugins: [removeTopLevelCode(keepExports, transformInclude)],
+        plugins: [
+          removeTopLevelCode(keepExports, transformInclude),
+          // External node builtin modules, such as `fs`, it will be imported by weex document.
+          externalBuiltinPlugin(),
+        ],
         sourcemap: false,
         logLevel: 'silent', // The main server compiler process will log it.
       }, {});


### PR DESCRIPTION
Relate to #6041

如果直接设置 node 不去设置 banner 有可能会报 Dynamic require 错误，设置 banner 的情况下，由于 routes-config.bundle.mjs 会再次被引入打包，有记录命名冲突