### PR TITLE
fix: mark polyfill signal as es module

### DIFF
--- a/.changeset/green-kangaroos-cry.md
+++ b/.changeset/green-kangaroos-cry.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: mark polyfill signal as es module

--- a/packages/runtime/src/polyfills/signal.ts
+++ b/packages/runtime/src/polyfills/signal.ts
@@ -24,3 +24,6 @@ if (import.meta.renderer === 'client' && window.Request && !window.Request.proto
       self.Request = Request;
   })(window);
 }
+// Mark the current file as es module, otherwise the polyfill will be inject by require,
+// it is not allowed to use require in `type: module` package.
+export default {};


### PR DESCRIPTION
在 webpack 打包时，如果该包为 `type: module` 的包，将不会对 require 进行处理，如果一旦 signal 文件在 `polyfill: usage` 场景下引入polyfill 将出现运行时错误

框架改写 core-js 的 import 语句，依赖其导入导出逻辑，因此需要增加 default 导出 https://github.com/alibaba/ice/blob/d8f238a5af3cf56f20b026826088aeb841c2250d/packages/shared-config/src/utils/transformImport.ts#L9-L49