### PR TITLE
fix: load route module error when only has one router

### DIFF
--- a/.changeset/big-ravens-refuse.md
+++ b/.changeset/big-ravens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: loadRouteModule error when only has one router

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -152,6 +152,7 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
     console.warn(`Root node #${rootId} is not found, current root is automatically created by the framework.`);
   }
   const hydrationData = needHydrate ? { loaderData } : undefined;
+  const routeModuleCache = {};
   if (needHydrate) {
     const lazyMatches = matchRoutes(routes, history.location, basename).filter((m) => m.route.lazy);
     if (lazyMatches?.length > 0) {
@@ -159,7 +160,7 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
       // so we can hydrate the SSR-rendered content synchronously.
       await Promise.all(
         lazyMatches.map(async (m) => {
-          let routeModule = await m.route.lazy();
+          let routeModule = await loadRouteModule(m.route, routeModuleCache);
           Object.assign(m.route, {
             ...routeModule,
             lazy: undefined,
@@ -180,7 +181,7 @@ async function render({ history, runtime, needHydrate }: RenderOptions) {
   let singleComponent = null;
   let routeData = null;
   if (process.env.ICE_CORE_ROUTER !== 'true') {
-    const { Component, loader } = await loadRouteModule(routes[0]);
+    const { Component, loader } = await loadRouteModule(routes[0], routeModuleCache);
     singleComponent = Component || routes[0].Component;
     routeData = loader && await loader();
   }


### PR DESCRIPTION
## 问题

开启单路由和 SSG 的情况下，加载组件模块的时候直接报错 `lazy is not defined` 

## 原因

已经前置通过 `lazy()` 加载过了组件并设置成 undefined，后续加载过程中不需要再加载，应该从缓存中拿组件实例