### PR TITLE
fix: always external dependencies when get config

### DIFF
--- a/.changeset/flat-spies-attack.md
+++ b/.changeset/flat-spies-attack.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: always external dependencies when get config

--- a/packages/ice/src/service/config.ts
+++ b/packages/ice/src/service/config.ts
@@ -53,6 +53,8 @@ class Config {
         sourcemap: false,
         logLevel: 'silent', // The main server compiler process will log it.
       }, {
+        // Always external dependencies when get config.
+        externalDependencies: true,
         swc: {
           keepExports: {
             value: keepExports,


### PR DESCRIPTION
Always external dependencies when get config otherwise `.ice/routes-config.bundle.mjs` will pack @ice/runtime and dependencies when server.bundle is true.