### PR TITLE
fix: user compilation config lose

### DIFF
--- a/.changeset/thick-monkeys-call.md
+++ b/.changeset/thick-monkeys-call.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+fix: user compilation config lose

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,9 +97,13 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         type: false,
       });
 
+      // Must create a variable to store the original compilationConfig.
+      const originalSwcCompilationConfig = typeof config.swcOptions?.compilationConfig === 'object'
+        ? cloneDeep(config.swcOptions?.compilationConfig || {})
+        : {};
       const compilationConfigFunc = typeof config.swcOptions?.compilationConfig === 'function'
         ? config.swcOptions?.compilationConfig
-        : () => config.swcOptions?.compilationConfig;
+        : () => originalSwcCompilationConfig;
 
       // Reset jsc.transform.react.runtime to classic.
       config.swcOptions = merge(config.swcOptions || {}, {

--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -97,6 +97,7 @@ const plugin: Plugin<CompatRaxOptions> = (options = {}) => ({
         type: false,
       });
 
+      // TODO: optimize the logic, support deep merge in plugin API.
       // Must create a variable to store the original compilationConfig.
       const originalSwcCompilationConfig = typeof config.swcOptions?.compilationConfig === 'object'
         ? cloneDeep(config.swcOptions?.compilationConfig || {})


### PR DESCRIPTION
问题：通过 userConfig 设置的 swc 编译配置（比如 syntaxFeatures.exportDefaultFrom），经过 `plugin-rax-compat` 插件处理后会丢失

