### PR TITLE
fix: support custom middleware on dev server

### DIFF
--- a/.changeset/spicy-planets-push.md
+++ b/.changeset/spicy-planets-push.md
@@ -1,0 +1,5 @@
+---
+'@ice/rspack-config': patch
+---
+
+fix: support custom middleware on dev server

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -54,6 +54,7 @@ const getConfig: GetConfig = (options) => {
     proxy,
     devServer = {},
     plugins = [],
+    middlewares,
   } = taskConfig || {};
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
   const hashKey = hash === true ? 'hash:8' : (hash || '');
@@ -161,6 +162,7 @@ const getConfig: GetConfig = (options) => {
         logging: 'info',
       },
       ...devServer,
+      setupMiddlewares: middlewares,
     },
   };
   return config;


### PR DESCRIPTION
Support custom middleware on dev server when use `speedup` mode.