### PR TITLE
fix: fix inlineStyle filter function check

### DIFF
--- a/.changeset/flat-dodos-sniff.md
+++ b/.changeset/flat-dodos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+fix inlineStyle filter function check

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -248,13 +248,16 @@ const styleSheetLoaderForClient = (config, transformCssModule, inlineStyleFiler:
         // the resource doesnot match the filter will be bypassed to stylesheet-loader.
         rule.test = (id: string) => {
           const inlineStyleDisabled = typeof inlineStyleFiler === 'function'
+            // The tester returns true, means this file should still be handled by InlineStyleLoader.
             // The tester returns false, means user want this file to be handled by ExternalStyleLoader.
             ? inlineStyleFiler(id) === false
-            // inlineStyle: true, use the next InlineStyleLoader just like before.
+            // Means `inlineStyle: true`, use the next InlineStyleLoader just like before.
             : false;
 
           const matched =
+            // Default test matcher.
             (transformCssModule ? /(\.module|global)\.css$/i : /(\.global)\.css$/i).test(id) ||
+            // CSS styles which was marked `inlineStyle: false` explicitly.
             inlineStyleDisabled;
 
           return matched;


### PR DESCRIPTION
TL;DR: 确保仅在 inlineStyle 为函数，且返回了 false 的情况下才更改原逻辑。

预期的正常逻辑：

- `inlineStyle: true`
  - ExternalStyleLoader → 处理 global.css / *.module.css
  - InlineStyleLoader → 处理所有其它 *.css 逻辑，将其处理为 JS 对象
- `inlineStyle: false`
  - ExternalStyleLoader → 处理所有 CSS 逻辑

问题逻辑：

- `inlineStyle: true`
  - ExternalStyleLoader → 处理 global.css / *.module.css **且被 inlineStyleFilter 显式返回 false 的文件**，也就是此时 `inlineStyle: true` （原逻辑中，等价于 `filter: () => true`）会导致且条件始终不满足，导致所有样式文件被 InlineStyleLoader 处理。

修正：

- 仅在 inlineStyle 显式传入一个函数，并且对当前的文件返回了 false 时，才使用 ExternalStyleLoader，否则对于 `inlineStyle: true` 或返回 filter 返回 true 的情况，都保持原有的正常逻辑。