### PR TITLE
remove plugin-rax-compat server options

### DIFF
--- a/.changeset/quick-oranges-fly.md
+++ b/.changeset/quick-oranges-fly.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+remove server options setter

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,15 +97,6 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         },
       });
 
-      if (!config.server) {
-        config.server = {};
-      }
-      const originalOptions = config.server.buildOptions;
-
-      config.server.buildOptions = (options) => ({
-        ...(originalOptions ? originalOptions(options) : options),
-      });
-
       Object.assign(config.alias, alias);
 
       if (options.inlineStyle) {
@@ -117,6 +108,7 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         const transformCssModule = options.cssModule == null ? true : options.cssModule;
 
         if (userConfig.ssr || userConfig.ssg) {
+          config.server ??= {};
           config.server.buildOptions = applyStylesheetLoaderForServer(config.server.buildOptions, transformCssModule);
         }
 
@@ -240,7 +232,7 @@ const styleSheetLoaderForClient = (config, transformCssModule) => {
  */
 function applyStylesheetLoaderForServer(preBuildOptions, transformCssModule) {
   return (buildOptions) => {
-    const currentOptions = preBuildOptions?.(buildOptions) || buildOptions;
+    const currentOptions = preBuildOptions?.(buildOptions) ?? buildOptions ?? {};
 
     // Remove esbuild-empty-css while use inline style.
     currentOptions.plugins = currentOptions.plugins?.filter(({ name }) => name !== 'esbuild-empty-css');

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,17 +97,6 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         },
       });
 
-      if (!config.server) {
-        config.server = {};
-      }
-      const originalOptions = config.server.buildOptions;
-      config.server.buildOptions = (options) => ({
-        ...(originalOptions ? originalOptions(options) : options),
-        jsx: 'transform',
-        jsxFactory: 'createElement',
-        jsxFragment: 'Fragment',
-      });
-
       Object.assign(config.alias, alias);
 
       if (options.inlineStyle) {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,6 +97,15 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         },
       });
 
+      if (!config.server) {
+        config.server = {};
+      }
+      const originalOptions = config.server.buildOptions;
+
+      config.server.buildOptions = (options) => ({
+        ...(originalOptions ? originalOptions(options) : options),
+      });
+
       Object.assign(config.alias, alias);
 
       if (options.inlineStyle) {

--- a/tests/integration/rax-inline-style.test.ts
+++ b/tests/integration/rax-inline-style.test.ts
@@ -2,12 +2,13 @@ import { expect, test, describe, afterAll } from 'vitest';
 import { buildFixture, setupBrowser } from '../utils/build';
 import { startFixture, setupStartBrowser } from '../utils/start';
 import type { Page } from '../utils/browser';
+import type Browser from '../utils/browser';
 
 const example = 'rax-inline-style';
 
 describe(`build ${example}`, () => {
-  let page: Page = null;
-  let browser = null;
+  let page: Page;
+  let browser: Browser;
 
   test('open /', async () => {
     await buildFixture(example);
@@ -31,15 +32,15 @@ describe(`build ${example}`, () => {
 });
 
 describe(`start ${example}`, () => {
-  let page: Page = null;
-  let browser = null;
+  let page: Page;
+  let browser: Browser;
 
   test('setup devServer', async () => {
     const { devServer, port } = await startFixture(example);
     const res = await setupStartBrowser({ server: devServer, port });
     page = res.page;
     browser = res.browser;
-    await page.waitForFunction('document.getElementsByTagName(\'span\').length > 0');
+    await page.waitForFunction("document.getElementsByTagName('span').length > 0");
 
     // css module
     expect((await page.$$attr('img', 'class'))[0]).contain('logo');


### PR DESCRIPTION
移除了 plugin-rax-compat 中的 server.buildOptions 配置，这一配置导致了项目中存在使用 tsc 或 jsx: preserve 构建的依赖时，启用 rax-compat，会出现 createElement is not defined 错误。