### PR TITLE
Fix unmountComponentAtNode compat rax

### DIFF
--- a/.changeset/neat-apples-divide.md
+++ b/.changeset/neat-apples-divide.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+fix: fix unmountComponentAtNode compat

--- a/packages/rax-compat/src/container-root-map.ts
+++ b/packages/rax-compat/src/container-root-map.ts
@@ -1,0 +1,8 @@
+import type { Root } from 'react-dom/client';
+
+/**
+ * A WeakMap that keeps track of container mouted root.
+ * @key The container element passed to `render` function, which call `createRoot` and `root.render` internally.
+ * @value The root instance returned by `createRoot` function.
+ */
+export const containerRootMap = new WeakMap<Element | DocumentFragment, Root>();

--- a/packages/rax-compat/src/render.ts
+++ b/packages/rax-compat/src/render.ts
@@ -32,7 +32,10 @@ export default function render(
  */
 export default function render(
   element: RaxElement,
-  container: Element | DocumentFragment | null,
+  // Doesnot provide overload like `render(<Container />, callback))`,
+  // should use `render(<Container />, null, callback))` instead,
+  // as rendering without specified container is NOT RECOMMENDED.
+  container?: Element | DocumentFragment | null,
   optionsOrCallback?: RenderOption | Function,
   callback?: Function,
 ): RaxElement {
@@ -42,12 +45,12 @@ export default function render(
   }
 
   /**
-   * Compat for rax driver-dom behavior, which use body as container for nullish container.
+   * Compat for rax driver-dom behavior, which use body as container for non-specified container.
    * ref: https://github.com/alibaba/rax/blob/13d80a491f18c74034aa9b05c36ac922ff8c3357/packages/rax/src/vdom/instance.js#L44
    * ref: https://github.com/alibaba/rax/blob/13d80a491f18c74034aa9b05c36ac922ff8c3357/packages/driver-dom/src/index.js#L75
    */
-  if (container === null) {
-    container = document.querySelector('body')!;
+  if (!container) {
+    container = document.body;
   }
 
   const root = createRoot(container, optionsOrCallback as RootOptions);

--- a/packages/rax-compat/src/render.ts
+++ b/packages/rax-compat/src/render.ts
@@ -5,6 +5,22 @@ import { createRoot } from 'react-dom/client';
 import { isFunction } from './type.js';
 import { containerRootMap } from './container-root-map.js';
 
+export default function render(
+  element: RaxElement,
+  container: Element | DocumentFragment | null,
+  options?: RenderOption,
+): RaxElement;
+export default function render(
+  element: RaxElement,
+  container: Element | DocumentFragment | null,
+  callback?: Function,
+): RaxElement;
+export default function render(
+  element: RaxElement,
+  container: Element | DocumentFragment | null,
+  options?: RenderOption,
+  callback?: Function,
+): RaxElement;
 /**
  * Compat render for rax export.
  * https://github.com/alibaba/rax/blob/master/packages/rax/src/render.js#L5
@@ -17,19 +33,28 @@ import { containerRootMap } from './container-root-map.js';
 export default function render(
   element: RaxElement,
   container: Element | DocumentFragment | null,
-  options?: RenderOption,
+  optionsOrCallback?: RenderOption | Function,
   callback?: Function,
 ): RaxElement {
-  if (isFunction(options)) {
-    callback = options;
-    options = null;
+  if (isFunction(optionsOrCallback)) {
+    callback = optionsOrCallback;
+    optionsOrCallback = {} as RenderOption;
   }
 
-  const root = createRoot(container, options as RootOptions);
+  /**
+   * Compat for rax driver-dom behavior, which use body as container for nullish container.
+   * ref: https://github.com/alibaba/rax/blob/13d80a491f18c74034aa9b05c36ac922ff8c3357/packages/rax/src/vdom/instance.js#L44
+   * ref: https://github.com/alibaba/rax/blob/13d80a491f18c74034aa9b05c36ac922ff8c3357/packages/driver-dom/src/index.js#L75
+   */
+  if (container === null) {
+    container = document.querySelector('body')!;
+  }
+
+  const root = createRoot(container, optionsOrCallback as RootOptions);
   root.render(element as ReactNode);
 
   // Save container and root relation.
-  container && containerRootMap.set(container, root);
+  containerRootMap.set(container, root);
 
   if (isFunction(callback)) {
     callback.call(element);

--- a/packages/rax-compat/src/render.ts
+++ b/packages/rax-compat/src/render.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { RootOptions } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
 import { isFunction } from './type.js';
+import { containerRootMap } from './container-root-map.js';
 
 /**
  * Compat render for rax export.
@@ -26,6 +27,10 @@ export default function render(
 
   const root = createRoot(container, options as RootOptions);
   root.render(element as ReactNode);
+
+  // Save container and root relation.
+  container && containerRootMap.set(container, root);
+
   if (isFunction(callback)) {
     callback.call(element);
   }

--- a/packages/rax-compat/src/unmount-component-at-node.ts
+++ b/packages/rax-compat/src/unmount-component-at-node.ts
@@ -1,6 +1,25 @@
 import type { Container } from 'react-dom';
+import { containerRootMap } from './container-root-map.js';
 
+/**
+ * Unmount a component rendered to a DOM node.
+ * To unmount a component strictly, its state and event handlers should be cleaned up appropriately,
+ * Which means we should let `React` do the unmounting work.
+ *
+ * In React 18, this method will be replaced by [root.unmount](https://react.dev/reference/react-dom/client/createRoot#root-unmount),
+ * We preserve this method for Rax API compatibility.
+ *
+ * As we cannot approach the root instance from container element directly,
+ * we use a WeakMap to keep track of container mouted root,
+ * which saves the container-root relation in `render`(and `createRoot()` under the hood) execution.
+
+ * @param container The container element which to be unmounted.
+ */
 export default function unmountComponentAtNode(container: Container) {
-  // @TODO: unmount
-  container.textContent = '';
+  const relatedRoot = containerRootMap.get(container);
+  // Ensure the root exists, then unmount root and remove it from containerRootMap.
+  if (relatedRoot) {
+    relatedRoot.unmount();
+    containerRootMap.delete(container);
+  }
 }

--- a/packages/rax-compat/tsconfig.json
+++ b/packages/rax-compat/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "allowJs": true,
     "noUnusedLocals": true,
+    "strictNullChecks": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,


### PR DESCRIPTION
- Fixs: Rax-Compat 下， `unmountComponentAtNode` 方法没有正确触发 Container 内部的 useEffect cleanup 流程。
- 由于 `render` 方法内部已经替换为 `createRoot`，而 React DOM 的 `unmountComponentAtNode` 方法不允许使用与 `createRoot` 相同的入参（即，`createRoot(container)` 后 `unmountComponentAtNode(container)`），同时 React 18 将废弃此方法，故不考虑用此方式实现。
- 为了直接抹平与 Rax 下的差异，无需模块代码变更，考虑使用 WeakMap 保存 container-root 关联，在 `render` 时保存此 container 对应的 root，并在 `unmountComponentAtNode` 时查找到对应的 root，调用 `root.unmount()`。