### PR TITLE
fix: render twice when navigate

### DIFF
--- a/.changeset/breezy-falcons-smell.md
+++ b/.changeset/breezy-falcons-smell.md
@@ -1,0 +1,6 @@
+---
+'@ice/runtime': patch
+'@ice/app': patch
+---
+
+fix: render twice when navigate and bump react-router to 6.14.2

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -80,7 +80,7 @@
     "esbuild": "^0.17.16",
     "jest": "^29.0.2",
     "react": "^18.2.0",
-    "react-router": "6.11.2",
+    "react-router": "6.14.2",
     "sass": "^1.50.0",
     "unplugin": "^0.9.0",
     "webpack": "^5.86.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -50,13 +50,13 @@
   ],
   "dependencies": {
     "@ice/jsx-runtime": "^0.2.1",
-    "@remix-run/router": "1.6.2",
+    "@remix-run/router": "1.7.2",
     "abortcontroller-polyfill": "1.7.5",
     "ejs": "^3.1.6",
     "fs-extra": "^10.0.0",
     "history": "^5.3.0",
     "htmlparser2": "^8.0.1",
-    "react-router-dom": "6.11.2",
+    "react-router-dom": "6.14.2",
     "semver": "^7.4.0",
     "source-map": "^0.7.4"
   },

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -69,9 +69,9 @@ export default async function runClientApp(options: RunClientAppOptions) {
     initialEntry: routePath,
     routes,
   };
-  const history = deprecatedHistory(createHistory(appConfig, historyOptions));
+  const history = createHistory(appConfig, historyOptions);
   // Set history for import it from ice.
-  setHistory(history);
+  setHistory(deprecatedHistory(history));
 
   const appContext: AppContext = {
     appExport: app,
@@ -219,10 +219,10 @@ function createHistory(
   const createHistory = process.env.ICE_CORE_ROUTER === 'true'
     ? createRouterHistory(appConfig?.router?.type, memoryRouter)
     : createHistorySingle;
-  let createHistoryOptions: Parameters<typeof createHistory>[0] = { window, v5Compat: true };
+  let createHistoryOptions: Parameters<typeof createHistory>[0] = { window };
 
   if (routerType === 'memory') {
-    const memoryOptions: Parameters<typeof createMemoryHistory>[0] = { v5Compat: true };
+    const memoryOptions: Parameters<typeof createMemoryHistory>[0] = {};
     memoryOptions.initialEntries = appConfig?.router?.initialEntries || getRoutesPath(routes);
     if (initialEntry) {
       const initialIndex = memoryOptions.initialEntries.findIndex((entry) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,7 +1125,7 @@ importers:
       open: ^8.4.0
       path-to-regexp: ^6.2.0
       react: ^18.2.0
-      react-router: 6.11.2
+      react-router: 6.14.2
       regenerator-runtime: ^0.13.0
       resolve.exports: ^1.1.0
       sass: ^1.50.0
@@ -1180,7 +1180,7 @@ importers:
       esbuild: 0.17.16
       jest: 29.5.0
       react: 18.2.0
-      react-router: 6.11.2_react@18.2.0
+      react-router: 6.14.2_react@18.2.0
       sass: 1.50.0
       unplugin: 0.9.5_3d2sldnof75occqqtyfzznb47i
       webpack: 5.86.0_esbuild@0.17.16
@@ -1557,7 +1557,7 @@ importers:
   packages/runtime:
     specifiers:
       '@ice/jsx-runtime': ^0.2.1
-      '@remix-run/router': 1.6.2
+      '@remix-run/router': 1.7.2
       '@remix-run/web-fetch': ^4.3.3
       '@types/react': ^18.0.8
       '@types/react-dom': ^18.0.3
@@ -1568,19 +1568,19 @@ importers:
       htmlparser2: ^8.0.1
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 6.11.2
+      react-router-dom: 6.14.2
       regenerator-runtime: ^0.13.9
       semver: ^7.4.0
       source-map: ^0.7.4
     dependencies:
       '@ice/jsx-runtime': link:../jsx-runtime
-      '@remix-run/router': 1.6.2
+      '@remix-run/router': 1.7.2
       abortcontroller-polyfill: 1.7.5
       ejs: 3.1.8
       fs-extra: 10.1.0
       history: 5.3.0
       htmlparser2: 8.0.1
-      react-router-dom: 6.11.2_biqbaboplfbrettd7655fr4n2y
+      react-router-dom: 6.14.2_biqbaboplfbrettd7655fr4n2y
       semver: 7.4.0
       source-map: 0.7.4
     devDependencies:
@@ -6443,8 +6443,8 @@ packages:
     resolution: {integrity: sha512-YUkWj+xs0oOzBe74OgErsuR3wVn+efrFhXBWrit50kOiED+pvQe2r6MWY0iJMQU/mSVKxvNzL4ZaYvjdX+G7ZA==}
     engines: {node: '>=14'}
 
-  /@remix-run/router/1.6.2:
-    resolution: {integrity: sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==}
+  /@remix-run/router/1.7.2:
+    resolution: {integrity: sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==}
     engines: {node: '>=14'}
 
   /@remix-run/web-blob/3.0.4:
@@ -9750,8 +9750,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -18827,6 +18827,12 @@ packages:
   /react-dev-utils/12.0.1_y75l3d5in5mgvug53qfq62ncxu:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.2
@@ -18857,9 +18863,7 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -19030,17 +19034,17 @@ packages:
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
 
-  /react-router-dom/6.11.2_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==}
+  /react-router-dom/6.14.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.6.2
+      '@remix-run/router': 1.7.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router: 6.11.2_react@18.2.0
+      react-router: 6.14.2_react@18.2.0
     dev: false
 
   /react-router/5.3.4_react@17.0.2:
@@ -19059,13 +19063,13 @@ packages:
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
 
-  /react-router/6.11.2_react@18.2.0:
-    resolution: {integrity: sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==}
+  /react-router/6.14.2_react@18.2.0:
+    resolution: {integrity: sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.6.2
+      '@remix-run/router': 1.7.2
       react: 18.2.0
 
   /react-textarea-autosize/8.4.0_h7fc2el62uaa77gho3xhys6ola:


### PR DESCRIPTION
- [x] fix: render twice when navigate 
- [x] chore: bump react-router to 6.14.2

> v5Compat is actived for the backforward  to use history API such as `history.push`,
> currently it will be replace by navigate api after router is created https://github.com/alibaba/ice/blob/ae705c03e8b6aa5ab4c7678c58788094f9e3d66d/packages/runtime/src/ClientRouter.tsx#L43

Fix #6390