### PR TITLE
fix: read the same task target

### DIFF
--- a/.changeset/dry-crabs-deny.md
+++ b/.changeset/dry-crabs-deny.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: read the same task target

--- a/.changeset/young-mice-joke.md
+++ b/.changeset/young-mice-joke.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+feat: add target field to config

--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -56,21 +56,25 @@ const build = async (
     warnOnHashRouterEnabled(userConfig);
   }
 
-  const webpackConfigs = taskConfigs.map(({ config }) => getWebpackConfig({
-    config,
-    rootDir,
-    // @ts-expect-error fix type error of compiled webpack
-    webpack,
-    target,
-    runtimeTmpDir: RUNTIME_TMP_DIR,
-    userConfigHash,
-    getExpandedEnvs,
-    runtimeDefineVars: {
-      [IMPORT_META_TARGET]: JSON.stringify(target),
-      [IMPORT_META_RENDERER]: JSON.stringify('client'),
-    },
-    getRoutesFile,
-  }));
+  const webpackConfigs = taskConfigs.map(({ config }) => {
+    // If the target in the task config doesn't exit, use the target from cli command option.
+    config.target ||= target;
+
+    return getWebpackConfig({
+      config,
+      rootDir,
+      // @ts-expect-error fix type error of compiled webpack
+      webpack,
+      runtimeTmpDir: RUNTIME_TMP_DIR,
+      userConfigHash,
+      getExpandedEnvs,
+      runtimeDefineVars: {
+        [IMPORT_META_TARGET]: JSON.stringify(target),
+        [IMPORT_META_RENDERER]: JSON.stringify('client'),
+      },
+      getRoutesFile,
+    });
+  });
   const outputDir = webpackConfigs[0].output.path;
 
   await emptyDir(outputDir);

--- a/packages/ice/src/commands/start.ts
+++ b/packages/ice/src/commands/start.ts
@@ -57,21 +57,25 @@ const start = async (
   const { commandArgs, rootDir, extendsPluginAPI } = context;
   const { target = WEB } = commandArgs;
   const { getRoutesFile } = extendsPluginAPI;
-  const webpackConfigs = taskConfigs.map(({ config }) => getWebpackConfig({
-    config,
-    rootDir,
-    // @ts-expect-error fix type error of compiled webpack
-    webpack,
-    target,
-    runtimeTmpDir: RUNTIME_TMP_DIR,
-    userConfigHash,
-    getExpandedEnvs,
-    runtimeDefineVars: {
-      [IMPORT_META_TARGET]: JSON.stringify(target),
-      [IMPORT_META_RENDERER]: JSON.stringify('client'),
-    },
-    getRoutesFile,
-  }));
+  const webpackConfigs = taskConfigs.map(({ config }) => {
+    // If the target in the task config doesn't exit, use the target from cli command option.
+    config.target ||= target;
+
+    return getWebpackConfig({
+      config,
+      rootDir,
+      // @ts-expect-error fix type error of compiled webpack
+      webpack,
+      runtimeTmpDir: RUNTIME_TMP_DIR,
+      userConfigHash,
+      getExpandedEnvs,
+      runtimeDefineVars: {
+        [IMPORT_META_TARGET]: JSON.stringify(target),
+        [IMPORT_META_RENDERER]: JSON.stringify('client'),
+      },
+      getRoutesFile,
+    });
+  });
 
   const hooksAPI = {
     serverCompiler,

--- a/packages/ice/src/plugins/web/task.ts
+++ b/packages/ice/src/plugins/web/task.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { createRequire } from 'module';
 import type { Config } from '@ice/webpack-config/types';
-import { CACHE_DIR, RUNTIME_TMP_DIR } from '../../constant.js';
+import { CACHE_DIR, RUNTIME_TMP_DIR, WEB } from '../../constant.js';
 
 const require = createRequire(import.meta.url);
 const getWebTask = ({ rootDir, command, userConfig }): Config => {
@@ -41,6 +41,7 @@ const getWebTask = ({ rootDir, command, userConfig }): Config => {
     minify: command === 'build',
     useDevServer: true,
     useDataLoader: true,
+    target: WEB,
   };
 };
 

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -34,7 +34,6 @@ interface GetWebpackConfigOptions {
   webpack: typeof webpack;
   runtimeTmpDir: string;
   userConfigHash: string;
-  target: string;
   getExpandedEnvs: () => Record<string, string>;
   runtimeDefineVars?: Record<string, any>;
   getRoutesFile?: () => string[];
@@ -134,7 +133,6 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
     getExpandedEnvs,
     runtimeDefineVars = {},
     getRoutesFile,
-    target,
   } = options;
 
   const {
@@ -282,7 +280,7 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
         fs: false,
         path: false,
       },
-      conditionNames: [target, '...'],
+      conditionNames: (config.target ? [config.target] : []).concat(['...']),
     },
     resolveLoader: {
       modules: ['node_modules'],

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -72,6 +72,8 @@ interface TransformPlugin {
 export type ModifyWebpackConfig<T=Configuration, U=typeof webpack> = (config: T, ctx: ConfigurationCtx<U>) => T;
 export type { webpack };
 export interface Config {
+  target?: string;
+
   mode: 'none' | 'development' | 'production';
 
   define?: {


### PR DESCRIPTION
原来的写法是统一读取 commandArgs 上的 target 字段，如果有多个 task 的情况下，会导致每个 task 的 target 都是一样的，最后导致 conditionName 的设置有问题。