### PR TITLE
fix: browsers compatibility of dataLoader

### DIFF
--- a/.changeset/orange-carrots-stare.md
+++ b/.changeset/orange-carrots-stare.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: browsers compatibility of dataLoader

--- a/packages/ice/src/types/plugin.ts
+++ b/packages/ice/src/types/plugin.ts
@@ -38,7 +38,8 @@ type ServerCompilerBuildOptions = Pick<
   'plugins' |
   'logLevel' |
   'sourcemap' |
-  'metafile'
+  'metafile' |
+  'supported'
 >;
 
 export type ServerBuildResult =

--- a/packages/ice/src/webpack/DataLoaderPlugin.ts
+++ b/packages/ice/src/webpack/DataLoaderPlugin.ts
@@ -55,6 +55,10 @@ export default class DataLoaderPlugin {
               target: 'es6', // should not set to esnext, https://github.com/alibaba/ice/issues/5830
               format: 'iife',
               entryPoints: [filePath],
+              supported: {
+                // Do not wrap arrow function when format as IIFE.
+                arrow: false,
+              },
               write: false,
               logLevel: 'silent', // The main server compile process will log it.
             },


### PR DESCRIPTION
Do not wrap arrow function when format as IIFE for browsers compatibility.