### PR TITLE
fix: build warning of runApp is not exported

### DIFF
--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -69,7 +69,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     command,
   });
 
-  let entryCode = 'render(app);';
+  let entryCode = 'render();';
 
   const generatorAPI = {
     addExport: (declarationData: Omit<DeclarationData, 'declarationType'>) => {

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -69,11 +69,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     command,
   });
 
-  let entryCode = `if (app.runApp) {
-  app.runApp(render, renderOptions);
-} else {
-  render();
-}`;
+  let entryCode = 'render(app);';
 
   const generatorAPI = {
     addExport: (declarationData: Omit<DeclarationData, 'declarationType'>) => {

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -174,6 +174,7 @@ async function webpackCompiler(options: {
       return;
     } else if (messages.warnings.length) {
       logger.warn('Client compiled with warnings.');
+      logger.warn(statsData);
       logger.warn(messages.warnings.join('\n'));
     }
     if (command === 'start') {

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -174,7 +174,6 @@ async function webpackCompiler(options: {
       return;
     } else if (messages.warnings.length) {
       logger.warn('Client compiled with warnings.');
-      logger.warn(statsData);
       logger.warn(messages.warnings.join('\n'));
     }
     if (command === 'start') {

--- a/packages/ice/templates/core/entry.client.tsx.ejs
+++ b/packages/ice/templates/core/entry.client.tsx.ejs
@@ -49,7 +49,7 @@ const renderOptions: RunClientAppOptions = {
   },
 };
 
-const render = (customOptions: Record<string, any> = {}) => {
+const defaultRender = (customOptions: Record<string, any> = {}) => {
   return runClientApp({
     ...renderOptions,
     ...customOptions,
@@ -59,6 +59,14 @@ const render = (customOptions: Record<string, any> = {}) => {
     },
   });
 };
+
+const render = (appExport: any) => {
+  if (appExport.runApp) {
+    return appExport.runApp(defaultRender, renderOptions);
+  } else {
+    return defaultRender();
+  }
+}
 
 <%- entryCode %>
 

--- a/packages/ice/templates/core/entry.client.tsx.ejs
+++ b/packages/ice/templates/core/entry.client.tsx.ejs
@@ -49,7 +49,7 @@ const renderOptions: RunClientAppOptions = {
   },
 };
 
-const defaultRender = (customOptions: Record<string, any> = {}) => {
+const defaultRender = (customOptions: Partial<RunClientAppOptions> = {}) => {
   return runClientApp({
     ...renderOptions,
     ...customOptions,
@@ -60,13 +60,17 @@ const defaultRender = (customOptions: Record<string, any> = {}) => {
   });
 };
 
-const render = (appExport: any) => {
+const renderApp = (appExport: any, customOptions: Partial<RunClientAppOptions>) => {
   if (appExport.runApp) {
     return appExport.runApp(defaultRender, renderOptions);
   } else {
-    return defaultRender();
+    return defaultRender(customOptions);
   }
-}
+};
+
+const render = (customOptions: Partial<RunClientAppOptions> = {}) => {
+  renderApp(app, customOptions);
+};
 
 <%- entryCode %>
 


### PR DESCRIPTION
Default imported will cause build warning when attempt to access props which is not exported in IIFE.

![image](https://github.com/alibaba/ice/assets/4219965/7ef0a0af-9ef0-491f-a4d0-eadd9c21004a)
