### PR TITLE
feat: support API useDocumentData

### DIFF
--- a/.changeset/olive-bikes-carry.md
+++ b/.changeset/olive-bikes-carry.md
@@ -1,0 +1,6 @@
+---
+'@ice/runtime': patch
+'@ice/app': patch
+---
+
+feat: support API useDocumentData

--- a/examples/basic-project/src/app.tsx
+++ b/examples/basic-project/src/app.tsx
@@ -46,3 +46,12 @@ export const dataLoader = defineDataLoader(() => {
 export const runApp = (render) => {
   render();
 };
+export const unstable_documentData = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        data: 'documentData',
+      });
+    }, 1000);
+  });
+};

--- a/examples/basic-project/src/app.tsx
+++ b/examples/basic-project/src/app.tsx
@@ -46,12 +46,3 @@ export const dataLoader = defineDataLoader(() => {
 export const runApp = (render) => {
   render();
 };
-export const unstable_documentData = () => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        data: 'documentData',
-      });
-    }, 1000);
-  });
-};

--- a/examples/basic-project/src/document.tsx
+++ b/examples/basic-project/src/document.tsx
@@ -1,8 +1,12 @@
-import { Meta, Title, Links, Main, Scripts, useAppData } from 'ice';
+import { Meta, Title, Links, Main, Scripts, useAppData, useDocumentData } from 'ice';
 import type { AppData } from '@/types';
 
 function Document() {
   const appData = useAppData<AppData>();
+  // Get document data when fallback to document only.
+  const data = useDocumentData();
+
+  console.log('document data', data);
 
   return (
     <html>

--- a/examples/basic-project/src/document.tsx
+++ b/examples/basic-project/src/document.tsx
@@ -1,12 +1,23 @@
-import { Meta, Title, Links, Main, Scripts, useAppData, unstable_useDocumentData } from 'ice';
+import { Meta, Title, Links, Main, Scripts, useAppData, defineDataLoader, unstable_useDocumentData } from 'ice';
 import type { AppData } from '@/types';
+
+export const dataLoader = defineDataLoader(() => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        title: 'documentData',
+      });
+      // ATTENTION: This async call will pause rendering document.
+    }, 1000);
+  });
+});
 
 function Document() {
   const appData = useAppData<AppData>();
   // Get document data when fallback to document only.
-  const data = unstable_useDocumentData();
+  const documentData = unstable_useDocumentData();
 
-  console.log('document data', data);
+  console.log('document data', documentData);
 
   return (
     <html>
@@ -25,6 +36,12 @@ function Document() {
       </head>
       <body>
         <Main />
+        <div>
+          <h1>Document Data</h1>
+          <code>
+            <pre>{JSON.stringify(documentData, null, 2)}</pre>
+          </code>
+        </div>
         <Scripts />
       </body>
     </html>

--- a/examples/basic-project/src/document.tsx
+++ b/examples/basic-project/src/document.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import { Meta, Title, Links, Main, Scripts, useAppData, defineDataLoader, unstable_useDocumentData } from 'ice';
 import type { AppData } from '@/types';
 

--- a/examples/basic-project/src/document.tsx
+++ b/examples/basic-project/src/document.tsx
@@ -1,10 +1,10 @@
-import { Meta, Title, Links, Main, Scripts, useAppData, useDocumentData } from 'ice';
+import { Meta, Title, Links, Main, Scripts, useAppData, unstable_useDocumentData } from 'ice';
 import type { AppData } from '@/types';
 
 function Document() {
   const appData = useAppData<AppData>();
   // Get document data when fallback to document only.
-  const data = useDocumentData();
+  const data = unstable_useDocumentData();
 
   console.log('document data', data);
 

--- a/packages/ice/src/constant.ts
+++ b/packages/ice/src/constant.ts
@@ -67,6 +67,7 @@ export const RUNTIME_EXPORTS = [
       'defineServerDataLoader',
       'defineStaticDataLoader',
       'usePageLifecycle',
+      'useDocumentData',
     ],
     alias: {
       usePublicAppContext: 'useAppContext',

--- a/packages/ice/src/constant.ts
+++ b/packages/ice/src/constant.ts
@@ -67,7 +67,7 @@ export const RUNTIME_EXPORTS = [
       'defineServerDataLoader',
       'defineStaticDataLoader',
       'usePageLifecycle',
-      'useDocumentData',
+      'unstable_useDocumentData',
     ],
     alias: {
       usePublicAppContext: 'useAppContext',

--- a/packages/ice/templates/core/entry.server.ts.ejs
+++ b/packages/ice/templates/core/entry.server.ts.ejs
@@ -4,7 +4,7 @@ import * as runtime from '@ice/runtime/server';
 import { commons, statics } from './runtimeModules';
 <% }-%>
 import * as app from '@/app';
-import Document from '@/document';
+import * as Document from '@/document';
 import type { RenderMode, DistType } from '@ice/runtime';
 import type { RenderToPipeableStreamOptions } from 'react-dom/server';
 // @ts-ignore
@@ -85,7 +85,8 @@ function mergeOptions(options) {
     assetsManifest,
     createRoutes,
     runtimeModules,
-    Document,
+    documentDataLoader: Document.dataLoader,
+    Document: Document.default,
     basename: basename || getRouterBasename(),
     renderMode,
     routesConfig,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -50,6 +50,7 @@
   ],
   "dependencies": {
     "@ice/jsx-runtime": "^0.2.1",
+    "@ice/shared": "^1.0.1",
     "@remix-run/router": "1.7.2",
     "abortcontroller-polyfill": "1.7.5",
     "ejs": "^3.1.6",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -82,7 +82,7 @@ function usePublicAppContext(): PublicAppContext {
 
 function useDocumentData() {
   const context = useInternalAppContext();
-  return context.unstable_documentData;
+  return context.documentData;
 }
 
 // @TODO: remove unstable prefix or refactor.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -82,8 +82,11 @@ function usePublicAppContext(): PublicAppContext {
 
 function useDocumentData() {
   const context = useInternalAppContext();
-  return context.documentData;
+  return context.unstable_documentData;
 }
+
+// @TODO: remove unstable prefix or refactor.
+export const unstable_useDocumentData = useDocumentData;
 
 export {
   getAppConfig,
@@ -97,7 +100,6 @@ export {
    */
   useAppContext,
   usePublicAppContext,
-  useDocumentData,
   useAppData,
   useData,
   getAppData,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -80,6 +80,11 @@ function usePublicAppContext(): PublicAppContext {
   };
 }
 
+function useDocumentData() {
+  const context = useInternalAppContext();
+  return context.documentData;
+}
+
 export {
   getAppConfig,
   defineAppConfig,
@@ -92,6 +97,7 @@ export {
    */
   useAppContext,
   usePublicAppContext,
+  useDocumentData,
   useAppData,
   useData,
   getAppData,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -86,6 +86,7 @@ function useDocumentData() {
 }
 
 // @TODO: remove unstable prefix or refactor.
+// eslint-disable-next-line
 export const unstable_useDocumentData = useDocumentData;
 
 export {

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -415,7 +415,14 @@ async function renderServerEntry(
   const pipe = renderToNodeStream(element);
 
   const fallback = () => {
-    return renderDocument({ matches, routePath, renderOptions, routes, downgrade: true, documentData: appContext.documentData });
+    return renderDocument({
+      matches,
+      routePath,
+      renderOptions,
+      routes,
+      downgrade: true,
+      documentData: appContext.documentData,
+    });
   };
 
   return {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -38,7 +38,6 @@ export interface AppExport {
   default?: AppConfig;
   [key: string]: any;
   dataLoader?: DataLoaderConfig;
-  documentData: (requestContext: RequestContext) => Promise<any>;
 }
 
 export type DataLoaderResult = (Promise<RouteData> | RouteData) | RouteData;
@@ -100,7 +99,7 @@ export interface LoaderData {
 export interface AppContext {
   appConfig: AppConfig;
   appData: any;
-  unstable_documentData?: any;
+  documentData?: any;
   serverData?: any;
   assetsManifest?: AssetsManifest;
   loaderData?: LoadersData;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -38,6 +38,7 @@ export interface AppExport {
   default?: AppConfig;
   [key: string]: any;
   dataLoader?: DataLoaderConfig;
+  documentData: (requestContext: RequestContext) => Promise<any>;
 }
 
 export type DataLoaderResult = (Promise<RouteData> | RouteData) | RouteData;
@@ -99,6 +100,7 @@ export interface LoaderData {
 export interface AppContext {
   appConfig: AppConfig;
   appData: any;
+  documentData?: any;
   serverData?: any;
   assetsManifest?: AssetsManifest;
   loaderData?: LoadersData;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -100,7 +100,7 @@ export interface LoaderData {
 export interface AppContext {
   appConfig: AppConfig;
   appData: any;
-  documentData?: any;
+  unstable_documentData?: any;
   serverData?: any;
   assetsManifest?: AssetsManifest;
   loaderData?: LoadersData;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1582,6 +1582,7 @@ importers:
   packages/runtime:
     specifiers:
       '@ice/jsx-runtime': ^0.2.1
+      '@ice/shared': ^1.0.1
       '@remix-run/router': 1.7.2
       '@remix-run/web-fetch': ^4.3.3
       '@types/react': ^18.0.8
@@ -1599,6 +1600,7 @@ importers:
       source-map: ^0.7.4
     dependencies:
       '@ice/jsx-runtime': link:../jsx-runtime
+      '@ice/shared': link:../shared
       '@remix-run/router': 1.7.2
       abortcontroller-polyfill: 1.7.5
       ejs: 3.1.8


### PR DESCRIPTION
### Usage

Step 1: export `dataLoader` in `src/document.tsx`

```ts
// 这里参考 data-loader 的定义
export const dataLoader = defineDataLoader(() => {/* ... */});
```

Step2: use API `unstable_useDocumentData` imported from `ice`

```ts
import { unstable_useDocumentData } from 'ice';
```

临时解决方案，需要 document 计划改造成 RSC 方式执行