### PR TITLE
fix: do not compile runtime library of tslib

### DIFF
--- a/.changeset/tricky-panthers-applaud.md
+++ b/.changeset/tricky-panthers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+fix: do not compile runtime library of tslib

--- a/packages/webpack-config/src/compileExcludes.ts
+++ b/packages/webpack-config/src/compileExcludes.ts
@@ -1,6 +1,6 @@
 const SKIP_COMPILE = [
   // polyfill and helpers
-  'core-js', 'core-js-pure', '@swc/helpers', '@babel/runtime',
+  'core-js', 'core-js-pure', '@swc/helpers', '@babel/runtime', 'tslib',
   // Deprecate version of @babel/runtime.
   'babel-runtime',
   // built-in runtime


### PR DESCRIPTION
Do not compile runtime library such as @babel/runtime, tslib, @swc/helpers