### PR TITLE
feat: support match target entry to bundle

### DIFF
--- a/.changeset/beige-colts-march.md
+++ b/.changeset/beige-colts-march.md
@@ -1,0 +1,6 @@
+---
+'@ice/webpack-config': patch
+'@ice/app': patch
+---
+
+feat: support match target entry to bundle

--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -61,6 +61,7 @@ const build = async (
     rootDir,
     // @ts-expect-error fix type error of compiled webpack
     webpack,
+    target,
     runtimeTmpDir: RUNTIME_TMP_DIR,
     userConfigHash,
     getExpandedEnvs,

--- a/packages/ice/src/commands/start.ts
+++ b/packages/ice/src/commands/start.ts
@@ -62,6 +62,7 @@ const start = async (
     rootDir,
     // @ts-expect-error fix type error of compiled webpack
     webpack,
+    target,
     runtimeTmpDir: RUNTIME_TMP_DIR,
     userConfigHash,
     getExpandedEnvs,

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -12,5 +12,11 @@ const config = { alias: {} };
 const rootDir = process.cwd();
 const runtimeTmpDir = '.ice';   // the path of the asset-manifest.json
 
-const webpackConfig = getWebpackConfig({ rootDir, config, webpack, runtimeTmpDir });
+const webpackConfig = getWebpackConfig({ 
+  rootDir, 
+  config,
+  webpack, 
+  runtimeTmpDir,
+  target: 'web',
+});
 ```

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -34,6 +34,7 @@ interface GetWebpackConfigOptions {
   webpack: typeof webpack;
   runtimeTmpDir: string;
   userConfigHash: string;
+  target: string;
   getExpandedEnvs: () => Record<string, string>;
   runtimeDefineVars?: Record<string, any>;
   getRoutesFile?: () => string[];
@@ -138,6 +139,7 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
     getExpandedEnvs,
     runtimeDefineVars = {},
     getRoutesFile,
+    target,
   } = options;
 
   const {
@@ -285,6 +287,7 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
         fs: false,
         path: false,
       },
+      conditionNames: [target, '...'],
     },
     resolveLoader: {
       modules: ['node_modules'],


### PR DESCRIPTION
## 背景

在框架打包不同目标（target）产物时，希望编译打包组件对应 target 的产物，这样一定程度上可以减小 最终 bundle 的产物

## 方案

假设有以下的组件 exports 导出：
```json
{
  "name": "@ice/component",
  "version": "1.0.0",
  "exports": {
    ".": {
      "web": "./web.js",
      "miniapp": "./miniapp.js",
      "weex": "./weex.js",
      "default": "./index.js"
    }
  }
}
```

将会根据当前框架编译的 `target` 值，寻找组件导出的 conditionName 对应的入口文件，然后进行打包。

这样做的好处是，如果一个组件有不同平台的产物，框架在构建的时候找到对应平台的 entry 打包可进一步减少产物体积，避免把其他平台的产物内容也打包进来。

对比与原来的 universal-env，这种做法少了 Tree Shaking 和编译的时间。