### PR TITLE
feat: disable compress config in dev server for streaming render

### DIFF
--- a/.changeset/sixty-walls-sin.md
+++ b/.changeset/sixty-walls-sin.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+feat: disable `compress` config in dev server for streaming render

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -371,7 +371,7 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
       },
       proxy,
       hot: true,
-      compress: true,
+      compress: false,
       webSocketServer: 'ws',
       devMiddleware: {
         publicPath,


### PR DESCRIPTION
本地调试下，开启 compress 配置项后，流式渲染无法正常工作。考虑到对本地调试影响不大，故直接关掉