### PR TITLE
Feat/support pullfresh

### DIFF
--- a/.changeset/smooth-sloths-give.md
+++ b/.changeset/smooth-sloths-give.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-pha': patch
+---
+
+feat: support pull refresh

--- a/packages/plugin-pha/src/constants.ts
+++ b/packages/plugin-pha/src/constants.ts
@@ -78,6 +78,7 @@ export const validPageConfigKeys = [
   'spm',
   'queryParams',
   'queryParamsPassKeys',
+  'pullRefresh',
   'queryParamsPassIgnoreKeys',
 ];
 

--- a/packages/plugin-pha/src/constants.ts
+++ b/packages/plugin-pha/src/constants.ts
@@ -82,6 +82,11 @@ export const validPageConfigKeys = [
   'queryParamsPassIgnoreKeys',
 ];
 
+// The manifest configuration is the default value for the page configuration
+export const pageDefaultValueKeys = [
+  'pullRefresh',
+];
+
 export const getCompilerConfig = (options: {
   getAllPlugin: Context['getAllPlugin'];
 }) => {

--- a/packages/plugin-pha/src/manifestHelpers.ts
+++ b/packages/plugin-pha/src/manifestHelpers.ts
@@ -51,7 +51,7 @@ interface InternalPageConfig {
 type MixedPage = InternalPageConfig & PageConfig;
 
 export function transformManifestKeys(manifest: Manifest, options?: TransformOptions): PHAManifest {
-  const { parentKey, isRoot } = options;
+  const { parentKey, isRoot } = options || {};
   const data = {};
 
   for (let key in manifest) {

--- a/packages/plugin-pha/src/types.ts
+++ b/packages/plugin-pha/src/types.ts
@@ -123,6 +123,7 @@ export interface PageConfig extends FrameConfig {
   defaultFrameIndex?: number;
   dataPrefetch?: DataPrefetch[];
   queryParams?: string;
+  pullRefresh?: PullRefresh;
 }
 
 export type Page = string | PageConfig;
@@ -134,6 +135,7 @@ export type PHAFrame = Partial<{
   background_color: string;
   header_position: 'absolute' | 'static';
   enable_pull_refresh: boolean;
+  pull_refresh: boolean;
   priority: Priority;
 } & Omit<PHAPage, 'frames' | 'default_frame_index'>>;
 
@@ -154,6 +156,7 @@ export type PHAPage = Partial<{
   path: string;
   background_color: string;
   enable_pull_refresh: boolean;
+  pull_refresh: boolean;
   priority: Priority;
   script: string;
   stylesheet: string;
@@ -168,6 +171,10 @@ export type PHAPage = Partial<{
   frames: PHAFrame[];
 }>;
 
+type PullRefresh = boolean | {
+  reload: boolean;
+};
+
 export type Manifest = Partial<{
   enablePoplayer: boolean;
   disableCapture: boolean;
@@ -181,6 +188,7 @@ export type Manifest = Partial<{
   appWorker: AppWorker;
   routes: Page[];
   enableExpiredManifest: boolean;
+  pullRefresh?: PullRefresh;
 }> & WindowConfig & Record<string, any>;
 
 export type PHAManifest = Partial<{

--- a/packages/plugin-pha/tests/manifestHelper.test.ts
+++ b/packages/plugin-pha/tests/manifestHelper.test.ts
@@ -281,6 +281,185 @@ describe('parse manifest', async () => {
     expect(manifest?.app_worker?.url).toBe('https://cdn-path.com/pha-worker.js');
   });
 
+  it('should work with enable pull refresh', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      pullRefresh: {
+        reload: false,
+      },
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+        },
+        {
+          path: '/about',
+          name: 'about',
+        },
+        {
+          path: '/',
+          name: 'frames',
+          frames: [
+            {
+              name: 'frame1',
+              url: 'https://m.taobao.com',
+            },
+            {
+              name: 'frame2',
+              url: 'https://m.taobao.com',
+            },
+          ],
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].enable_pull_refresh).toBe(true);
+    expect(manifest?.pages![1].enable_pull_refresh).toBe(true);
+    expect(manifest?.pages![2].enable_pull_refresh).toBe(true);
+  });
+
+  it('should work with enable pull refresh', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      pullRefresh: {
+        reload: true,
+      },
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+          pullRefresh: {
+            reload: true,
+          },
+        },
+        {
+          path: '/about',
+          name: 'about',
+
+        },
+        {
+          path: '/',
+          name: 'frames',
+          frames: [
+            {
+              name: 'frame1',
+              url: 'https://m.taobao.com',
+              pullRefresh: {
+                reload: true,
+              },
+            },
+            {
+              name: 'frame2',
+              url: 'https://m.taobao.com',
+              pullRefresh: {
+                reload: true,
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].pull_refresh).toBe(true);
+    expect(manifest?.pages![1].pull_refresh).toBe(true);
+    expect(manifest?.pages![2].frames![0].pull_refresh).toBe(true);
+    expect(manifest?.pages![2].frames![1].pull_refresh).toBe(true);
+  });
+
+  it('pull refresh of manifest should be default value of page', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      pullRefresh: {
+        reload: true,
+      },
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+        },
+        {
+          path: '/about',
+          name: 'about',
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].pull_refresh).toBe(true);
+    expect(manifest?.pages![1].pull_refresh).toBe(true);
+  });
+
+  it('enable pull refresh of manifest should be default value of page', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      pullRefresh: true,
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+        },
+        {
+          path: '/about',
+          name: 'about',
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].enable_pull_refresh).toBe(true);
+    expect(manifest?.pages![1].enable_pull_refresh).toBe(true);
+  });
+
+  it('enable pull refresh of page should cover value of page', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      pullRefresh: {
+        reload: true,
+      },
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+          pullRefresh: {
+            reload: true,
+          },
+        },
+        {
+          path: '/about',
+          name: 'about',
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].pull_refresh).toBe(true);
+    expect(manifest?.pages![1].pull_refresh).toBe(true);
+  });
+
+  it('should work with enable pull refresh', async () => {
+    const phaManifest = {
+      appWorker: {
+        url: 'pha-worker.js',
+      },
+      routes: [
+        {
+          path: '/',
+          name: 'home',
+          pullRefresh: true,
+        },
+      ],
+    };
+    const manifest = await parseManifest(phaManifest, options);
+    expect(manifest?.pages![0].enable_pull_refresh).toBe(true);
+  });
+
   it('should set document to manifest', async () => {
     const phaManifest = {
       routes: [


### PR DESCRIPTION
close https://github.com/alibaba/ice/issues/6117

增加 pullfresh 配置 

{pullfresh: true} 打开软刷，{pullfresh: {reload: true}} 打开硬刷。

```js
// app.tsx
export const phaManifest: Manifest = {
  title: 'test',
  pullRefresh: {
    reload: true,
  },
  appWorker: {
    url: 'app-worker.ts',
  },
  routes: [
    {
      pageHeader: {},
      frames: [
        'blog',
        'home',
      ],
    },
    'home',
    'about',
    'custom',
  ],
};
```

```js
// home.tsx
export const pageConfig = definePageConfig(() => {
  return {
    pullRefresh: true,
    queryParamsPassKeys: [
      'questionId',
      'source',
      'disableNav',
    ],
    title: 'Home',
  };
});
```

page 的优先级会覆盖 phaManifest 的配置。