### PR TITLE
chore: bump rspack version for more hook and plugin support

### DIFF
--- a/.changeset/violet-beds-wave.md
+++ b/.changeset/violet-beds-wave.md
@@ -1,0 +1,7 @@
+---
+'@ice/rspack-config': patch
+'@ice/bundles': patch
+'@ice/app': patch
+---
+
+chore: bump rspack version for more hook and plugin support

--- a/packages/bundles/package.json
+++ b/packages/bundles/package.json
@@ -33,8 +33,8 @@
     "react-refresh": "0.14.0",
     "core-js-pure": "^3.8.1",
     "error-stack-parser": "^2.0.6",
-    "@rspack/core": "0.2.12",
-    "@rspack/dev-server": "0.2.12",
+    "@rspack/core": "0.3.0",
+    "@rspack/dev-server": "0.3.0",
     "@ice/css-modules-hash": "0.0.6"
   },
   "devDependencies": {

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -88,8 +88,8 @@
     "unplugin": "^0.9.0",
     "webpack": "^5.88.0",
     "webpack-dev-server": "^4.7.4",
-    "@rspack/core": "0.2.12",
-    "@rspack/dev-server": "0.2.12"
+    "@rspack/core": "0.3.0",
+    "@rspack/dev-server": "0.3.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/ice/src/bundler/rspack/build.ts
+++ b/packages/ice/src/bundler/rspack/build.ts
@@ -1,6 +1,7 @@
+import type { MultiStats } from '@rspack/core';
 import { logger } from '../../utils/logger.js';
 import { getOutputPaths, removeServerOutput } from '../config/output.js';
-import type { BuildOptions, CompileResults, MultiStats } from '../types.js';
+import type { BuildOptions, CompileResults } from '../types.js';
 import formatStats from './formatStats.js';
 
 async function build(options: BuildOptions) {

--- a/packages/ice/src/bundler/rspack/formatStats.ts
+++ b/packages/ice/src/bundler/rspack/formatStats.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
+import type { Stats, MultiStats } from '@rspack/core';
 import formatWebpackMessages from '../../utils/formatWebpackMessages.js';
-import type { Stats, MultiStats } from '../types.js';
 
 function formatStats(stats: Stats | MultiStats, showWarnings = true) {
   const statsData = stats.toJson({

--- a/packages/ice/src/bundler/types.ts
+++ b/packages/ice/src/bundler/types.ts
@@ -2,7 +2,7 @@ import type { Config } from '@ice/shared-config/types';
 import type ora from '@ice/bundles/compiled/ora/index.js';
 import type { Stats as WebpackStats } from '@ice/bundles/compiled/webpack/index.js';
 import type { AppConfig } from '@ice/runtime/types';
-import type { Configuration, MultiCompiler } from '@rspack/core';
+import type { Configuration, MultiCompiler, MultiStats } from '@rspack/core';
 import type { Context as DefaultContext, TaskConfig } from 'build-scripts';
 import type { ServerCompiler, GetAppConfig, GetRoutesConfig, GetDataloaderConfig, ExtendsPluginAPI } from '../types/plugin.js';
 import type { UserConfig } from '../types/userConfig.js';
@@ -45,98 +45,3 @@ export type CompileResults = {
   isSuccessful: boolean;
   messages: { errors: string[]; warnings: string[] };
 };
-
-interface StatsOptionsObj {
-  all?: boolean;
-  preset?: 'normal' | 'none' | 'verbose' | 'errors-only' | 'errors-warnings';
-  assets?: boolean;
-  chunks?: boolean;
-  modules?: boolean;
-  entrypoints?: boolean;
-  warnings?: boolean;
-  warningsCount?: boolean;
-  errors?: boolean;
-  errorsCount?: boolean;
-  colors?: boolean;
-  timings?: boolean;
-
-  /** Rspack not support below opts */
-  cachedAssets?: boolean;
-  groupAssetsByInfo?: boolean;
-  groupAssetsByPath?: boolean;
-  groupAssetsByChunk?: boolean;
-  groupAssetsByExtension?: boolean;
-  groupAssetsByEmitStatus?: boolean;
-}
-
-/** webpack not support boolean or string */
-type StatsOptions = StatsOptionsObj;
-
-interface StatsAssetInfo {
-  development?: boolean;
-}
-
-export interface StatsAsset {
-  type: string;
-  name: string;
-  size: number;
-  chunks?: Array<string | number>;
-  chunkNames?: Array<string | number>;
-  info: StatsAssetInfo;
-}
-
-interface StatsError {
-  message: string;
-  formatted?: string;
-}
-
-interface StatsModule {
-  type?: string;
-  moduleType?: string;
-  identifier?: string;
-  name?: string;
-  id?: string;
-  chunks?: Array<string>;
-  size?: number;
-}
-
-interface StatsCompilation {
-  assets?: Array<StatsAsset>;
-  modules?: Array<StatsModule>;
-  chunks?: Array<StatsChunk>;
-  // entrypoints?: Array<StatsEntrypoint>;
-  errors?: Array<StatsError>;
-  errorsCount?: number;
-  warnings?: Array<StatsError>;
-  warningsCount?: number;
-  time?: number;
-  name?: string;
-  children?: StatsCompilation[];
-}
-
-interface StatsChunk {
-  type?: string;
-  files?: Array<string>;
-  id?: string | number;
-  entry: boolean;
-  initial: boolean;
-  names?: Array<string>;
-  size: number;
-}
-
-export declare class Stats {
-  constructor(statsJson: any);
-  hasErrors(): boolean;
-  hasWarnings(): boolean;
-  toJson(opts?: StatsOptions): StatsCompilation;
-  toString(opts?: StatsOptions): string;
-}
-
-export declare class MultiStats {
-  stats: Stats[];
-  hasErrors(): boolean;
-  hasWarnings(): boolean;
-  toJson(options?: StatsOptions): StatsCompilation;
-  toString(options?: StatsOptions): string;
-}
-

--- a/packages/rspack-config/package.json
+++ b/packages/rspack-config/package.json
@@ -19,7 +19,7 @@
     "@ice/bundles": "0.1.14"
   },
   "devDependencies": {
-    "@rspack/core": "^0.2.12"
+    "@rspack/core": "^0.3.0"
   },
   "scripts": {
     "watch": "tsc -w",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,8 +903,8 @@ importers:
       '@ice/swc-plugin-node-transform': 0.2.0
       '@ice/swc-plugin-remove-export': 0.2.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10
-      '@rspack/core': 0.2.12
-      '@rspack/dev-server': 0.2.12
+      '@rspack/core': 0.3.0
+      '@rspack/dev-server': 0.3.0
       '@swc/core': 1.3.77
       '@types/less': ^3.0.3
       '@types/lodash': ^4.14.181
@@ -984,8 +984,8 @@ importers:
       '@ice/swc-plugin-keep-export': 0.2.0
       '@ice/swc-plugin-node-transform': 0.2.0
       '@ice/swc-plugin-remove-export': 0.2.0
-      '@rspack/core': 0.2.12_zur76qpjdwubwowmoyfe2ntqhe
-      '@rspack/dev-server': 0.2.12_x32enbhagq6lxl6wy5tbwrcyii
+      '@rspack/core': 0.3.0_zur76qpjdwubwowmoyfe2ntqhe
+      '@rspack/dev-server': 0.3.0_kzlmicsiitbjjbwlzzbnjagole
       '@swc/core': 1.3.77
       ansi-html-community: 0.0.8
       caniuse-lite: 1.0.30001462
@@ -1101,8 +1101,8 @@ importers:
       '@ice/runtime': ^1.2.7
       '@ice/shared-config': 1.0.1
       '@ice/webpack-config': 1.1.0
-      '@rspack/core': 0.2.12
-      '@rspack/dev-server': 0.2.12
+      '@rspack/core': 0.3.0
+      '@rspack/dev-server': 0.3.0
       '@swc/helpers': 0.5.1
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
@@ -1180,8 +1180,8 @@ importers:
       temp: 0.9.4
       yargs-parser: 21.1.1
     devDependencies:
-      '@rspack/core': 0.2.12_ls5vlc7kphql6b6gtepk5p7cmu
-      '@rspack/dev-server': 0.2.12_47whzdhzq5y53rbotb3d4jbbju
+      '@rspack/core': 0.3.0_ls5vlc7kphql6b6gtepk5p7cmu
+      '@rspack/dev-server': 0.3.0_saarlyqjwgcwik7cbeuxgtrvdm
       '@types/babel__generator': 7.6.4
       '@types/babel__traverse': 7.18.3
       '@types/cross-spawn': 6.0.2
@@ -1572,12 +1572,12 @@ importers:
     specifiers:
       '@ice/bundles': 0.1.14
       '@ice/shared-config': 1.0.1
-      '@rspack/core': ^0.2.12
+      '@rspack/core': ^0.3.0
     dependencies:
       '@ice/bundles': link:../bundles
       '@ice/shared-config': link:../shared-config
     devDependencies:
-      '@rspack/core': 0.2.12
+      '@rspack/core': 0.3.0
 
   packages/runtime:
     specifiers:
@@ -6808,87 +6808,87 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rspack/binding-darwin-arm64/0.2.12:
-    resolution: {integrity: sha512-TTiizzXNYGILAwwUhf49AqeNRJ7NXnzObhmqaDJ76lwDph+yLf8HYhNWAzrhYljaWQGYjwTYUdXVrGflYb2pHA==}
+  /@rspack/binding-darwin-arm64/0.3.0:
+    resolution: {integrity: sha512-VJ/UR4SlW6P7N3z/EdmQMedbH6qS6rtS/SvEOeugUMx5xUL3UC4TSmA37HWYcDGVXdalqhIFskud3LaGlTEYyg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-darwin-x64/0.2.12:
-    resolution: {integrity: sha512-zq32runVEEXoJQjo5xfKxoDsxPVQu3KHplZR3Yxp5fxnx7b9eiM5BPf1FQ6ml7b6FC4ZXyQNYwtoDsLSTYRnfg==}
+  /@rspack/binding-darwin-x64/0.3.0:
+    resolution: {integrity: sha512-rxxam1EHXQ6Ex2XMJW5Zyxy0irB6KOZ+34fzkpFiop8rDvxxr2x16TAPxQzolgJNsq/6NLKkspzmrbQpkP6BLQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu/0.2.12:
-    resolution: {integrity: sha512-C5LR+/na47/ZlQXvrQP96GfzRnh34fa4cT3wD7C+BOwPrPrCdhf8Z3GNzv2J6Rs/ACBZjpD2DE+ARrWsBAv33w==}
+  /@rspack/binding-linux-arm64-gnu/0.3.0:
+    resolution: {integrity: sha512-JIq1ehp2oDOURoSiad+EyHWUD+CPReWxnvTgAUUHjNAH6mnGmJCMl3031/2lq1c9ZsH0yve36MzfTZa42K8gKw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-arm64-musl/0.2.12:
-    resolution: {integrity: sha512-UbLGMUOSPaivO6TbGVt1JKeOXTfj1DFjIBTy2CKxIF5+B6xvg+ns9BhZobtZmjDlJ9GvkkHFoawFyl6UG+XLpg==}
+  /@rspack/binding-linux-arm64-musl/0.3.0:
+    resolution: {integrity: sha512-GhyAj3laN69Kxu6qoane7nteCemVvqn6oKAB7edqfav4/Xq0DGRtlumAFR2ooShw4KpRI9I0keAZ5LDefAFc2Q==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-x64-gnu/0.2.12:
-    resolution: {integrity: sha512-I5W6WaD9llJjFR+Z1aJj0Ml/cheyHDH4eyTfEZXiOCEeTFJlA5NhMn97fDWoFKVYh5wq6uwCrxnaOSehYlsbYw==}
+  /@rspack/binding-linux-x64-gnu/0.3.0:
+    resolution: {integrity: sha512-tQdVXLnulhnhFYtN+r5ZZTNQyS8ErbEvC1efN7P7DSNOU3XRcL5WFzvlcY2KVtZyjmg3Z0xSoDbpYwQ7GAMHKQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-x64-musl/0.2.12:
-    resolution: {integrity: sha512-JuJKw502u/1FroIfR5iwoZ9pfx/iPpFEQmA6TseIKnu8eHM1jPKlPWAY4geBvzgiz04EdTs4uJ8o1ItoQLsddg==}
+  /@rspack/binding-linux-x64-musl/0.3.0:
+    resolution: {integrity: sha512-/XvTDvslEjPoCb8BICbKjXKAKO/dNOlIdTzZL7cXYfOrJSxIFpsWen4txNxnky9ArVTw9TuDBQNfFAwi3Sq0kQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc/0.2.12:
-    resolution: {integrity: sha512-f5npfQkXP8uHDSwiT1cXAhrdPwr7hrCz3EVKfwsB5Y1ny17YAH4ztm5Pk7oBB8H8SjQfn2Af8C3YEz1SUyk5/g==}
+  /@rspack/binding-win32-arm64-msvc/0.3.0:
+    resolution: {integrity: sha512-IVjFLfHFMnCbHf6m/ARIi0AdHpaf5Y94NfkPMwODkhx1DOUZCG5L4oC6+4rBdWP9DlhREN+csq5kzgcpTWxuMg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc/0.2.12:
-    resolution: {integrity: sha512-pw8a1gCK+TK8suZdEZwXzdEzC+ZGtYsv75BhwHNRrcKUbmRjn7FTtvSO0beZlRMNcfc3A2SD1ZmozZM1czbang==}
+  /@rspack/binding-win32-ia32-msvc/0.3.0:
+    resolution: {integrity: sha512-83e1/M+x/LIq60C3tp84X3NoSylntOC608NVr7iuvZ6B+T2OhI3BO9x5MiIMiO8PAt5yu1+fGmXIB/8u8bWY+g==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-x64-msvc/0.2.12:
-    resolution: {integrity: sha512-6UGQKJ0CG5g/v7vSeDr5wI1AuAaWR4P6xoRcyWMeeW5Vw3sOxqK/MfEOtwVseX47IcF+NhrmHhVX7MN4EiO0ZA==}
+  /@rspack/binding-win32-x64-msvc/0.3.0:
+    resolution: {integrity: sha512-2ZoYG3+wjoySq0QCQpgt5UWUH6ouJYR6g/ZHgcLOUGRPsEfu9obfIKisH2et/Ozh4ttAiKHfvkpiyGwZmDvZ7Q==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rspack/binding/0.2.12:
-    resolution: {integrity: sha512-Pi/Zi6NgOXiHPA08lk1yFTJwlTozLx6cLI87astcMQz56LSOQb8wBV9uiRvWufnWWijh7+jznNxpv7psWqXRoA==}
+  /@rspack/binding/0.3.0:
+    resolution: {integrity: sha512-DfnWZT2qPt4YV5tcWzdzbPDnNj1qAXYVmd+oW2Sl1EzoWPNV/ibMEjDFKVEmq1UIA/XvRlz3ZgVXw1AgTi1mhw==}
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.2.12
-      '@rspack/binding-darwin-x64': 0.2.12
-      '@rspack/binding-linux-arm64-gnu': 0.2.12
-      '@rspack/binding-linux-arm64-musl': 0.2.12
-      '@rspack/binding-linux-x64-gnu': 0.2.12
-      '@rspack/binding-linux-x64-musl': 0.2.12
-      '@rspack/binding-win32-arm64-msvc': 0.2.12
-      '@rspack/binding-win32-ia32-msvc': 0.2.12
-      '@rspack/binding-win32-x64-msvc': 0.2.12
+      '@rspack/binding-darwin-arm64': 0.3.0
+      '@rspack/binding-darwin-x64': 0.3.0
+      '@rspack/binding-linux-arm64-gnu': 0.3.0
+      '@rspack/binding-linux-arm64-musl': 0.3.0
+      '@rspack/binding-linux-x64-gnu': 0.3.0
+      '@rspack/binding-linux-x64-musl': 0.3.0
+      '@rspack/binding-win32-arm64-msvc': 0.3.0
+      '@rspack/binding-win32-ia32-msvc': 0.3.0
+      '@rspack/binding-win32-x64-msvc': 0.3.0
 
-  /@rspack/core/0.2.12:
-    resolution: {integrity: sha512-SekS+6bdTSx16nWQD7rGdnLK6fr0PewV2KKDt6w3jwHkJxDQygdUqL+st3c/JBGm/dpIVVpWkAcoLpK3EjFUcA==}
+  /@rspack/core/0.3.0:
+    resolution: {integrity: sha512-YltE0AQimUMOSTIFuDP+BW2GoJsabrig/GmgCR1eDWlVeKlmGJ6wd2GdYjmW5TWdH6FBQPQ3YfU8GOB4XWsvgQ==}
     dependencies:
-      '@rspack/binding': 0.2.12
-      '@rspack/dev-client': 0.2.12_react-refresh@0.14.0
+      '@rspack/binding': 0.3.0
+      '@rspack/dev-client': 0.3.0_react-refresh@0.14.0
       '@swc/helpers': 0.5.1
       browserslist: 4.21.5
       compare-versions: 6.0.0-rc.1
@@ -6913,11 +6913,11 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/core/0.2.12_ls5vlc7kphql6b6gtepk5p7cmu:
-    resolution: {integrity: sha512-SekS+6bdTSx16nWQD7rGdnLK6fr0PewV2KKDt6w3jwHkJxDQygdUqL+st3c/JBGm/dpIVVpWkAcoLpK3EjFUcA==}
+  /@rspack/core/0.3.0_ls5vlc7kphql6b6gtepk5p7cmu:
+    resolution: {integrity: sha512-YltE0AQimUMOSTIFuDP+BW2GoJsabrig/GmgCR1eDWlVeKlmGJ6wd2GdYjmW5TWdH6FBQPQ3YfU8GOB4XWsvgQ==}
     dependencies:
-      '@rspack/binding': 0.2.12
-      '@rspack/dev-client': 0.2.12_tqapdebyd4tzx34bcf5zu6h6n4
+      '@rspack/binding': 0.3.0
+      '@rspack/dev-client': 0.3.0_tqapdebyd4tzx34bcf5zu6h6n4
       '@swc/helpers': 0.5.1
       browserslist: 4.21.5
       compare-versions: 6.0.0-rc.1
@@ -6942,11 +6942,11 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/core/0.2.12_zur76qpjdwubwowmoyfe2ntqhe:
-    resolution: {integrity: sha512-SekS+6bdTSx16nWQD7rGdnLK6fr0PewV2KKDt6w3jwHkJxDQygdUqL+st3c/JBGm/dpIVVpWkAcoLpK3EjFUcA==}
+  /@rspack/core/0.3.0_zur76qpjdwubwowmoyfe2ntqhe:
+    resolution: {integrity: sha512-YltE0AQimUMOSTIFuDP+BW2GoJsabrig/GmgCR1eDWlVeKlmGJ6wd2GdYjmW5TWdH6FBQPQ3YfU8GOB4XWsvgQ==}
     dependencies:
-      '@rspack/binding': 0.2.12
-      '@rspack/dev-client': 0.2.12_ynqbgb5bmgbvx2am6mt2h3lxsq
+      '@rspack/binding': 0.3.0
+      '@rspack/dev-client': 0.3.0_ynqbgb5bmgbvx2am6mt2h3lxsq
       '@swc/helpers': 0.5.1
       browserslist: 4.21.5
       compare-versions: 6.0.0-rc.1
@@ -6971,8 +6971,8 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@rspack/dev-client/0.2.12_4p7fys4vpjth4wnvvzaxfza3hm:
-    resolution: {integrity: sha512-EeovUu3iItItbSKcZH3eNoGvvFiqUfFEHg22jJQTGeV3I5sZWvgfQA7+JQq44HI50Rq1EI8R9rB5X1rXwrhv/w==}
+  /@rspack/dev-client/0.3.0_4p7fys4vpjth4wnvvzaxfza3hm:
+    resolution: {integrity: sha512-nttTUBVctbh9auvPq91ThmjNDcBLj3kfLDjM/O1jBYA3xTz9MNsTN3rInLOb4S2fWEsSBLz7CVsNLP7LWtUecA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -6991,8 +6991,8 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@rspack/dev-client/0.2.12_p44l2xjftguod6ctnkuod3jp7e:
-    resolution: {integrity: sha512-EeovUu3iItItbSKcZH3eNoGvvFiqUfFEHg22jJQTGeV3I5sZWvgfQA7+JQq44HI50Rq1EI8R9rB5X1rXwrhv/w==}
+  /@rspack/dev-client/0.3.0_p44l2xjftguod6ctnkuod3jp7e:
+    resolution: {integrity: sha512-nttTUBVctbh9auvPq91ThmjNDcBLj3kfLDjM/O1jBYA3xTz9MNsTN3rInLOb4S2fWEsSBLz7CVsNLP7LWtUecA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -7010,8 +7010,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/dev-client/0.2.12_react-refresh@0.14.0:
-    resolution: {integrity: sha512-EeovUu3iItItbSKcZH3eNoGvvFiqUfFEHg22jJQTGeV3I5sZWvgfQA7+JQq44HI50Rq1EI8R9rB5X1rXwrhv/w==}
+  /@rspack/dev-client/0.3.0_react-refresh@0.14.0:
+    resolution: {integrity: sha512-nttTUBVctbh9auvPq91ThmjNDcBLj3kfLDjM/O1jBYA3xTz9MNsTN3rInLOb4S2fWEsSBLz7CVsNLP7LWtUecA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -7030,8 +7030,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/dev-client/0.2.12_tqapdebyd4tzx34bcf5zu6h6n4:
-    resolution: {integrity: sha512-EeovUu3iItItbSKcZH3eNoGvvFiqUfFEHg22jJQTGeV3I5sZWvgfQA7+JQq44HI50Rq1EI8R9rB5X1rXwrhv/w==}
+  /@rspack/dev-client/0.3.0_tqapdebyd4tzx34bcf5zu6h6n4:
+    resolution: {integrity: sha512-nttTUBVctbh9auvPq91ThmjNDcBLj3kfLDjM/O1jBYA3xTz9MNsTN3rInLOb4S2fWEsSBLz7CVsNLP7LWtUecA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -7050,8 +7050,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/dev-client/0.2.12_ynqbgb5bmgbvx2am6mt2h3lxsq:
-    resolution: {integrity: sha512-EeovUu3iItItbSKcZH3eNoGvvFiqUfFEHg22jJQTGeV3I5sZWvgfQA7+JQq44HI50Rq1EI8R9rB5X1rXwrhv/w==}
+  /@rspack/dev-client/0.3.0_ynqbgb5bmgbvx2am6mt2h3lxsq:
+    resolution: {integrity: sha512-nttTUBVctbh9auvPq91ThmjNDcBLj3kfLDjM/O1jBYA3xTz9MNsTN3rInLOb4S2fWEsSBLz7CVsNLP7LWtUecA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -7070,47 +7070,13 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@rspack/dev-server/0.2.12_47whzdhzq5y53rbotb3d4jbbju:
-    resolution: {integrity: sha512-z69w6lvRR1ZVJmdSWzs/bc9w29ZhSU1bz1GPDSdHPJ05fesvEtMrEYwg8YOO69lAKHGVQHoevHILO32cwMtKQQ==}
+  /@rspack/dev-server/0.3.0_kzlmicsiitbjjbwlzzbnjagole:
+    resolution: {integrity: sha512-aKY1mUP1PdOWXDvxpUA14mEE7p+IFYnU67i7cAUh361z2/v5KbCTngt521ly8H1LqJv3SJIoEXqSqNc8c62Dsg==}
     peerDependencies:
       '@rspack/core': '*'
     dependencies:
-      '@rspack/core': 0.2.12_ls5vlc7kphql6b6gtepk5p7cmu
-      '@rspack/dev-client': 0.2.12_p44l2xjftguod6ctnkuod3jp7e
-      chokidar: 3.5.3
-      connect-history-api-fallback: 2.0.0
-      express: 4.18.1
-      http-proxy-middleware: 2.0.6_@types+express@4.17.17
-      mime-types: 2.1.35
-      webpack: 5.76.0_esbuild@0.17.16
-      webpack-dev-middleware: 6.0.2_webpack@5.76.0
-      webpack-dev-server: 4.13.1_webpack@5.76.0
-      ws: 8.8.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/express'
-      - '@types/webpack'
-      - bufferutil
-      - debug
-      - esbuild
-      - react-refresh
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
-  /@rspack/dev-server/0.2.12_x32enbhagq6lxl6wy5tbwrcyii:
-    resolution: {integrity: sha512-z69w6lvRR1ZVJmdSWzs/bc9w29ZhSU1bz1GPDSdHPJ05fesvEtMrEYwg8YOO69lAKHGVQHoevHILO32cwMtKQQ==}
-    peerDependencies:
-      '@rspack/core': '*'
-    dependencies:
-      '@rspack/core': 0.2.12_zur76qpjdwubwowmoyfe2ntqhe
-      '@rspack/dev-client': 0.2.12_4p7fys4vpjth4wnvvzaxfza3hm
+      '@rspack/core': 0.3.0_zur76qpjdwubwowmoyfe2ntqhe
+      '@rspack/dev-client': 0.3.0_4p7fys4vpjth4wnvvzaxfza3hm
       chokidar: 3.5.3
       connect-history-api-fallback: 2.0.0
       express: 4.18.1
@@ -7137,6 +7103,40 @@ packages:
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false
+
+  /@rspack/dev-server/0.3.0_saarlyqjwgcwik7cbeuxgtrvdm:
+    resolution: {integrity: sha512-aKY1mUP1PdOWXDvxpUA14mEE7p+IFYnU67i7cAUh361z2/v5KbCTngt521ly8H1LqJv3SJIoEXqSqNc8c62Dsg==}
+    peerDependencies:
+      '@rspack/core': '*'
+    dependencies:
+      '@rspack/core': 0.3.0_ls5vlc7kphql6b6gtepk5p7cmu
+      '@rspack/dev-client': 0.3.0_p44l2xjftguod6ctnkuod3jp7e
+      chokidar: 3.5.3
+      connect-history-api-fallback: 2.0.0
+      express: 4.18.1
+      http-proxy-middleware: 2.0.6_@types+express@4.17.17
+      mime-types: 2.1.35
+      webpack: 5.76.0_esbuild@0.17.16
+      webpack-dev-middleware: 6.0.2_webpack@5.76.0
+      webpack-dev-server: 4.13.1_webpack@5.76.0
+      ws: 8.8.1
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/express'
+      - '@types/webpack'
+      - bufferutil
+      - debug
+      - esbuild
+      - react-refresh
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+    dev: true
 
   /@sideway/address/4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}


### PR DESCRIPTION
Bump rspack version(0.3.0) for more hook and plugin support,  visit [announcing](https://www.rspack.dev/blog/announcing-0.3.html#breaking-changes) for more details.