### PR TITLE
fix: getRoutesFile is undefined when use onDemand server

### DIFF
--- a/.changeset/heavy-eggs-itch.md
+++ b/.changeset/heavy-eggs-itch.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: pass `getRoutesFile` for onDemand server runner.

--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 3.2.3
-
-- fix: pass `getRoutesFile` for onDemand server runner.
-
 ## 3.2.2
 
 ### Patch Changes

--- a/packages/ice/CHANGELOG.md
+++ b/packages/ice/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.3
+
+- fix: pass `getRoutesFile` for onDemand server runner.
+
 ## 3.2.2
 
 ### Patch Changes

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -311,6 +311,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
       task: platformTaskConfig,
       server,
       csr,
+      getRoutesFile: () => routeManifest.getRoutesFile(),
     });
     addWatchEvent([
       /src\/?[\w*-:.$]+$/,

--- a/packages/ice/src/service/ServerRunner.ts
+++ b/packages/ice/src/service/ServerRunner.ts
@@ -27,6 +27,7 @@ interface InitOptions {
   server: UserConfig['server'];
   csr: boolean;
   task: TaskConfig<Config>;
+  getRoutesFile: () => string[];
 }
 
 type ResolveCallback = Parameters<PluginBuild['onResolve']>[1];
@@ -88,12 +89,14 @@ class ServerRunner extends Runner {
     server,
     rootDir,
     csr,
+    getRoutesFile,
   }: InitOptions) {
     const transformPlugins = getCompilerPlugins(rootDir, {
       ...task.config,
       fastRefresh: false,
       enableEnv: false,
       polyfill: false,
+      getRoutesFile,
       swcOptions: {
         nodeTransform: true,
         // Remove all exports except pageConfig when ssr and ssg both are false.


### PR DESCRIPTION
Pass `getRoutesFile` for onDemand server runner.