### PR TITLE
fix: ignore hydration error in dev server overly

### DIFF
--- a/.changeset/short-jeans-fly.md
+++ b/.changeset/short-jeans-fly.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+fix: ignore hydration error in dev server overly

--- a/.changeset/tidy-balloons-ring.md
+++ b/.changeset/tidy-balloons-ring.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: throw error when route loads failed

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -39,7 +39,7 @@ export async function loadRouteModule(route: RouteModule, routeModulesCache = {}
     return routeModule;
   } catch (error) {
     console.error(`Failed to load route module: ${id}.`);
-    console.error(error);
+    throw error;
   }
 }
 

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -392,7 +392,18 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
         },
       },
       client: {
-        overlay: true,
+        overlay: {
+          errors: true,
+          warnings: false,
+          runtimeErrors: (error) => {
+            // Ignore hydration error in webpack-dev-server overlay.
+            // FIXME when hydration error is not occurred in HMR.
+            if (['Hydration failed', 'server-rendered HTML', 'Text content did not match', 'There was an error while hydrating'].some((text) => error.message.includes(text))) {
+              return false;
+            }
+            return true;
+          },
+        },
         logging: 'info',
       },
       setupMiddlewares: middlewares,


### PR DESCRIPTION
Ignore hydration error in dev server overly, it will be fix in next version when HMR won't trigger hydration error.