### PR TITLE
remove plugin-rax-compat server options

### DIFF
--- a/.changeset/quick-oranges-fly.md
+++ b/.changeset/quick-oranges-fly.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+remove server options setter

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,17 +97,6 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         },
       });
 
-      if (!config.server) {
-        config.server = {};
-      }
-      const originalOptions = config.server.buildOptions;
-      config.server.buildOptions = (options) => ({
-        ...(originalOptions ? originalOptions(options) : options),
-        jsx: 'transform',
-        jsxFactory: 'createElement',
-        jsxFragment: 'Fragment',
-      });
-
       Object.assign(config.alias, alias);
 
       if (options.inlineStyle) {


### PR DESCRIPTION
移除了 plugin-rax-compat 中的 `server.buildOptions` 配置，这一配置导致了项目中存在使用 `tsc` 或 `jsx: preserve` 构建的依赖时，启用 rax-compat，会出现 `createElement is not defined` 错误。