### PR TITLE
[WIP]feat: rsc router

### DIFF
--- a/examples/with-rsc/package.json
+++ b/examples/with-rsc/package.json
@@ -13,7 +13,8 @@
     "@ice/runtime": "workspace:*",
     "react": "18.3.0-canary-dd480ef92-20230822",
     "react-dom": "18.3.0-canary-dd480ef92-20230822",
-    "react-server-dom-webpack": "18.3.0-canary-dd480ef92-20230822"
+    "react-server-dom-webpack": "18.3.0-canary-dd480ef92-20230822",
+    "react-router-dom": "6.14.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/examples/with-rsc/src/components/Counter.client.tsx
+++ b/examples/with-rsc/src/components/Counter.client.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import { useAppContext } from 'ice';
 import styles from './index.module.css';
 
 export default function Counter() {
@@ -8,6 +9,9 @@ export default function Counter() {
   function updateCount() {
     setCount(count + 1);
   }
+
+  const appContext = useAppContext();
+  console.log(appContext);
 
   return (
     <button className={styles.button} type="button" onClick={updateCount}>

--- a/examples/with-rsc/src/pages/index.tsx
+++ b/examples/with-rsc/src/pages/index.tsx
@@ -10,7 +10,6 @@ export default function Home() {
   console.log('Render: Index');
 
   const appContext = useAppContext();
-
   console.log(appContext);
 
   return (

--- a/examples/with-rsc/src/pages/index.tsx
+++ b/examples/with-rsc/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useAppContext } from 'ice';
 import styles from './index.module.css';
 // import Comments from '@/components/Comments';
 // import Footer from '@/components/Footer';
@@ -7,6 +8,10 @@ import Counter from '@/components/Counter.client';
 
 export default function Home() {
   console.log('Render: Index');
+
+  const appContext = useAppContext();
+
+  console.log(appContext);
 
   return (
     <div>

--- a/examples/with-rsc/src/pages/layout.tsx
+++ b/examples/with-rsc/src/pages/layout.tsx
@@ -1,12 +1,10 @@
-import { Outlet } from 'ice';
-
-export default function Layout() {
+export default function Layout(props) {
   console.log('Render: Layout');
 
   return (
     <div>
       <h1>Suspense App</h1>
-      <Outlet />
+      {props.children}
     </div>
   );
 }

--- a/packages/ice/src/bundler/webpack/getWebpackConfig.ts
+++ b/packages/ice/src/bundler/webpack/getWebpackConfig.ts
@@ -125,6 +125,11 @@ clientReferences: [{
       recursive: true,
       include: /\.(js|ts|jsx|tsx)$/,
       exclude: /types.ts|.d.ts/,
+    }, {
+      directory: path.join(rootDir, '.ice'),
+      recursive: true,
+      include: /\.(js|ts|jsx|tsx)$/,
+      exclude: /types.ts|.d.ts/,
     }] }));
 
     return webpackConfig;

--- a/packages/ice/src/esbuild/rscServerRegister.ts
+++ b/packages/ice/src/esbuild/rscServerRegister.ts
@@ -5,7 +5,7 @@ const rscServerRegister = (): Plugin => {
   return {
     name: 'rsc-server-register',
     setup: async (build: PluginBuild) => {
-      build.onLoad({ filter: /\/src\/.*\.client\.(js|ts|jsx|tsx)$/ }, async (args) => { //  /src\/.*\
+      build.onLoad({ filter: /.*\.client\.(js|ts|jsx|tsx)$/ }, async (args) => { //  /src\/.*\
         const { path } = args;
         const loader = path.endsWith('.tsx') || path.endsWith('.ts') ? 'tsx' : 'jsx';
         const moduleId: string = url.pathToFileURL(path).href;

--- a/packages/ice/src/routes.ts
+++ b/packages/ice/src/routes.ts
@@ -73,11 +73,7 @@ export function getRoutesDefinition(nestRouteManifest: NestedRouteManifest[], la
       routeImports.push(`import * as ${routeSpecifier} from '${formatPath(componentPath)}';`);
       loadStatement = routeSpecifier;
     }
-    const component = `Component: () => WrapRouteComponent({
-          routeId: '${id}',
-          isLayout: ${layout},
-          routeExports: ${lazy ? 'componentModule' : loadStatement},
-        })`;
+    const component = `Component: ${lazy ? 'componentModule' : loadStatement}`;
     const loader = `loader: createRouteLoader({
           routeId: '${id}',
           requestContext,

--- a/packages/ice/src/routes.ts
+++ b/packages/ice/src/routes.ts
@@ -73,7 +73,12 @@ export function getRoutesDefinition(nestRouteManifest: NestedRouteManifest[], la
       routeImports.push(`import * as ${routeSpecifier} from '${formatPath(componentPath)}';`);
       loadStatement = routeSpecifier;
     }
-    const component = `Component: ${lazy ? 'componentModule' : loadStatement}`;
+    const component = `Component: (props) => WrapRouteComponent({
+      routeId: '${id}',
+      isLayout: ${layout},
+      routeExports: ${lazy ? 'componentModule' : loadStatement},
+      children: props?.children
+    })`;
     const loader = `loader: createRouteLoader({
           routeId: '${id}',
           requestContext,

--- a/packages/ice/templates/core/entry.server.ts.ejs
+++ b/packages/ice/templates/core/entry.server.ts.ejs
@@ -12,6 +12,7 @@ import assetsManifest from 'virtual:assets-manifest.json';
 import clientManifest from 'virtual:react-client-manifest.json';
 import createRoutes from './routes';
 import routesConfig from './routes-config.bundle.mjs';
+import AppRouter from './router.client.js';
 <% if(dataLoaderImport.imports) {-%><%-dataLoaderImport.imports%><% } -%>
 <%- runtimeOptions.imports %>
 <% if(!hydrate) {-%>
@@ -92,6 +93,7 @@ function mergeOptions(options) {
     renderMode,
     routesConfig,
     clientManifest,
+    AppRouter,
     runtimeOptions: {
     <% if (runtimeOptions.exports) { -%>
       <%- runtimeOptions.exports %>

--- a/packages/ice/templates/core/router.client.tsx.ejs
+++ b/packages/ice/templates/core/router.client.tsx.ejs
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+import { StaticRouterProvider, createStaticRouter } from 'react-router-dom/server.mjs';
+import { matchRoutes as originMatchRoutes } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+
+export default function Router(props) {
+  const { routes, location, basename } = props;
+  // Server router only be called once.
+
+  const matches = matchRoutes(routes, location, basename);
+  const routerContext = {
+    location,
+    basename,
+    matches
+  };
+  const router = createStaticRouter(routes, routerContext);
+
+  const element = (
+    <StaticRouterProvider
+      router={router}
+      context={routerContext}
+      hydrate={false}
+    />
+  );
+
+  return element;
+}
+
+function matchRoutes(
+  routes,
+  location,
+  basename,
+): RouteMatch[] {
+  const matchRoutesFn = originMatchRoutes;
+  let matches = matchRoutesFn(routes as RouteObject[], location, basename);
+  if (!matches) return [];
+  return matches.map(({ params, pathname, pathnameBase, route }) => ({
+    params,
+    pathname,
+    route: route as RouteItem,
+    pathnameBase,
+  }));
+}

--- a/packages/runtime/src/AppContext.tsx
+++ b/packages/runtime/src/AppContext.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import type { AppContext } from './types.js';
 
-const Context = React.createContext<AppContext | undefined>(undefined);
+// @ts-ignore
+const Context = React.createServerContext ? React.createServerContext(undefined) : React.createContext(undefined);
 
 Context.displayName = 'AppContext';
 

--- a/packages/runtime/src/AppContext.tsx
+++ b/packages/runtime/src/AppContext.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import type { AppContext } from './types.js';
 
 // @ts-ignore
-const Context = React.createServerContext ? React.createServerContext(undefined) : React.createContext(undefined);
+const Context = React.createServerContext ? React.createServerContext<AppContext | undefined>(undefined) : React.createContext<AppContext | undefined>(undefined);
 
 Context.displayName = 'AppContext';
 
 function useAppContext() {
-  const value = React.useContext(Context);
+  const value: AppContext = React.useContext(Context);
   return value;
 }
 

--- a/packages/runtime/src/AppContext.tsx
+++ b/packages/runtime/src/AppContext.tsx
@@ -13,6 +13,7 @@ function useAppContext() {
 
 function useAppData() {
   const value = React.useContext(Context);
+  // @ts-ignore
   return value.appData;
 }
 

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -57,13 +57,16 @@ export function WrapRouteComponent(options: {
   routeId: string;
   isLayout?: boolean;
   routeExports: ComponentModule;
+  children?: Array<ComponentModule>;
 }) {
-  const { routeId, isLayout, routeExports } = options;
+  const { routeId, isLayout, routeExports, children } = options;
 
   const { RouteWrappers } = useAppContext() || {};
   return (
     <RouteWrapper routeExports={routeExports} id={routeId} isLayout={isLayout} wrappers={RouteWrappers}>
-      <routeExports.default />
+      <routeExports.default>
+        { children }
+      </routeExports.default>
     </RouteWrapper>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,12 +778,14 @@ importers:
       '@types/react-dom': ^18.0.6
       react: 18.3.0-canary-dd480ef92-20230822
       react-dom: 18.3.0-canary-dd480ef92-20230822
+      react-router-dom: 6.14.2
       react-server-dom-webpack: 18.3.0-canary-dd480ef92-20230822
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/runtime': link:../../packages/runtime
       react: 18.3.0-canary-dd480ef92-20230822
       react-dom: 18.3.0-canary-dd480ef92-20230822_hhgf3bgmselb7o32scmuz3hjam
+      react-router-dom: 6.14.2_i5uyhljmd6xc2xkotszrmzynhy
       react-server-dom-webpack: 18.3.0-canary-dd480ef92-20230822_i5uyhljmd6xc2xkotszrmzynhy
     devDependencies:
       '@types/react': 18.0.34


### PR DESCRIPTION
问题记录：
* react-router 内部使用了很多 Context 逻辑，并且往上面挂载了 function，所以路由相关的逻辑只能作为 client component
* 如果 react-router 作为 client component, 而 pages 下的入口文件是 server component，意味着 pages 下的 入口文件不能调用基于 react-router 提供的 useData 等 hooks
* 假设有页面 Index，Index 不能作为 Function 交给 react-router 渲染，只能将 <Index /> 传给 react-router，如果有 Layout 的情况，也只能提前处理好，不能使用 Outlet 等基于 Context 的实现。所以感觉页面的组装可以脱离 react-router，只使用 react-router 的 matchRoutes 等基础能力。

