### PR TITLE
Chore: add exports of service for node api

### DIFF
--- a/.changeset/soft-flies-happen.md
+++ b/.changeset/soft-flies-happen.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: add exports of service for node api

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./esm/index.js",
     "./types": "./esm/types/index.js",
-    "./analyze": "./esm/service/analyze.js"
+    "./analyze": "./esm/service/analyze.js",
+    "./service": "./esm/createService.js"
   },
   "bin": {
     "ice": "./bin/ice-cli.mjs"


### PR DESCRIPTION
Support Node API for other build tools:

```js
import createService from '@ice/app/service';
const service = createService({ rootDir: '', command: 'start', commadArgs: {} });
service.run();
```

Close #6441