### PR TITLE
feat: support define route with absolute path

### DIFF
--- a/.changeset/famous-bottles-lick.md
+++ b/.changeset/famous-bottles-lick.md
@@ -1,0 +1,6 @@
+---
+'@ice/route-manifest': patch
+'@ice/app': patch
+---
+
+feat: support define route with absolute path

--- a/packages/ice/src/routes.ts
+++ b/packages/ice/src/routes.ts
@@ -22,7 +22,7 @@ export async function generateRoutesInfo(
     // add exports filed for route manifest
     routeItem.exports = await getFileExports({
       rootDir,
-      file: formatPath(path.join('./src/pages', routeItem.file)),
+      file: formatPath(path.isAbsolute(routeItem.file) ? routeItem.file : path.join('./src/pages', routeItem.file)),
     });
   });
   await Promise.all(analyzeTasks);
@@ -55,12 +55,15 @@ export default {
   };
 }
 
+function getFilePath(file: string) {
+  return formatPath(path.isAbsolute(file) ? file : `@/pages/${file}`.replace(new RegExp(`${path.extname(file)}$`), ''));
+}
+
 export function getRoutesDefinition(nestRouteManifest: NestedRouteManifest[], lazy = false, depth = 0) {
   const routeImports: string[] = [];
   const routeDefinition = nestRouteManifest.reduce((prev, route) => {
     const { children, path: routePath, index, componentName, file, id, layout, exports } = route;
-
-    const componentPath = id.startsWith('__') ? file : `@/pages/${file}`.replace(new RegExp(`${path.extname(file)}$`), '');
+    const componentPath = id.startsWith('__') ? file : getFilePath(file);
 
     let loadStatement = '';
     if (lazy) {

--- a/packages/ice/src/service/analyze.ts
+++ b/packages/ice/src/service/analyze.ts
@@ -221,7 +221,7 @@ type CachedRouteExports = { hash: string; exports: string[] };
 // Exports for other plugin to get exports info.
 export async function getFileExports(options: FileOptions): Promise<CachedRouteExports['exports']> {
   const { rootDir, file } = options;
-  const filePath = path.join(rootDir, file);
+  const filePath = path.isAbsolute(file) ? file : path.join(rootDir, file);
   let cached: CachedRouteExports | null = null;
   try {
     cached = await getCache(rootDir, filePath);

--- a/packages/route-manifest/src/index.ts
+++ b/packages/route-manifest/src/index.ts
@@ -83,6 +83,7 @@ export function generateRouteManifest(
     defineExtraRoutesQueue.forEach((defineExtraRoutes) => {
       if (defineExtraRoutes) {
         const extraRoutes = defineRoutes(
+          rootDir,
           defineExtraRoutes,
           {
             routeManifest,
@@ -244,7 +245,7 @@ function defineConventionalRoutes(
     }
   }
 
-  return defineRoutes(defineNestedRoutes, options);
+  return defineRoutes(rootDir, defineNestedRoutes, options);
 }
 
 const escapeStart = '[';

--- a/packages/route-manifest/src/routes.ts
+++ b/packages/route-manifest/src/routes.ts
@@ -1,6 +1,6 @@
 // based on https://github.com/remix-run/remix/blob/main/packages/remix-dev/config/routes.ts
 
-import { win32, join } from 'path';
+import { win32, join, isAbsolute, relative, sep } from 'path';
 
 export interface ConfigRoute {
   /**
@@ -92,14 +92,19 @@ export type DefineExtraRoutes = (
   options: DefineRoutesOptions,
 ) => void;
 
+
+export function formatPath(pathStr: string): string {
+  return process.platform === 'win32' ? pathStr.split(sep).join('/') : pathStr;
+}
+
 export function defineRoutes(
+  rootDir: string,
   callback: (defineRoute: DefineRouteFunction, options: DefineRoutesOptions) => void,
   options: DefineRoutesOptions,
 ) {
   const routes: RouteManifest = Object.create(null);
   const parentRoutes: ConfigRoute[] = [];
   let alreadyReturned = false;
-
   const defineRoute: DefineRouteFunction = (path, file, optionsOrChildren, children) => {
     if (alreadyReturned) {
       throw new Error(
@@ -131,7 +136,7 @@ export function defineRoutes(
       id,
       parentId: parentRoute ? parentRoute.id : undefined,
       file,
-      componentName: createComponentName(file),
+      componentName: createComponentName(isAbsolute(file) ? formatPath(relative(rootDir, file)) : file),
       layout: id.endsWith('layout'),
     };
 

--- a/packages/route-manifest/tests/__snapshots__/generateRouteManifest.spec.ts.snap
+++ b/packages/route-manifest/tests/__snapshots__/generateRouteManifest.spec.ts.snap
@@ -50,20 +50,6 @@ exports[`generateRouteManifest function > basic-routes 1`] = `
 }
 `;
 
-exports[`generateRouteManifest function > define-absolute-route 1`] = `
-{
-  "/about-me": {
-    "componentName": "src-index",
-    "file": "/Users/clark/develop/ice/packages/route-manifest/tests/fixtures/define-absolute-route/src/index.tsx",
-    "id": "/about-me",
-    "index": undefined,
-    "layout": false,
-    "parentId": undefined,
-    "path": "/about-me",
-  },
-}
-`;
-
 exports[`generateRouteManifest function > define-extra-routes 1`] = `
 {
   "/": {

--- a/packages/route-manifest/tests/__snapshots__/generateRouteManifest.spec.ts.snap
+++ b/packages/route-manifest/tests/__snapshots__/generateRouteManifest.spec.ts.snap
@@ -50,6 +50,20 @@ exports[`generateRouteManifest function > basic-routes 1`] = `
 }
 `;
 
+exports[`generateRouteManifest function > define-absolute-route 1`] = `
+{
+  "/about-me": {
+    "componentName": "src-index",
+    "file": "/Users/clark/develop/ice/packages/route-manifest/tests/fixtures/define-absolute-route/src/index.tsx",
+    "id": "/about-me",
+    "index": undefined,
+    "layout": false,
+    "parentId": undefined,
+    "path": "/about-me",
+  },
+}
+`;
+
 exports[`generateRouteManifest function > define-extra-routes 1`] = `
 {
   "/": {

--- a/packages/route-manifest/tests/generateRouteManifest.spec.ts
+++ b/packages/route-manifest/tests/generateRouteManifest.spec.ts
@@ -52,6 +52,18 @@ describe('generateRouteManifest function', () => {
     expect(routeManifest).toMatchSnapshot();
   });
 
+  test('define-absolute-route', () => {
+    const rootDir = path.join(fixturesDir, 'define-absolute-route');
+    const routeManifest = generateRouteManifest(
+      rootDir,
+      ['About/index.tsx'],
+      [(defineRoute) => {
+        defineRoute('/about-me', path.join(rootDir, 'src/index.tsx'));
+      }],
+    );
+    expect(routeManifest).toMatchSnapshot();
+  });
+
   test('escape-routes', () => {
     const routeManifest = generateRouteManifest(
       path.join(fixturesDir, 'escape-routes'),

--- a/packages/route-manifest/tests/generateRouteManifest.spec.ts
+++ b/packages/route-manifest/tests/generateRouteManifest.spec.ts
@@ -61,7 +61,8 @@ describe('generateRouteManifest function', () => {
         defineRoute('/about-me', path.join(rootDir, 'src/index.tsx'));
       }],
     );
-    expect(routeManifest).toMatchSnapshot();
+    expect(path.isAbsolute(routeManifest['/about-me'].file)).toBeTruthy();
+    expect(routeManifest['/about-me'].componentName).toBe('src-index');
   });
 
   test('escape-routes', () => {


### PR DESCRIPTION
Support the usage of define absolute route path:
```js
defineRoutes('/hi', '/...path.jsx');
```

Close #6441 