### PR TITLE
fix: remove all exports of routes when render mode is csr

### DIFF
--- a/.changeset/tricky-fans-shave.md
+++ b/.changeset/tricky-fans-shave.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: remove all exports of components when render mode is csr

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -293,6 +293,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
       rootDir,
       task: platformTaskConfig,
       server,
+      csr,
     });
     addWatchEvent([
       /src\/?[\w*-:.$]+$/,

--- a/packages/ice/src/service/ServerRunner.ts
+++ b/packages/ice/src/service/ServerRunner.ts
@@ -25,6 +25,7 @@ import { filterAlias, getRuntimeDefination } from './serverCompiler.js';
 interface InitOptions {
   rootDir: string;
   server: UserConfig['server'];
+  csr: boolean;
   task: TaskConfig<Config>;
 }
 
@@ -86,6 +87,7 @@ class ServerRunner extends Runner {
     task,
     server,
     rootDir,
+    csr,
   }: InitOptions) {
     const transformPlugins = getCompilerPlugins(rootDir, {
       ...task.config,
@@ -94,6 +96,8 @@ class ServerRunner extends Runner {
       polyfill: false,
       swcOptions: {
         nodeTransform: true,
+        // Remove all exports except pageConfig when ssr and ssg both are false.
+        keepExports: csr ? ['pageConfig'] : null,
         compilationConfig: {
           jsc: {
             // https://node.green/#ES2020


### PR DESCRIPTION
SSR and SSG both are disabled, it may also cause server error such as `window is undefined` when using onDemand compiling.