### PR TITLE
Fix: modified task alias not be consumed

### DIFF
--- a/.changeset/tiny-plants-learn.md
+++ b/.changeset/tiny-plants-learn.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: modified task alias not be used

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -37,6 +37,7 @@ import { logger, createLogger } from './utils/logger.js';
 import ServerRunner from './service/ServerRunner.js';
 import RouteManifest from './utils/routeManifest.js';
 import dynamicImport from './utils/dynamicImport.js';
+import mergeTaskConfig from './utils/mergeTaskConfig.js';
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -235,10 +236,13 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const csr = !userConfig.ssr && !userConfig.ssg;
 
   const disableRouter = userConfig?.optimization?.router && routesInfo.routesCount <= 1;
-  let taskAlias = {};
   if (disableRouter) {
     logger.info('`optimization.router` is enabled and only have one route, ice build will remove react-router and history which is unnecessary.');
-    taskAlias['@ice/runtime/router'] = path.join(require.resolve('@ice/runtime'), '../single-router.js');
+    mergeTaskConfig(taskConfigs, {
+      alias: {
+        '@ice/runtime/router': '@ice/runtime/single-router',
+      },
+    });
   }
 
   // Get first task config as default platform config.


### PR DESCRIPTION
## 问题

开启单路由时，由于 useConfig 和 useData 用的是 [RouteContext](https://github.com/alibaba/ice/blob/master/packages/runtime/src/RouteContext.ts) 中的，其需要依赖 react-router。但单路由的场景 react-router 是被移除的，导致执行报错