### PR TITLE
fix: rax compat state

### DIFF
--- a/.changeset/olive-bobcats-trade.md
+++ b/.changeset/olive-bobcats-trade.md
@@ -1,0 +1,6 @@
+---
+'rax-compat': patch
+---
+
+fix: state not update error
+feat: support defaultProps in forwardRef 

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -50,7 +50,7 @@ export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _use
     }
     eagerState.current = newState;
   }
-  
+
   return [stateHook[0], updateState, eagerState.current];
 }
 

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -30,7 +30,7 @@ import { isFunction } from './type';
  * @returns [ value, dispatch ]
  */
 export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _useState> | any {
-  const eagerState = _useRef();
+  const eagerState = _useRef(null);
   // If the initial state is the result of an expensive computation,
   // you may provide a function instead for lazy initial state.
   if (isFunction(initialState)) {

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -52,8 +52,6 @@ export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _use
         eagerState: newState,
       });
     }
-
-    stateHook[0].eagerState = newState;
   }
 
   return [stateHook[0].state, updateState, stateHook[0].eagerState];

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -30,31 +30,28 @@ import { isFunction } from './type';
  * @returns [ value, dispatch ]
  */
 export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _useState> | any {
+  const eagerState = _useRef();
   // If the initial state is the result of an expensive computation,
   // you may provide a function instead for lazy initial state.
   if (isFunction(initialState)) {
     initialState = initialState();
   }
   // The eagerState should be saved for filter shallow-equal value set.
-  const stateHook = _useState({
-    state: initialState,
-    eagerState: initialState,
-  });
+  const stateHook = _useState(initialState);
+  eagerState.current = stateHook[0];
   // @NOTE: Rax will not re-render if set a same value.
   function updateState(newState: S) {
     if (isFunction(newState)) {
-      newState = newState(stateHook[0].eagerState);
+      newState = newState(eagerState.current);
     }
     // Filter shallow-equal value set.
-    if (!is(newState, stateHook[0].eagerState)) {
-      stateHook[1]({
-        state: newState,
-        eagerState: newState,
-      });
+    if (!is(newState, eagerState.current)) {
+      stateHook[1](newState);
     }
+    eagerState.current = newState;
   }
-
-  return [stateHook[0].state, updateState, stateHook[0].eagerState];
+  
+  return [stateHook[0], updateState, eagerState.current];
 }
 
 /**

--- a/packages/rax-compat/src/ref.ts
+++ b/packages/rax-compat/src/ref.ts
@@ -1,6 +1,22 @@
-import { forwardRef, createRef } from 'react';
+import { forwardRef as _forwardRef, createRef } from 'react';
+import type { ForwardRefRenderFunction, ForwardedRef } from 'react';
+
+export function forwardRef(render: ForwardRefRenderFunction<unknown, ForwardedRef<unknown>>) {
+  if (render.defaultProps) {
+    const { defaultProps } = render;
+
+    // forwardRef render functions do not support propTypes or defaultProps.
+    delete render.defaultProps;
+
+    const component = _forwardRef(render);
+    component.defaultProps = defaultProps;
+
+    return component;
+  }
+
+  return _forwardRef(render);
+}
 
 export {
-  forwardRef,
   createRef,
 };

--- a/packages/rax-compat/tests/hooks.test.tsx
+++ b/packages/rax-compat/tests/hooks.test.tsx
@@ -144,11 +144,11 @@ describe('hooks', () => {
       const setPassedFalse = useCallback(() => {
         setPassed(false);
       }, []);
-       useEffect(() => {
+      useEffect(() => {
         setPassed(true);
-       }, []);
+      }, []);
 
-       useEffect(() => {
+      useEffect(() => {
         count.current++;
         if (count.current < 10) {
           if (count.current % 2) {
@@ -159,7 +159,7 @@ describe('hooks', () => {
             setPassedFalse();
           }
         }
-       }, [isPassed, setPassedFalse]);
+      }, [isPassed, setPassedFalse]);
       return <div />;
     }
 

--- a/packages/rax-compat/tests/hooks.test.tsx
+++ b/packages/rax-compat/tests/hooks.test.tsx
@@ -11,6 +11,7 @@ import {
   useLayoutEffect,
   createContext,
   useContext,
+  useCallback,
   useRef,
 } from '../src/hooks';
 
@@ -131,6 +132,35 @@ describe('hooks', () => {
           <input ref={inputEl} type="text" />
         </>
       );
+    }
+
+    render(<TextInputWithFocusButton />);
+  });
+
+  it('useState x useCallback', () => {
+    function TextInputWithFocusButton() {
+      let count = useRef(0);
+      const [isPassed, setPassed] = useState(false);
+      const setPassedFalse = useCallback(() => {
+        setPassed(false);
+      }, []);
+       useEffect(() => {
+        setPassed(true);
+       }, []);
+
+       useEffect(() => {
+        count.current++;
+        if (count.current < 10) {
+          if (count.current % 2) {
+            expect(isPassed).toBeFalsy();
+            setPassed(true);
+          } else {
+            expect(isPassed).toBeTruthy();
+            setPassedFalse();
+          }
+        }
+       }, [isPassed]);
+      return <div />;
     }
 
     render(<TextInputWithFocusButton />);

--- a/packages/rax-compat/tests/hooks.test.tsx
+++ b/packages/rax-compat/tests/hooks.test.tsx
@@ -159,7 +159,7 @@ describe('hooks', () => {
             setPassedFalse();
           }
         }
-       }, [isPassed]);
+       }, [isPassed, setPassedFalse]);
       return <div />;
     }
 


### PR DESCRIPTION
1. fix: state 被污染的情况
由于在 setState 的实现中，里面的 updateState方法会获取 eagerState 来判断是否需要更新，但是在使用了 useCallback 之后，这里面拿到的 eagerState 的值是定义是的，不会更新。

所以通过 useRef 在定义时创建一个共享的对象，使用这个共享对象来存储 eagerState

2. fix https://github.com/alibaba/ice/issues/6165