### PR TITLE
fix(@ice/app): add typesVersions for export fields support

### DIFF
--- a/.changeset/fuzzy-dolls-tell.md
+++ b/.changeset/fuzzy-dolls-tell.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+add typesVersions for export fields support

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -10,6 +10,19 @@
     "./analyze": "./esm/service/analyze.js",
     "./service": "./esm/createService.js"
   },
+  "typesVersions": {
+    "*": {
+      "types": [
+        "./esm/types/index.d.ts"
+      ],
+      "analyze": [
+        "./esm/service/analyze.d.ts"
+      ],
+      "service": [
+        "./esm/createService.d.ts"
+      ]
+    }
+  },
   "bin": {
     "ice": "./bin/ice-cli.mjs"
   },


### PR DESCRIPTION
With `typesVersions` TypeScript can find the type definition for exports field correctly:
![image](https://github.com/alibaba/ice/assets/48507806/c0df51d7-6346-4f6d-9e19-ed52c5a1e4f2)


or it works like:

![image](https://github.com/alibaba/ice/assets/48507806/52f25964-e26c-4b1b-89c0-8d50219f962e)
