### PR TITLE
Rax Compat createElement should transofrm array type style

### DIFF
--- a/.changeset/few-hounds-deliver.md
+++ b/.changeset/few-hounds-deliver.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+normalize style prop on creating elemnt

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -1,11 +1,26 @@
 import type {
   Attributes,
   FunctionComponent,
+  HTMLAttributes,
   ReactElement,
   ReactNode,
 } from 'react';
 import { createElement as _createElement } from 'react';
 import { createJSXElementFactory } from './compat/element.js';
+
+/**
+  * Transform array type style to avoid
+  * `Failed to set an indexed property on 'CSSStyleDeclaration': Index property setter is not supported`
+  * error.
+  */
+const normalizeStyleProp = (style: unknown) => {
+  if (Array.isArray(style)) {
+    return style.reduce((acc, val) => {
+      return { ...acc, ...val };
+    }, {});
+  }
+  return style;
+};
 
 const jsx = createJSXElementFactory((type: any, props: any, ...children: ReactNode[]) =>
   _createElement(type, props, ...children));
@@ -20,7 +35,11 @@ const jsx = createJSXElementFactory((type: any, props: any, ...children: ReactNo
  */
 export function createElement<P>(
   type: FunctionComponent<P> | string,
-  props?: Attributes & P | null,
+  props?: Attributes & P & HTMLAttributes<any> | null,
   ...children: ReactNode[]): ReactElement {
+  if (props?.style) {
+    props.style = normalizeStyleProp(props.style);
+  }
+
   return jsx(type, props, ...children);
 }


### PR DESCRIPTION
对于数组类型的 style 属性，应当将其转换为对象类型，避免浏览器层面的异常。

Ref: https://github.com/facebook/react/issues/15375#issuecomment-490701560

TODO: transform string type?