### PR TITLE
fix(runtime): when SSR client send extra useless requests (fix #6306)

### DIFF
--- a/packages/runtime/src/dataLoader.ts
+++ b/packages/runtime/src/dataLoader.ts
@@ -169,12 +169,12 @@ const cache = new Map<string, CachedResult>();
 function loadInitialDataInClient(loaders: Loaders) {
   const context = (window as any).__ICE_APP_CONTEXT__ || {};
   const matchedIds = context.matchedIds || [];
-  const routesData = context.routesData || {};
+  const loaderData = context.loaderData || {};
   const { renderMode } = context;
 
   const ids = ['_app'].concat(matchedIds);
   ids.forEach(id => {
-    const dataFromSSR = routesData[id];
+    const dataFromSSR = loaderData[id]?.data;
     if (dataFromSSR) {
       cache.set(renderMode === 'SSG' ? `${id}_ssg` : id, {
         value: dataFromSSR,


### PR DESCRIPTION
detail: SSR compile time data field 'loaderData' not match runtime 'routesData'
Fix: https://github.com/alibaba/ice/issues/6306