### PR TITLE
fix: compilation config not extend

### DIFF
--- a/.changeset/hip-adults-trade.md
+++ b/.changeset/hip-adults-trade.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+fix: compilation config not extend

--- a/packages/plugin-rax-compat/package.json
+++ b/packages/plugin-rax-compat/package.json
@@ -24,13 +24,14 @@
     "babel-plugin-transform-jsx-stylesheet": "1.0.6",
     "consola": "^2.15.3",
     "css": "^2.2.1",
-    "lodash.merge": "^4.6.2",
+    "lodash-es": "^4.17.21",
     "rax-compat": "^0.2.1",
     "style-unit": "^3.0.5",
     "stylesheet-loader": "^0.9.1"
   },
   "devDependencies": {
     "@ice/app": "^3.2.1",
+    "@types/lodash-es": "^4.17.7",
     "webpack": "^5.86.0"
   },
   "repository": {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -66,11 +66,9 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
     const { userConfig } = context;
 
     onGetConfig((config) => {
-      // Clone config object to avoid Maximum call stack size exceeded error.
-      const originalCompilationConfig = cloneDeep(config.swcOptions?.compilationConfig || {});
-      const originalCompilationConfigFunc = typeof originalCompilationConfig === 'function'
-        ? originalCompilationConfig
-        : () => originalCompilationConfig;
+      const compilationConfigFunc = typeof config.swcOptions?.compilationConfig === 'function'
+        ? config.swcOptions?.compilationConfig
+        : () => config.swcOptions?.compilationConfig;
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {
         compilationConfig: (source: string, id: string) => {
@@ -100,7 +98,11 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
             };
           }
 
-          return merge(cloneDeep(originalCompilationConfigFunc(source, id)), swcCompilationConfig);
+          return merge(
+            // Clone config object to avoid Maximum call stack size exceeded error.
+            cloneDeep(compilationConfigFunc(source, id)),
+            swcCompilationConfig,
+          );
         },
       });
 

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -76,6 +76,8 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         compilationConfig: (source: string, id: string) => {
           let swcCompilationConfig = {};
           const hasJSXComment = source.indexOf('@jsx createElement') !== -1;
+          const isRaxComponent = /(from|require\()\s*['"]rax['"]/.test(source);
+
           if (hasJSXComment) {
             swcCompilationConfig = {
               jsc: {
@@ -86,10 +88,7 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
                 },
               },
             };
-          }
-
-          const isRaxComponent = /(from|require\()\s*['"]rax['"]/.test(source);
-          if (isRaxComponent) {
+          } else if (isRaxComponent) {
             swcCompilationConfig = {
               jsc: {
                 transform: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1405,10 +1405,11 @@ importers:
       '@babel/plugin-proposal-export-default-from': ^7.18.9
       '@ice/app': ^3.2.1
       '@ice/bundles': ^0.1.10
+      '@types/lodash-es': ^4.17.7
       babel-plugin-transform-jsx-stylesheet: 1.0.6
       consola: ^2.15.3
       css: ^2.2.1
-      lodash.merge: ^4.6.2
+      lodash-es: ^4.17.21
       rax-compat: ^0.2.1
       style-unit: ^3.0.5
       stylesheet-loader: ^0.9.1
@@ -1420,12 +1421,13 @@ importers:
       babel-plugin-transform-jsx-stylesheet: 1.0.6
       consola: 2.15.3
       css: 2.2.4
-      lodash.merge: 4.6.2
+      lodash-es: 4.17.21
       rax-compat: link:../rax-compat
       style-unit: 3.0.5
       stylesheet-loader: 0.9.1
     devDependencies:
       '@ice/app': link:../ice
+      '@types/lodash-es': 4.17.7
       webpack: 5.86.0
 
   packages/plugin-request:
@@ -7360,6 +7362,12 @@ packages:
 
   /@types/less/3.0.3:
     resolution: {integrity: sha512-1YXyYH83h6We1djyoUEqTlVyQtCfJAFXELSKW2ZRtjHD4hQ82CC4lvrv5D0l0FLcKBaiPbXyi3MpMsI9ZRgKsw==}
+    dev: true
+
+  /@types/lodash-es/4.17.7:
+    resolution: {integrity: sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==}
+    dependencies:
+      '@types/lodash': 4.14.191
     dev: true
 
   /@types/lodash/4.14.191:
@@ -15044,6 +15052,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
+  /lodash-es/4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
     dev: true
@@ -15080,6 +15092,7 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
 
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}


### PR DESCRIPTION
## 问题

开启 [syntaxFeatures.exportDefaultFrom](https://ice3.alibaba-inc.com/v3/docs/guide/basic/config#syntaxfeatures) 选项并且开启 rax-compat 插件后，对于 `export default from xxx` 的语法不能正常解析编译

## 原因

rax-compat 插件改写了 compilationConfig 从对象变为函数，导致原来的 `compilationConfig: { exportDefaultFrom: true }` 对象丢掉了。因此需要把原来的对象拷贝过去。

https://github.com/alibaba/ice/blob/45cb1c779dbe88805a3bcc7dcce538108b0cc328/packages/plugin-rax-compat/src/index.ts#L71