### PR TITLE
fix: get flatten routes which nested level more than 3

### DIFF
--- a/.changeset/wicked-trainers-relate.md
+++ b/.changeset/wicked-trainers-relate.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: get flatten routes which nested level more than 3

--- a/packages/ice/src/utils/getRoutePaths.ts
+++ b/packages/ice/src/utils/getRoutePaths.ts
@@ -9,12 +9,12 @@ import formatPath from './formatPath.js';
  */
 export default function getRoutePaths(routes: NestedRouteManifest[], parentPath = ''): string[] {
   let pathList = [];
-
   routes.forEach(route => {
+    const routePath = formatPath(path.join('/', parentPath.replace(/^\//, ''), route.path || ''));
     if (route.children) {
-      pathList = pathList.concat(getRoutePaths(route.children, route.path));
+      pathList = pathList.concat(getRoutePaths(route.children, routePath));
     } else {
-      pathList.push(formatPath(path.join('/', parentPath, route.path || '')));
+      pathList.push(routePath);
     }
   });
 

--- a/packages/ice/tests/getRoutePaths.test.ts
+++ b/packages/ice/tests/getRoutePaths.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, expect, it, describe } from 'vitest';
+import getRoutePaths from '../src/utils/getRoutePaths.js';
+
+describe('getRoutePaths', () => {
+  it('index route with layout', () => {
+    const routeManifest = [
+      {
+        children: [
+          {},
+        ],
+      },
+    ];
+    // @ts-ignore for mock routeManifest.
+    const routePaths = getRoutePaths(routeManifest);
+    expect(routePaths).toEqual(['/']);
+  });
+  it('nested level 1', () => {
+    const routeManifest = [
+      {
+        children: [
+          {
+            path: 'a',
+          },
+          {
+            path: 'b',
+          },
+        ],
+      },
+    ];
+    // @ts-ignore for mock routeManifest.
+    const routePaths = getRoutePaths(routeManifest);
+    expect(routePaths).toEqual(['/a', '/b']);
+  });
+
+  it('nested level 2', () => {
+    const routeManifest = [
+      {
+        children: [
+          {
+            path: 'a',
+            children: [
+              {
+                path: 'a1',
+              },
+              {
+                path: 'a2',
+              },
+            ],
+          },
+          {
+            path: 'b',
+          },
+        ],
+      },
+    ];
+    // @ts-ignore for mock routeManifest.
+    const routePaths = getRoutePaths(routeManifest, '/');
+    expect(routePaths).toEqual(['/a/a1', '/a/a2', '/b']);
+  });
+
+  it('nested level 3', () => {
+    const routeManifest = [
+      {
+        children: [
+          {
+            path: 'a',
+            children: [
+              {
+                path: 'a1',
+                children: [
+                  {
+                    path: 'a11',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            path: 'b',
+          },
+        ],
+      },
+    ];
+    // @ts-ignore for mock routeManifest.
+    const routePaths = getRoutePaths(routeManifest);
+    expect(routePaths).toEqual(['/a/a1/a11', '/b']);
+  });
+});


### PR DESCRIPTION
Fix: get flatten routes which nested level more than 3.