### PR TITLE
fix: only create esbuild context when dev

### DIFF
--- a/.changeset/stale-ants-notice.md
+++ b/.changeset/stale-ants-notice.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: only create esbuild context when dev

--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -221,9 +221,14 @@ export function createServerCompiler(options: Options) {
     logger.debug('[esbuild]', `start compile for: ${JSON.stringify(buildOptions.entryPoints)}`);
 
     try {
-      const context = await esbuild.context(buildOptions);
-
-      const esbuildResult = await context.rebuild();
+      let esbuildResult: esbuild.BuildResult;
+      let context: esbuild.BuildContext;
+      if (dev) {
+        context = await esbuild.context(buildOptions);
+        esbuildResult = await context.rebuild();
+      } else {
+        esbuildResult = await esbuild.build(buildOptions);
+      }
 
       logger.debug('[esbuild]', `time cost: ${new Date().getTime() - startTime}ms`);
 


### PR DESCRIPTION
Create esbuild context when dev