### PR TITLE
fix: export createElement for react in @ice/runtime

### DIFF
--- a/.changeset/hungry-lions-build.md
+++ b/.changeset/hungry-lions-build.md
@@ -1,0 +1,6 @@
+---
+'@ice/shared-config': minor
+'@ice/runtime': minor
+---
+
+fix: modify import source

--- a/.changeset/wise-donkeys-relate.md
+++ b/.changeset/wise-donkeys-relate.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: export createElement from react

--- a/packages/ice/src/service/ServerRunner.ts
+++ b/packages/ice/src/service/ServerRunner.ts
@@ -67,7 +67,7 @@ async function transformJsxRuntime(source: string) {
     }
     // JSX runtime is added after swc plugins
     // use es-module-lexer to replace the import statement.
-    if (imp.n === '@ice/runtime/jsx-dev-runtime') {
+    if (imp.n === '@ice/runtime/jsx-dev-runtime' || imp.n === '@ice/runtime/react/jsx-dev-runtime') {
       str().overwrite(
         imp.ss,
         imp.se,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,7 +17,10 @@
     "./types": "./esm/types.js",
     "./package.json": "./package.json",
     "./polyfills/signal": "./esm/polyfills/signal.js",
-    "./polyfills/abortcontroller": "./esm/polyfills/abortcontroller.js"
+    "./polyfills/abortcontroller": "./esm/polyfills/abortcontroller.js",
+    "./react": "./esm/react.js",
+    "./react/jsx-runtime": "./esm/jsx-runtime.js",
+    "./react/jsx-dev-runtime": "./esm/jsx-dev-runtime.js"
   },
   "files": [
     "esm",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,4 @@
+import { createElement } from 'react';
 import {
   Link,
   Outlet,
@@ -90,6 +91,8 @@ function useDocumentData() {
 export const unstable_useDocumentData = useDocumentData;
 
 export {
+  // Export createElement while `@ice/runtime` is configured as `importSource` in swc jsx transform options.
+  createElement,
   getAppConfig,
   defineAppConfig,
   Runtime,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,3 @@
-import { createElement } from 'react';
 import {
   Link,
   Outlet,
@@ -91,8 +90,6 @@ function useDocumentData() {
 export const unstable_useDocumentData = useDocumentData;
 
 export {
-  // Export createElement while `@ice/runtime` is configured as `importSource` in swc jsx transform options.
-  createElement,
   getAppConfig,
   defineAppConfig,
   Runtime,

--- a/packages/runtime/src/react.ts
+++ b/packages/runtime/src/react.ts
@@ -1,0 +1,5 @@
+import { createElement } from 'react';
+export {
+  // Export createElement while `@ice/runtime` is configured as `importSource` in swc jsx transform options.
+  createElement,
+};

--- a/packages/shared-config/src/unPlugins/compilation.ts
+++ b/packages/shared-config/src/unPlugins/compilation.ts
@@ -203,7 +203,7 @@ function getJsxTransformOptions({
     development: mode === 'development',
     refresh: fastRefresh,
     runtime: 'automatic',
-    importSource: '@ice/runtime', // The exact import source is '@ice/runtime/jsx-runtime'
+    importSource: '@ice/runtime/react', // The exact import source is '@ice/runtime/react/jsx-runtime'
   };
 
   const commonOptions: SwcConfig = {


### PR DESCRIPTION
swc will inject createElement import even in the case of jsx. [Case](https://github.com/swc-project/swc/blob/main/crates/swc_ecma_transforms_react/src/jsx/static_check.rs)

swc support script within automatic runtime in version 1.3.44 and bring a break change for the behavior of import source:

Previously:
```jsx
// <div {...props} key={key} /> transform result in ice.js:

iimport { jsx as _jsx , jsxs as _jsxs , Fragment as _Fragment  } from "@ice/runtime/jsx-runtime";
import { createElement as _createElement  } from "react";
...

```

After @swc/core [1.3.44](https://github.com/swc-project/swc/blob/main/CHANGELOG.md#1344---2023-03-30):

```jsx
// <div {...props} key={key} /> transform result in ice.js:

import { jsx as _jsx , jsxs as _jsxs , Fragment as _Fragment  }  from "@ice/runtime/jsx-runtime";
import { createElement as _createElement  } from "@ice/runtime";
...
```

More trasform detail in swc: [Code](https://github.com/swc-project/swc/blob/ed648337f1640dfb7d646b1df4047b81b9d6c46d/crates/swc_ecma_transforms_react/src/jsx/mod.rs#L388-L395)

Solution:
Add a new entry for export `createElement`,  if export it directly in `index.ts`, it will case dataLoader pack the react package.
