### PR TITLE
fix: import store source before swc compiler

### DIFF
--- a/.changeset/dull-hounds-hunt.md
+++ b/.changeset/dull-hounds-hunt.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-store': patch
+---
+
+fix: import store source before swc compiler

--- a/packages/plugin-store/src/index.ts
+++ b/packages/plugin-store/src/index.ts
@@ -70,7 +70,7 @@ const formatId = (id: string) => id.split(path.sep).join('/');
 function exportStoreProviderPlugin({ pageDir, resetPageState }: { pageDir: string; resetPageState: boolean }): Config['transformPlugins'][0] {
   return {
     name: 'export-store-provider',
-    enforce: 'post',
+    enforce: 'pre',
     transformInclude: (id) => {
       return (
         /\.[jt]sx?$/i.test(id) &&


### PR DESCRIPTION
原先部分代码移除能力由 babel 封装的 esbuild 插件处理，目前代码移除统一收敛至 swc 编译，需要调整 store 插件注入代码的顺序，避免使用 store 场景下 store 源码未被移除的问题