### PR TITLE
Support inline style filter

### DIFF
--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -139,9 +139,8 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
 
         config.configureWebpack ??= [];
 
-        // when code enters here, options.inlineStyle is either `true` or filter function
-        // if user provide `true`, use a filter which always return true
-        // else, use the filter
+        // When code enters here, options.inlineStyle is either `true` or filter function.
+        // If user provide `true`, use a filter which always return true, or, use the filter.
         const inlineStyleFilter = options.inlineStyle === true ? () => true : options.inlineStyle;
 
         config.configureWebpack.unshift((config) =>
@@ -240,7 +239,7 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
 
           const matched =
             (transformCssModule ? /(\.module|global)\.css$/i : /(\.global)\.css$/i).test(id) &&
-            // if filter returns true, bypass the resource to stylesheet-loader
+            // If filter returns true, bypass the resource to stylesheet-loader.
             !inlineStyleFilterEnabled;
 
           return matched;
@@ -248,9 +247,9 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
         rules[i] = {
           test: /\.css$/i,
           oneOf: [
-            // handle project css and those module can only work under inlineStyle disabled
+            // Handle project css and those module can only work under inlineStyle disabled.
             rule,
-            // handle those module can only work under inlineStyle enabled
+            // Handle those module can only work under inlineStyle enabled.
             ruleSetStylesheet,
           ],
         };

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -81,10 +81,9 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         type: false,
       });
 
-      const compilationConfigFunc =
-        typeof config.swcOptions?.compilationConfig === 'function'
-          ? config.swcOptions?.compilationConfig
-          : () => config.swcOptions?.compilationConfig;
+      const compilationConfigFunc = typeof config.swcOptions?.compilationConfig === 'function'
+        ? config.swcOptions?.compilationConfig
+        : () => config.swcOptions?.compilationConfig;
 
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {
@@ -127,9 +126,7 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
 
       if (options.inlineStyle) {
         if (!warnOnce) {
-          consola.warn(
-            'Enabling inline style is not recommended.\n       It is recommended to use CSS modules (as default). Only allow old projects to migrate and use.',
-          );
+          consola.warn('Enabling inline style is not recommended.\n       It is recommended to use CSS modules (as default). Only allow old projects to migrate and use.');
           warnOnce = true;
         }
 
@@ -166,13 +163,10 @@ function getClassNameToStyleTransformer(syntaxFeatures) {
   const { exportDefaultFrom } = syntaxFeatures;
 
   const plugins: (string | Array<string | object>)[] = [
-    [
-      require.resolve('babel-plugin-transform-jsx-stylesheet'),
-      {
-        retainClassName: true,
-        forceEnableCSS: true,
-      },
-    ],
+    [require.resolve('babel-plugin-transform-jsx-stylesheet'), {
+      retainClassName: true,
+      forceEnableCSS: true,
+    }],
   ];
 
   if (exportDefaultFrom) {
@@ -186,7 +180,13 @@ function getClassNameToStyleTransformer(syntaxFeatures) {
     }
 
     if (jsRegex.test(id)) {
-      const parserPlugins = ['jsx', 'importMeta', 'topLevelAwait', 'classProperties', 'classPrivateMethods'];
+      const parserPlugins = [
+        'jsx',
+        'importMeta',
+        'topLevelAwait',
+        'classProperties',
+        'classPrivateMethods',
+      ];
 
       if (/\.tsx?$/.test(id)) {
         // when routes file is a typescript file,
@@ -245,7 +245,10 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
         };
         rules[i] = {
           test: /\.css$/i,
-          oneOf: [rule, ruleSetStylesheet],
+          oneOf: [
+            rule,
+            ruleSetStylesheet,
+          ],
         };
       }
 
@@ -254,7 +257,10 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
         rule.test = transformCssModule ? /(\.module|global)\.css$/i : /(\.global)\.css$/i;
         rules[i] = {
           test: /\.less$/i,
-          oneOf: [rule, ruleSetStylesheetForLess],
+          oneOf: [
+            rule,
+            ruleSetStylesheetForLess,
+          ],
         };
       }
     }

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -232,6 +232,8 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
       const rule: RuleSetRule = rules[i];
       // Find the css rule, that default to CSS Modules.
       if (rule.test && rule.test instanceof RegExp && rule.test.source.indexOf('.css') > -1) {
+        // Apply inlineStyle here as original rule got higher priority,
+        // the resource doesnot match the filter will be bypassed to stylesheet-loader.
         rule.test = (id: string) => {
           const inlineStyleFilterEnabled = inlineStyleFiler(id) === true;
 

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -139,8 +139,10 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
 
         config.configureWebpack ??= [];
 
-        // enable inlineStyle only when filter returns true explicitly.
-        const inlineStyleFilter = typeof options.inlineStyle === 'function' ? options.inlineStyle : () => false;
+        // when code enters here, options.inlineStyle is either `true` or filter function
+        // if user provide `true`, use a filter which always return true
+        // else, use the filter
+        const inlineStyleFilter = options.inlineStyle === true ? () => true : options.inlineStyle;
 
         config.configureWebpack.unshift((config) =>
           styleSheetLoaderForClient(config, transformCssModule, inlineStyleFilter),
@@ -246,7 +248,9 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
         rules[i] = {
           test: /\.css$/i,
           oneOf: [
+            // handle project css and those module can only work under inlineStyle disabled
             rule,
+            // handle those module can only work under inlineStyle enabled
             ruleSetStylesheet,
           ],
         };

--- a/website/docs/guide/advanced/rax-compat.md
+++ b/website/docs/guide/advanced/rax-compat.md
@@ -21,6 +21,8 @@ $ npm i @ice/plugin-rax-compat --save-dev
 export default defineConfig(() => ({
   plugins: [
 +    compatRax({ inlineStyle: true }), // 是否开启内联样式，这里是开启
++    // 也可以使用函数形式，根据文件名来判断是否开启内联样式
++    compatRax({ inlineStyle: (id) => id.includes('some-module') }),
   ],
 }));
 ```
@@ -78,6 +80,41 @@ console.log(styles); // { foo: { color: 'red' } }
 ```
 
 此外，当 `width` 等属性没有单位时，如 `width: 300`，在 `inlineStyle` 模式下会自动补齐 `rpx` 单位并最终转化成 `vw`，同理，写了 `rpx` 单位的值也一样会被转化成 `vw`。
+
+### 兼容 rax-swiper
+
+由于 [rax-swiper](https://rax.alibaba-inc.com/docs/components/swiper) 仅支持在非内联模式下使用，如果你启用了 `inlineStyle`，则需要在项目的全局 CSS 中新增对其样式的导入：
+
+```diff title="global.css"
++ @import url('swiper/swiper-bundle.min.css');
+```
+
+或者你也可以使用函数形式的 lineStyle，将引用了 `rax-swiper` 的模块排除出内联样式的处理流程：
+
+```diff title="ice.config.mts"
+import compatRax from '@ice/plugin-rax-compat';
+
+export default defineConfig(() => ({
+  plugins: [
++    compatRax({ inlineStyle: (id) => !id.includes('feeds-module') }), 
+  ],
+}));
+```
+
+
+### 兼容使用内联样式构建的模块
+
+Rax 的 inlineStyle 模式是具有传染性的，因此，如果你的项目中存在使用内联样式构建的模块，在 rax-compat 模式下需要确保这些模块也使用内联样式处理，否则会出现样式丢失的问题。此时你可以使用函数形式的 inlineStyle：
+
+```diff title="ice.config.mts"
+import compatRax from '@ice/plugin-rax-compat';
+
+export default defineConfig(() => ({
+  plugins: [
++    compatRax({ inlineStyle: (id) => id.includes('inline-style-module') }), 
+  ],
+}));
+```
 
 ### DOM 属性差异
 


### PR DESCRIPTION
说明：inlineStyle 是具有传染性的，如果项目依赖了启用 inlineStyle 构建的模块，则此项目也必须启用 inlineStyle（即 stylesheet-loader），否则无法加载这些模块的样式。但 inlineStyle 应该被视为废弃的行为，同时可能导致其它非内联构建的模块出现问题（如依赖了 rax-swiper 的模块）。因此这个 PR 引入了文件粒度的配置，支持用户通过函数来延迟决定当前模块应该使用何种行为进行构建。