### PR TITLE
fix: compatible with runtime absolute path on win32

### DIFF
--- a/.changeset/wise-snails-sip.md
+++ b/.changeset/wise-snails-sip.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: compatible with runtime absolute path on win32 platform

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -183,7 +183,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
 
   // get plugins include built-in plugins and custom plugins
   const resolvedPlugins = await ctx.resolvePlugins() as PluginData[];
-  const runtimeModules = getRuntimeModules(resolvedPlugins);
+  const runtimeModules = getRuntimeModules(resolvedPlugins, rootDir);
 
   const { getAppConfig, init: initAppConfigCompiler } = getAppExportConfig(rootDir);
   const { getRoutesConfig, getDataloaderConfig, init: initRouteConfigCompiler } = getRouteExportConfig(rootDir);

--- a/packages/ice/src/utils/getRuntimeModules.ts
+++ b/packages/ice/src/utils/getRuntimeModules.ts
@@ -1,4 +1,7 @@
+import * as path from 'path';
+import { RUNTIME_TMP_DIR } from '../constant.js';
 import type { PluginData } from '../types/plugin.js';
+import formatPath from './formatPath.js';
 
 export interface RuntimeModule {
   staticRuntime: boolean;
@@ -6,10 +9,18 @@ export interface RuntimeModule {
   name: string;
 }
 
-function getRuntimeModules(plugins: PluginData[]) {
+function getRuntimeModules(plugins: PluginData[], rootDir: string) {
   return plugins
     .filter(({ runtime }) => !!runtime)
-    .map(({ name, runtime, staticRuntime }) => ({ name, path: runtime, staticRuntime }));
+    .map(({ name, runtime, staticRuntime }) => {
+      return {
+        name,
+        path: path.isAbsolute(runtime)
+          ? formatPath(path.relative(path.join(rootDir, RUNTIME_TMP_DIR), runtime)) // Be compatible with win32.
+          : runtime,
+        staticRuntime,
+      };
+    });
 }
 
 export default getRuntimeModules;


### PR DESCRIPTION
Close: https://github.com/alibaba/ice/issues/6162

规定自定义插件写的 runtime 路径是绝对路径，如果在 windows 系统中，拿到的路径是不符合 ESM 模块引入规范的。因此在最终 runtimeModules 中引入 runtime 时候，需要使用相对路径引入