### PR TITLE
fix: basename not prepend

### DIFF
--- a/packages/plugin-icestark/src/runtime/framework.tsx
+++ b/packages/plugin-icestark/src/runtime/framework.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppRouter, AppRoute } from '@ice/stark';
-import type { RuntimePlugin, AppRouterProps } from '@ice/runtime/types';
+import type { RuntimePlugin, ClientAppRouterProps } from '@ice/runtime/types';
 import type { RouteInfo, AppConfig } from '../types';
 
 const { useState, useEffect } = React;
@@ -11,7 +11,7 @@ const runtime: RuntimePlugin = ({ getAppRouter, setAppRouter, appContext }) => {
   const { layout, getApps, appRouter } = appExport?.icestark || {};
 
   if (getApps) {
-    const FrameworkRouter = (props: AppRouterProps) => {
+    const FrameworkRouter = (props: ClientAppRouterProps) => {
       const [routeInfo, setRouteInfo] = useState<RouteInfo>({});
       const [appEnter, setAppEnter] = useState<AppConfig>({});
       const [appLeave, setAppLeave] = useState<AppConfig>({});

--- a/packages/runtime/src/ClientRouter.tsx
+++ b/packages/runtime/src/ClientRouter.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { createRouter } from '@remix-run/router';
-import type { AppRouterProps } from './types.js';
+import type { ClientAppRouterProps } from './types.js';
 import App from './App.js';
 import { DataContextProvider } from './singleRouter.js';
 import { useAppContext } from './AppContext.js';
 
 let router: ReturnType<typeof createRouter> = null;
-function ClientRouter(props: AppRouterProps) {
+function ClientRouter(props: ClientAppRouterProps) {
   const { Component, loaderData, routerContext } = props;
   const { revalidate } = useAppContext();
 

--- a/packages/runtime/src/ClientRouter.tsx
+++ b/packages/runtime/src/ClientRouter.tsx
@@ -21,6 +21,7 @@ function ClientRouter(props: ClientAppRouterProps) {
   if (process.env.ICE_CORE_ROUTER === 'true') {
     // Clear router before re-create in case of hot module replacement.
     clearRouter();
+    // @ts-expect-error routes type should be AgnosticBaseRouteObject[]
     router = createRouter(routerContext).initialize();
   }
   useEffect(() => {

--- a/packages/runtime/src/ServerRouter.tsx
+++ b/packages/runtime/src/ServerRouter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StaticRouterProvider, createStaticRouter } from 'react-router-dom/server.mjs';
 import type { RouteObject } from 'react-router-dom';
 import { RouteComponent } from './routes.js';
-import type { AppRouterProps } from './types.js';
+import type { ClientAppRouterProps, ServerAppRouterProps } from './types.js';
 import App from './App.js';
 
 function createServerRoutes(routes: RouteObject[]) {
@@ -26,7 +26,7 @@ function createServerRoutes(routes: RouteObject[]) {
   });
 }
 
-function ServerRouter(props: AppRouterProps) {
+function ServerRouter(props: ServerAppRouterProps) {
   const { routerContext, routes } = props;
   // Server router only be called once.
   const router = createStaticRouter(createServerRoutes(routes), routerContext);

--- a/packages/runtime/src/ServerRouter.tsx
+++ b/packages/runtime/src/ServerRouter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StaticRouterProvider, createStaticRouter } from 'react-router-dom/server.mjs';
 import type { RouteObject } from 'react-router-dom';
 import { RouteComponent } from './routes.js';
-import type { ClientAppRouterProps, ServerAppRouterProps } from './types.js';
+import type { ServerAppRouterProps } from './types.js';
 import App from './App.js';
 
 function createServerRoutes(routes: RouteObject[]) {

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createHashHistory, createBrowserHistory, createMemoryHistory } from '@remix-run/router';
-import type { History, RouterInit } from '@remix-run/router';
+import type { History } from '@remix-run/router';
 import type {
   AppContext, WindowContext, AppExport, RouteItem, RuntimeModules, AppConfig, AssetsManifest, ClientAppRouterProps,
 } from './types.js';
@@ -165,7 +165,7 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
       );
     }
   }
-  const routerOptions: RouterInit = {
+  const routerOptions: ClientAppRouterProps['routerContext'] = {
     basename,
     routes,
     history,

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom/client';
 import { createHashHistory, createBrowserHistory, createMemoryHistory } from '@remix-run/router';
 import type { History, RouterInit } from '@remix-run/router';
 import type {
-  AppContext, WindowContext, AppExport, RouteItem, RuntimeModules, AppConfig, AssetsManifest,
+  AppContext, WindowContext, AppExport, RouteItem, RuntimeModules, AppConfig, AssetsManifest, ClientAppRouterProps,
 } from './types.js';
 import { createHistory as createHistorySingle } from './singleRouter.js';
 import { setHistory } from './history.js';
@@ -86,7 +86,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
   };
 
   const runtime = new Runtime(appContext, runtimeOptions);
-  runtime.setAppRouter(ClientRouter);
+  runtime.setAppRouter<ClientAppRouterProps>(ClientRouter);
   // Load static module before getAppData,
   // so we can call request in in getAppData which provide by `plugin-request`.
   if (runtimeModules.statics) {
@@ -138,7 +138,7 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
   const { appConfig, loaderData, routes, basename } = appContext;
   const appRender = runtime.getRender();
   const AppRuntimeProvider = runtime.composeAppProvider() || React.Fragment;
-  const AppRouter = runtime.getAppRouter();
+  const AppRouter = runtime.getAppRouter<ClientAppRouterProps>();
 
   const rootId = appConfig.app.rootId || 'app';
   let root = document.getElementById(rootId);

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createHashHistory, createBrowserHistory, createMemoryHistory } from '@remix-run/router';
-import type { History } from '@remix-run/router';
+import type { History, RouterInit } from '@remix-run/router';
 import type {
   AppContext, WindowContext, AppExport, RouteItem, RuntimeModules, AppConfig, AssetsManifest,
 } from './types.js';
@@ -165,11 +165,14 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
       );
     }
   }
-  const routerOptions = {
+  const routerOptions: RouterInit = {
     basename,
     routes,
     history,
     hydrationData,
+    future: {
+      v7_prependBasename: true,
+    },
   };
   let singleComponent = null;
   let routeData = null;

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { parsePath } from 'history';
 import type { Location } from 'history';
-import type { StaticHandlerContext } from '@remix-run/router';
 import type {
   AppContext, RouteItem, ServerContext,
   AppExport, AssetsManifest,
@@ -353,8 +352,8 @@ async function renderServerEntry(
   const { routes, routePath, loaderData, basename } = appContext;
   const AppRuntimeProvider = runtime.composeAppProvider() || React.Fragment;
   const AppRouter = runtime.getAppRouter<ServerAppRouterProps>();
-  const routerContext: StaticHandlerContext = {
-    // @ts-ignore
+  const routerContext: ServerAppRouterProps['routerContext'] = {
+    // @ts-expect-error matches type should be use `AgnosticDataRouteMatch[]`
     matches,
     basename,
     loaderData,

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { parsePath } from 'history';
 import type { Location } from 'history';
+import type { StaticHandlerContext } from '@remix-run/router';
 import type {
   AppContext, RouteItem, ServerContext,
   AppExport, AssetsManifest,
@@ -12,6 +13,7 @@ import type {
   DocumentComponent,
   RuntimeModules,
   AppData,
+  ServerAppRouterProps,
 } from './types.js';
 import Runtime from './runtime.js';
 import { AppContextProvider } from './AppContext.js';
@@ -234,7 +236,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
     serverData,
   };
   const runtime = new Runtime(appContext, runtimeOptions);
-  runtime.setAppRouter(ServerRouter);
+  runtime.setAppRouter<ServerAppRouterProps>(ServerRouter);
   // Load static module before getAppData.
   if (runtimeModules.statics) {
     await Promise.all(runtimeModules.statics.map(m => runtime.loadModule(m)).filter(Boolean));
@@ -350,9 +352,13 @@ async function renderServerEntry(
   const appContext = runtime.getAppContext();
   const { routes, routePath, loaderData, basename } = appContext;
   const AppRuntimeProvider = runtime.composeAppProvider() || React.Fragment;
-  const AppRouter = runtime.getAppRouter();
-  const routerContext = {
-    matches, basename, loaderData, location,
+  const AppRouter = runtime.getAppRouter<ServerAppRouterProps>();
+  const routerContext: StaticHandlerContext = {
+    // @ts-ignore
+    matches,
+    basename,
+    loaderData,
+    location,
   };
 
   const documentContext = {

--- a/packages/runtime/src/runtime.tsx
+++ b/packages/runtime/src/runtime.tsx
@@ -47,6 +47,7 @@ class Runtime {
     this.RouteWrappers = [];
     this.runtimeOptions = runtimeOptions;
     this.responseHandlers = [];
+    this.getAppRouter = this.getAppRouter.bind(this);
   }
 
   public getAppContext = () => {

--- a/packages/runtime/src/runtime.tsx
+++ b/packages/runtime/src/runtime.tsx
@@ -64,7 +64,9 @@ class Runtime {
     return this.render;
   };
 
-  public getAppRouter = () => this.AppRouter;
+  public getAppRouter<T>() {
+    return this.AppRouter as ComponentType<T>;
+  }
 
   public getWrappers = () => this.RouteWrappers;
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { InitialEntry, AgnosticRouteObject, Location, History } from '@remix-run/router';
+import type { InitialEntry, AgnosticRouteObject, Location, History, RouterInit } from '@remix-run/router';
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { HydrationOptions, Root } from 'react-dom/client';
 import type { Params, RouteObject } from 'react-router-dom';
@@ -240,7 +240,7 @@ export interface RuntimeModules {
 
 export interface AppRouterProps {
   routes?: RouteObject[];
-  routerContext?: any;
+  routerContext?: RouterInit;
   location?: Location;
   Component?: ComponentType<any>;
   loaderData?: LoaderData;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { InitialEntry, AgnosticRouteObject, Location, History, RouterInit } from '@remix-run/router';
+import type { InitialEntry, AgnosticRouteObject, Location, History, RouterInit, StaticHandlerContext } from '@remix-run/router';
 import type { ComponentType, PropsWithChildren } from 'react';
 import type { HydrationOptions, Root } from 'react-dom/client';
 import type { Params, RouteObject } from 'react-router-dom';
@@ -168,7 +168,7 @@ export type ResponseHandler = (
   res: ServerResponse,
 ) => any | Promise<any>;
 
-export type SetAppRouter = (AppRouter: ComponentType<AppRouterProps>) => void;
+export type SetAppRouter = <T>(AppRouter: ComponentType<T>) => void;
 export type GetAppRouter = () => AppProvider;
 export type AddProvider = (Provider: AppProvider) => void;
 export type SetRender = (render: Renderer) => void;
@@ -240,10 +240,17 @@ export interface RuntimeModules {
 
 export interface AppRouterProps {
   routes?: RouteObject[];
-  routerContext?: RouterInit;
   location?: Location;
   Component?: ComponentType<any>;
   loaderData?: LoaderData;
+}
+
+export interface ClientAppRouterProps extends AppRouterProps {
+  routerContext?: RouterInit;
+}
+
+export interface ServerAppRouterProps extends AppRouterProps {
+  routerContext?: StaticHandlerContext;
 }
 
 export interface AppRouteProps {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -246,7 +246,7 @@ export interface AppRouterProps {
 }
 
 export interface ClientAppRouterProps extends AppRouterProps {
-  routerContext?: RouterInit;
+  routerContext?: Omit<RouterInit, 'routes'> & { routes?: RouteObject[] };
 }
 
 export interface ServerAppRouterProps extends AppRouterProps {


### PR DESCRIPTION
## 问题描述

升级 react-router-dom 到最新版本后，设置 basename 为 `/app` 后，如果 Link 组件是下面的写法：
```tsx
<Link to='/aaa'>aaa</Link>
```

这样路由地址直接跳转到 `/aaa`，而不是期望的 `/app/aaa`，导致无法正确匹配并渲染对应的组件。与之前的表现不一致

## 解决

createBrowser 默认会开启 v7_prependBasename，这样就可以自动添加 basename 到路由地址：

https://github.com/remix-run/react-router/blob/853a9382b748466f9bf1af5c4c7e5571670f8b97/packages/react-router-dom/index.tsx#L223