### PR TITLE
[WIP]feat: rsc to html

### DIFF
--- a/examples/with-rsc/src/components/Feeds.tsx
+++ b/examples/with-rsc/src/components/Feeds.tsx
@@ -1,0 +1,25 @@
+export default async function Feeds() {
+  console.log('Render: Feeds');
+
+  const data = await getData('http://localhost:4000/getData');
+
+  // const appContext = useAppContext();
+  // console.log(appContext);
+
+  return (
+    <div>
+      {/* @ts-ignore */}
+      {data.map(data => data.name)}
+    </div>
+  );
+}
+
+export async function getData(url: string) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        { name: 'feeds' },
+      ]);
+    }, 1 * 2000);
+  });
+}

--- a/examples/with-rsc/src/components/RefreshButton.client.tsx
+++ b/examples/with-rsc/src/components/RefreshButton.client.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { useRSCRouter } from '@ice/runtime';
+import { useRefresh } from '@ice/runtime';
 
 export default function Button({ children }) {
-  const router = useRSCRouter();
+  const refresh = useRefresh();
 
   return (
     <button
@@ -10,7 +10,7 @@ export default function Button({ children }) {
         'edit-button',
         'edit-button--solid',
       ].join(' ')}
-      onClick={() => router.refresh()}
+      onClick={() => refresh()}
       role="menuitem"
     >
       {children}

--- a/examples/with-rsc/src/components/RefreshButton.client.tsx
+++ b/examples/with-rsc/src/components/RefreshButton.client.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useRSCRouter } from '@ice/runtime';
+
+export default function Button({ children }) {
+  const router = useRSCRouter();
+
+  return (
+    <button
+      className={[
+        'edit-button',
+        'edit-button--solid',
+      ].join(' ')}
+      onClick={() => router.refresh()}
+      role="menuitem"
+    >
+      {children}
+    </button>
+  );
+}

--- a/examples/with-rsc/src/pages/about.tsx
+++ b/examples/with-rsc/src/pages/about.tsx
@@ -1,0 +1,26 @@
+import { useAppContext } from 'ice';
+import styles from './index.module.css';
+import RefreshButton from '@/components/RefreshButton.client';
+import Counter from '@/components/Counter.client';
+
+if (!global.requestCount) {
+  global.requestCount = 0;
+}
+
+export default function Home() {
+  console.log('Render: Index');
+
+  const appContext = useAppContext();
+  console.log(appContext);
+
+  return (
+    <div className={styles.app}>
+      <h2>About Page</h2>
+      <div>server request count:  { global.requestCount++ }</div>
+      <Counter />
+      <RefreshButton>
+        Refresh Button
+      </RefreshButton>
+    </div>
+  );
+}

--- a/examples/with-rsc/src/pages/index.tsx
+++ b/examples/with-rsc/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { useAppContext } from 'ice';
 import { Suspense } from 'react';
 import styles from './index.module.css';
 // import EditButton from '@/components/EditButton.client';

--- a/examples/with-rsc/src/pages/index.tsx
+++ b/examples/with-rsc/src/pages/index.tsx
@@ -1,21 +1,40 @@
 import { useAppContext } from 'ice';
+import { Suspense } from 'react';
 import styles from './index.module.css';
-import EditButton from '@/components/EditButton.client';
-import Counter from '@/components/Counter.client';
+// import EditButton from '@/components/EditButton.client';
+// import Counter from '@/components/Counter.client';
+import Feeds from '@/components/Feeds';
 
-export default function Home() {
+export default async function Home() {
   console.log('Render: Index');
 
-  const appContext = useAppContext();
-  console.log(appContext);
+  const data = await getData('http://localhost:4000/getData');
+
+  // const appContext = useAppContext();
+  // console.log(appContext);
 
   return (
     <div className={styles.app}>
-      <h2>Home Page</h2>
-      <Counter />
+      {/* @ts-ignore */}
+      <h2>Home Page {data?.name}</h2>
+      {/* <Counter />
       <EditButton noteId="editButton">
         hello world
-      </EditButton>
+      </EditButton> */}
+      <Suspense fallback={<p>Loading feed...</p>}>
+        {/* @ts-ignore */}
+        <Feeds />
+      </Suspense>
     </div>
   );
+}
+
+export async function getData(url: string) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        name: 'About',
+      });
+    }, 1 * 100);
+  });
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -26,8 +26,7 @@ import type { RunClientAppOptions, CreateRoutes } from './runClientApp.js';
 import { useAppContext as useInternalAppContext, useAppData, AppContextProvider } from './AppContext.js';
 import { getAppData } from './appData.js';
 import { useData, useConfig } from './RouteContext.js';
-import { runRSCClientApp, useRSCRouter } from './runRSCClientApp.js';
-
+import { runRSCClientApp, useRefresh } from './runRSCClientApp.js';
 import {
   Meta,
   Title,
@@ -146,7 +145,7 @@ export {
   RouteErrorComponent,
 
   runRSCClientApp,
-  useRSCRouter,
+  useRefresh,
 };
 
 export type {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -26,7 +26,7 @@ import type { RunClientAppOptions, CreateRoutes } from './runClientApp.js';
 import { useAppContext as useInternalAppContext, useAppData, AppContextProvider } from './AppContext.js';
 import { getAppData } from './appData.js';
 import { useData, useConfig } from './RouteContext.js';
-import { runRSCClientApp } from './runRSCClientApp.js';
+import { runRSCClientApp, useRSCRouter } from './runRSCClientApp.js';
 
 import {
   Meta,
@@ -146,6 +146,7 @@ export {
   RouteErrorComponent,
 
   runRSCClientApp,
+  useRSCRouter,
 };
 
 export type {

--- a/packages/runtime/src/runRSCClientApp.tsx
+++ b/packages/runtime/src/runRSCClientApp.tsx
@@ -44,15 +44,6 @@ function Router() {
     });
   }
 
-  // function navigate(nextLocation) {
-  //   startTransition(() => {
-  //     setLocation(loc => ({
-  //       ...loc,
-  //       ...nextLocation
-  //     }));
-  //   });
-  // }
-
   return (
     <RouterContext.Provider value={{ location, refresh }}>
       <Suspense fallback={<h1>Loading...</h1>}>
@@ -62,8 +53,9 @@ function Router() {
   );
 }
 
-export function useRSCRouter() {
-  return useContext(RouterContext);
+export function useRefresh() {
+  const router = useContext(RouterContext);
+  return router.refresh;
 }
 
 function getReactTree(location) {

--- a/packages/runtime/src/runRSCClientApp.tsx
+++ b/packages/runtime/src/runRSCClientApp.tsx
@@ -3,24 +3,69 @@ import * as ReactDOM from 'react-dom/client';
 import pkg from 'react-server-dom-webpack/client';
 
 // @ts-ignore
-const { Suspense, use } = React;
+const { Suspense, use, useState, createContext, useContext, startTransition } = React;
 const { createFromFetch } = pkg;
 
 export async function runRSCClientApp() {
-  function App({ response }) {
-    return (
-      <Suspense fallback={<h1>Loading...</h1>}>
-        {use(response)}
-      </Suspense>
-    );
-  }
-
-  const rscPath = location.href + (location.href.indexOf('?') ? '?rsc' : '&rsc');
-  const response = createFromFetch(
-    fetch(rscPath),
-  );
-
   const container = document.getElementById('app');
   const root = ReactDOM.createRoot(container);
-  root.render(<App response={response} />);
+  root.render(<Root />);
+}
+
+function Root() {
+  return (
+    <Router />
+  );
+}
+
+const RouterContext = createContext(null);
+const initialCache = new Map();
+
+function Router() {
+  const [cache, setCache] = useState(initialCache);
+  const [location, setLocation] = useState(window.location.href);
+
+  let content = cache.get(location);
+  if (!content) {
+    content = createFromFetch(
+      getReactTree(location),
+    );
+    cache.set(location, content);
+  }
+
+  function refresh() {
+    startTransition(() => {
+      const nextCache = new Map();
+      const nextContent = createFromFetch(
+        getReactTree(location),
+      );
+      nextCache.set(location, nextContent);
+      setCache(nextCache);
+    });
+  }
+
+  // function navigate(nextLocation) {
+  //   startTransition(() => {
+  //     setLocation(loc => ({
+  //       ...loc,
+  //       ...nextLocation
+  //     }));
+  //   });
+  // }
+
+  return (
+    <RouterContext.Provider value={{ location, refresh }}>
+      <Suspense fallback={<h1>Loading...</h1>}>
+        {use(content)}
+      </Suspense>
+    </RouterContext.Provider>
+  );
+}
+
+export function useRSCRouter() {
+  return useContext(RouterContext);
+}
+
+function getReactTree(location) {
+  return fetch(location + location.indexOf('?') ? '?rsc' : '&rsc');
 }

--- a/packages/runtime/src/runRSCClientApp.tsx
+++ b/packages/runtime/src/runRSCClientApp.tsx
@@ -4,7 +4,7 @@ import pkg from 'react-server-dom-webpack/client';
 
 // @ts-ignore
 const { Suspense, use, useState, createContext, useContext, startTransition } = React;
-const { createFromFetch } = pkg;
+const { createFromFetch, createFromReadableStream } = pkg;
 
 export async function runRSCClientApp() {
   const container = document.getElementById('app');
@@ -14,7 +14,7 @@ export async function runRSCClientApp() {
 
 function Root() {
   return (
-    <Router />
+    <ServerRoot cacheKey={getCacheKey()} />
   );
 }
 
@@ -60,4 +60,99 @@ export function useRefresh() {
 
 function getReactTree(location) {
   return fetch(location + location.indexOf('?') ? '?rsc' : '&rsc');
+}
+
+const getCacheKey = () => {
+  const { pathname, search } = location;
+  return pathname + search;
+};
+
+const encoder = new TextEncoder();
+
+let initialServerDataBuffer: string[] | undefined = [];
+let initialServerDataWriter: ReadableStreamDefaultController | undefined;
+let initialServerDataLoaded = false;
+let initialServerDataFlushed = false;
+
+function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
+  if (initialServerDataBuffer) {
+    initialServerDataBuffer.forEach((val) => {
+      ctr.enqueue(encoder.encode(val));
+    });
+    if (initialServerDataLoaded && !initialServerDataFlushed) {
+      ctr.close();
+      initialServerDataFlushed = true;
+      initialServerDataBuffer = undefined;
+    }
+  }
+
+  initialServerDataWriter = ctr;
+}
+
+function createResponseCache() {
+  return new Map<string, any>();
+}
+const rscCache = createResponseCache();
+
+function useInitialServerResponse(cacheKey: string): Promise<JSX.Element> {
+  const response = rscCache.get(cacheKey);
+  if (response) return response;
+
+  const readable = new ReadableStream({
+    start(controller) {
+      nextServerDataRegisterWriter(controller);
+    },
+  });
+
+  const newResponse = createFromReadableStream(readable);
+
+  rscCache.set(cacheKey, newResponse);
+  return newResponse;
+}
+
+function ServerRoot({ cacheKey }: { cacheKey: string }): JSX.Element {
+  React.useEffect(() => {
+    rscCache.delete(cacheKey);
+  });
+  const response = useInitialServerResponse(cacheKey);
+  const root = use(response);
+  return root;
+}
+
+const DOMContentLoaded = function () {
+  if (initialServerDataWriter && !initialServerDataFlushed) {
+    initialServerDataWriter.close();
+    initialServerDataFlushed = true;
+    initialServerDataBuffer = undefined;
+  }
+  initialServerDataLoaded = true;
+};
+
+const nextServerDataLoadingGlobal = typeof self !== 'undefined' ? (((self as any).__next_f =
+  (self as any).__next_f || [])) : [];
+nextServerDataLoadingGlobal.forEach(nextServerDataCallback);
+nextServerDataLoadingGlobal.push = nextServerDataCallback;
+
+function nextServerDataCallback(
+  seg: [isBootStrap: 0] | [isNotBootstrap: 1, responsePartial: string],
+): void {
+  if (seg[0] === 0) {
+    initialServerDataBuffer = [];
+  } else {
+    // if (!initialServerDataBuffer)
+    //   throw new Error('Unexpected server data: missing bootstrap script.')
+
+    if (initialServerDataWriter) {
+      initialServerDataWriter.enqueue(encoder.encode(seg[1]));
+    } else {
+      initialServerDataBuffer.push(seg[1]);
+    }
+  }
+}
+
+// It's possible that the DOM is already loaded.
+if (typeof document !== 'undefined' && document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', DOMContentLoaded, false);
+} else {
+  DOMContentLoaded();
 }

--- a/packages/runtime/src/runRSCServerApp.tsx
+++ b/packages/runtime/src/runRSCServerApp.tsx
@@ -83,6 +83,7 @@ export async function runRSCServerApp(serverContext: ServerContext, renderOption
     moduleMap[id]['*'] = {
       ...clientManifest[key],
       chunks: [],
+      async: false,
     };
   }
 

--- a/packages/runtime/src/runRSCServerApp.tsx
+++ b/packages/runtime/src/runRSCServerApp.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { renderToPipeableStream } from 'react-server-dom-webpack/server.node';
+// import { renderToPipeableStream } from 'react-server-dom-webpack/server.node';
+import { use } from 'react';
+import * as EdgeServer from 'react-dom/server.edge';
+import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
+import { renderToReadableStream } from 'react-server-dom-webpack/server.edge';
 import { AppContextProvider } from './AppContext.js';
 import { DocumentContextProvider } from './Document.js';
 import { loadRouteModules } from './routes.js';
@@ -16,6 +20,8 @@ import type {
   RouteModules,
   ServerRenderOptions as RenderOptions,
 } from './types.js';
+// @ts-ignore
+// @ts-ignore
 
 export async function runRSCServerApp(serverContext: ServerContext, renderOptions: RenderOptions) {
   const { req, res } = serverContext;
@@ -28,6 +34,7 @@ export async function runRSCServerApp(serverContext: ServerContext, renderOption
     serverOnlyBasename,
     clientManifest,
     assetsManifest,
+    Document,
   } = renderOptions;
 
   const location = getLocation(req.url);
@@ -49,24 +56,106 @@ export async function runRSCServerApp(serverContext: ServerContext, renderOption
     matches: [],
   };
 
-  if (req.url?.indexOf('rsc') === -1) {
-    return renderDocument(serverContext, renderOptions, appContext);
-  }
+  // if (req.url?.indexOf('rsc') === -1) {
+  //   return renderDocument(serverContext, renderOptions, appContext);
+  // }
 
   const routeModules = await loadRouteModules(matches.map(({ route: { id, lazy } }) => ({ id, lazy })));
 
   const element = (
-    <AppContextProvider value={appContext}>
+    <>
       {renderMatches(matches, routeModules)}
-    </AppContextProvider>
+    </>
   );
 
-  const { pipe } = renderToPipeableStream(
-    element,
-    clientManifest,
-  );
+  const stream = renderToReadableStream(element, clientManifest);
+  const [renderStream, forwardStream] = stream.tee();
 
-  pipe(res);
+  const moduleMap = {};
+
+  for (const key in clientManifest) {
+    const { id } = clientManifest[key];
+    moduleMap[id] = {
+      id: id,
+      name: '*',
+    };
+
+    moduleMap[id]['*'] = {
+      ...clientManifest[key],
+      chunks: [],
+    };
+  }
+
+  const response = createFromReadableStream(renderStream, {
+    moduleMap: moduleMap,
+  });
+
+  function App() {
+    const documentContext = {
+      main: use(response),
+    };
+
+    return (
+      <AppContextProvider value={appContext}>
+        <DocumentContextProvider value={documentContext}>
+          <Document pagePath="/" />
+        </DocumentContextProvider>
+      </AppContextProvider>
+    );
+  }
+
+  const forwardReader = forwardStream.getReader();
+
+  const rscChunks = [];
+
+  function readRSCTree() {
+    res.write('<script>!window.__next_f && (window.__next_f = []);</script>');
+
+    forwardReader.read().then(({ done, value }) => {
+      if (value) {
+        rscChunks.push(value);
+      }
+
+      if (done) {
+        return;
+      } else {
+        const responsePartial = decodeText(value, textDecoder);
+        const scripts = `<script>self.__next_f.push(${htmlEscapeJsonString(
+          JSON.stringify([1, responsePartial]),
+        )})</script>`;
+        res.write(scripts);
+        readRSCTree();
+      }
+    });
+  }
+
+  readRSCTree();
+
+  const appStream = await EdgeServer.renderToReadableStream(<App />);
+  startReadingFromStream(res, appStream);
+}
+
+function startReadingFromStream(response, stream) {
+  let reader = stream.getReader();
+
+  function progress(_ref) {
+    let { done } = _ref,
+        { value } = _ref;
+
+    if (done) {
+      response.end();
+      return;
+    }
+
+    response.write(value);
+    return reader.read().then(progress).catch(error);
+  }
+
+  function error(e) {
+    console.log(e);
+  }
+
+  reader.read().then(progress).catch(error);
 }
 
 function renderMatches(matches: RouteMatch[], routeModules: RouteModules) {
@@ -106,3 +195,29 @@ function renderDocument(requestContext, renderOptions, appContext) {
   res.send(`<!DOCTYPE html>${htmlStr}`);
 }
 
+const ESCAPE_LOOKUP: { [match: string]: string } = {
+  '&': '\\u0026',
+  '>': '\\u003e',
+  '<': '\\u003c',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+
+const ESCAPE_REGEX = /[&><\u2028\u2029]/g;
+
+function htmlEscapeJsonString(str: string): string {
+  return str.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match]);
+}
+
+const textDecoder = new TextDecoder();
+
+function decodeText(
+  input: Uint8Array | undefined,
+  textDecoder: TextDecoder,
+) {
+  return textDecoder.decode(input, { stream: true });
+}
+
+function encodeText(input: string) {
+  return new TextEncoder().encode(input);
+}

--- a/packages/runtime/src/runRSCServerApp.tsx
+++ b/packages/runtime/src/runRSCServerApp.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 // import { renderToPipeableStream } from 'react-server-dom-webpack/server.node';
+// @ts-ignore
 import { use } from 'react';
+// @ts-ignore
 import * as EdgeServer from 'react-dom/server.edge';
 import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
 import { renderToReadableStream } from 'react-server-dom-webpack/server.edge';
@@ -20,8 +22,6 @@ import type {
   RouteModules,
   ServerRenderOptions as RenderOptions,
 } from './types.js';
-// @ts-ignore
-// @ts-ignore
 
 export async function runRSCServerApp(serverContext: ServerContext, renderOptions: RenderOptions) {
   const { req, res } = serverContext;


### PR DESCRIPTION
feat: 首次渲染时将 RSC 的 DOM Tree 渲染为 HTML 字符串后，在 HTML 中返回

基本工作原理：
- Server 端
   - 先将组件渲染为 RSC，渲染过程中，通过另一个流保存 RSC DOM Tree，同时下发 
   - 利用  react-server-dom-webpack 的 edge 版本，模拟 Client 端的渲染过程，将 RSC 转为 HTML
-  Client 端，读取额外下发的 RSC DOM Tree，进行 Hydrate

暴露的问题：
- 初始的 HTML 中，需要同时传递渲染后的 HTML 字符串和原始的 DOM Tree（供 Hydrate），会导致初始 HTML 体积 double

这个 PR 中尚未解决的问题
- [ ] 利用 `react-server-dom-webpack/client.edge` 在 Server 端渲染时，无法正常加载 Client Module
- [ ] 控制 DOM Tree 的插入位置在 body 内