### PR TITLE
fix: jsx comment

### DIFF
--- a/.changeset/plenty-rings-hammer.md
+++ b/.changeset/plenty-rings-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+fix: auto add jsx comment

--- a/examples/rax-inline-style/src/document.tsx
+++ b/examples/rax-inline-style/src/document.tsx
@@ -1,4 +1,3 @@
-/* @jsx createElement */
 import { Meta, Title, Links, Main, Scripts } from 'ice';
 
 function Document() {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -69,30 +69,27 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {
         compilationConfig: (source: string) => {
-          const isRaxComponent = /from\s['"]rax['"]/.test(source);
-          if (isRaxComponent) {
-            const hasJSXComment = source.indexOf('@jsx createElement') !== -1;
-            if (hasJSXComment) {
-              return {
-                jsc: {
-                  transform: {
-                    react: {
-                      runtime: 'classic',
-                    },
-                  },
-                },
-              };
-            }
+          const hasJSXComment = source.indexOf('@jsx createElement') !== -1;
+          if (hasJSXComment) {
             return {
               jsc: {
                 transform: {
                   react: {
-                    importSource: 'rax-compat/runtime',
+                    runtime: 'classic',
                   },
                 },
               },
             };
           }
+          return {
+            jsc: {
+              transform: {
+                react: {
+                  importSource: 'rax-compat/runtime',
+                },
+              },
+            },
+          };
         },
       });
 

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -81,15 +81,19 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
               },
             };
           }
-          return {
-            jsc: {
-              transform: {
-                react: {
-                  importSource: 'rax-compat/runtime',
+
+          const isRaxComponent = /(from|require\()\s*['"]rax['"]/.test(source);
+          if (isRaxComponent) {
+            return {
+              jsc: {
+                transform: {
+                  react: {
+                    importSource: 'rax-compat/runtime',
+                  },
                 },
               },
-            },
-          };
+            };
+          }
         },
       });
 


### PR DESCRIPTION
所有文件中如果有 jsx 注释了，就应该使用 classic 模式，而不应该只判断是否有 import rax