### PR TITLE
fix: update route config when dataLoader is not defined

### DIFF
--- a/.changeset/tiny-hounds-hope.md
+++ b/.changeset/tiny-hounds-hope.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: update route config when dataLoader is not defined

--- a/examples/hash-router/src/pages/layout.tsx
+++ b/examples/hash-router/src/pages/layout.tsx
@@ -5,7 +5,7 @@ export default () => {
   return (
     <div>
       <h1>Layout</h1>
-      <h2>{config.title}</h2>
+      <h3>{config.title}</h3>
       <Outlet />
     </div>
   );

--- a/examples/hash-router/src/pages/layout.tsx
+++ b/examples/hash-router/src/pages/layout.tsx
@@ -1,9 +1,11 @@
-import { Outlet } from 'ice';
+import { Outlet, useConfig } from 'ice';
 
 export default () => {
+  const config = useConfig();
   return (
     <div>
       <h1>Layout</h1>
+      <h2>{config.title}</h2>
       <Outlet />
     </div>
   );

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -143,10 +143,14 @@ export function createRouteLoader(options: RouteLoaderOptions): LoaderFunction {
   }
 
   if (!dataLoaderConfig) {
-    return () => {
-      return {
+    return async () => {
+      const loaderData = {
         pageConfig: pageConfig ? pageConfig({}) : {},
       };
+      if (import.meta.renderer === 'client') {
+        await updateRoutesConfig(loaderData);
+      }
+      return loaderData;
     };
   }
 


### PR DESCRIPTION
Update route config when dataLoader is not defined.