### PR TITLE
feat: enable type=module to rax-compat

### DIFF
--- a/.changeset/lazy-dodos-compare.md
+++ b/.changeset/lazy-dodos-compare.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+feat: add type module

--- a/packages/rax-compat/package.json
+++ b/packages/rax-compat/package.json
@@ -9,6 +9,7 @@
     "dist",
     "build"
   ],
+  "type": "module",
   "main": "esm/index.js",
   "module": "esm/index.js",
   "exports": {

--- a/packages/rax-compat/src/compat/element.ts
+++ b/packages/rax-compat/src/compat/element.ts
@@ -1,10 +1,10 @@
 import type { ReactElement } from 'react';
 import { createElement } from 'react';
 import VisibilityChange from '@ice/appear';
-import transformProps from '../props';
-import { compatStyle } from '../style';
-import { isFunction } from '../type';
-import { InputCompat } from './input';
+import transformProps from '../props.js';
+import { compatStyle } from '../style.js';
+import { isFunction } from '../type.js';
+import { InputCompat } from './input.js';
 
 let ElementFactory: (type: any, props: any, ...args: any[]) => ReactElement;
 export function createJSXElementFactory(factory: typeof ElementFactory) {

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -5,7 +5,7 @@ import type {
   ReactNode,
 } from 'react';
 import { createElement as _createElement } from 'react';
-import { createJSXElementFactory } from './compat/element';
+import { createJSXElementFactory } from './compat/element.js';
 
 const jsx = createJSXElementFactory((type: any, props: any, ...children: ReactNode[]) =>
   _createElement(type, props, ...children));

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -20,8 +20,8 @@ import {
   useState as _useState,
   createContext as _createContext,
 } from 'react';
-import is from './is';
-import { isFunction } from './type';
+import is from './is.js';
+import { isFunction } from './type.js';
 
 /**
  * Compat useState for rax export.

--- a/packages/rax-compat/src/index.ts
+++ b/packages/rax-compat/src/index.ts
@@ -1,5 +1,5 @@
-import { createElement } from './create-element';
-import render from './render';
+import { createElement } from './create-element.js';
+import render from './render.js';
 import {
   useState,
   useContext,
@@ -10,12 +10,12 @@ import {
   useMemo,
   useReducer,
   useImperativeHandle,
-} from './hooks';
-import Fragment from './fragment';
-import { forwardRef, createRef } from './ref';
-import { Component, PureComponent, memo } from './component';
-import { createContext } from './context';
-import shared from './shared';
+} from './hooks.js';
+import Fragment from './fragment.js';
+import { forwardRef, createRef } from './ref.js';
+import { Component, PureComponent, memo } from './component.js';
+import { createContext } from './context.js';
+import shared from './shared.js';
 
 // Mocked version for rax.
 const version = '1.2.2-compat';

--- a/packages/rax-compat/src/props.ts
+++ b/packages/rax-compat/src/props.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps, JSXElementConstructor } from 'react';
-import { registrationNameToReactEvent } from './events';
-import possibleStandardNames from './possible-standard-names';
+import { registrationNameToReactEvent } from './events.js';
+import possibleStandardNames from './possible-standard-names.js';
 
 // String#indexOf is usually faster than any other methods.
 // https://www.measurethat.net/Benchmarks/Show/12312/0/js-regex-vs-startswith-vs-indexof-vs-endswith-vs-charat

--- a/packages/rax-compat/src/render.ts
+++ b/packages/rax-compat/src/render.ts
@@ -2,7 +2,7 @@ import type { RaxElement, RenderOption } from 'rax';
 import type { ReactNode } from 'react';
 import type { RootOptions } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
-import { isFunction } from './type';
+import { isFunction } from './type.js';
 
 /**
  * Compat render for rax export.

--- a/packages/rax-compat/src/runtime/jsx-dev-runtime.ts
+++ b/packages/rax-compat/src/runtime/jsx-dev-runtime.ts
@@ -1,7 +1,7 @@
 
 // @ts-ignore
 import { jsxDEV as _jsxDEV } from 'react/jsx-dev-runtime';
-import { createJSXElementFactory } from '../compat/element';
+import { createJSXElementFactory } from '../compat/element.js';
 
 export { Fragment } from 'react';
 export const jsxDEV = createJSXElementFactory(_jsxDEV);

--- a/packages/rax-compat/src/runtime/jsx-runtime.ts
+++ b/packages/rax-compat/src/runtime/jsx-runtime.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { jsxs as _jsxs, jsx as _jsx } from 'react/jsx-runtime';
-import { createJSXElementFactory } from '../compat/element';
+import { createJSXElementFactory } from '../compat/element.js';
 
 export { Fragment } from 'react';
 export const jsx = createJSXElementFactory(_jsx);


### PR DESCRIPTION
### 问题

rax-compat 目前的构建产物是 .js 后缀，并且使用 ESM，在其他模块直接引入 rax-compat 会报错（因为当做 cjs 模块处理）
