### PR TITLE
fix: compile @remix-run/router when minify is swc

### DIFF
--- a/.changeset/perfect-bags-hug.md
+++ b/.changeset/perfect-bags-hug.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+fix: compile @remix-run/router when minify is swc

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -44,8 +44,8 @@ const compilationPlugin = (options: Options): UnpluginOptions => {
   } = options;
 
   const { removeExportExprs, compilationConfig, keepExports, nodeTransform } = swcOptions;
-
-  const compileRegex = compileIncludes.map((includeRule) => {
+  const COMPILE_DEPS = ['@remix-run/router'];
+  const compileRegex = [...compileIncludes, ...COMPILE_DEPS].map((includeRule) => {
     return includeRule instanceof RegExp ? includeRule : new RegExp(includeRule);
   });
 

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -28,6 +28,9 @@ interface Options {
 
 const formatId = (id: string) => id.split(path.sep).join('/');
 
+// HACK: swc minify will hang on when '@remix-run/router' is not compiled.
+// It may be a bug of swc, so we add it to compile deps when @swc/core is update to latest version.
+const COMPILE_DEPS = ['@remix-run/router'];
 const compilationPlugin = (options: Options): UnpluginOptions => {
   const {
     rootDir,
@@ -44,7 +47,6 @@ const compilationPlugin = (options: Options): UnpluginOptions => {
   } = options;
 
   const { removeExportExprs, compilationConfig, keepExports, nodeTransform } = swcOptions;
-  const COMPILE_DEPS = ['@remix-run/router'];
   const compileRegex = [...compileIncludes, ...COMPILE_DEPS].map((includeRule) => {
     return includeRule instanceof RegExp ? includeRule : new RegExp(includeRule);
   });


### PR DESCRIPTION
swc minify will hang on when '@remix-run/router' is not compiled