### PR TITLE
fix: query info in fc

### DIFF
--- a/.changeset/famous-pigs-pretend.md
+++ b/.changeset/famous-pigs-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: compatible with query parsing errors caused by ctx.req.url error in the fc environment

--- a/packages/runtime/src/requestContext.ts
+++ b/packages/runtime/src/requestContext.ts
@@ -10,7 +10,9 @@ export interface Location {
  */
 export default function getRequestContext(location: Location, serverContext: ServerContext = {}): RequestContext {
   const { pathname, search } = location;
-  const query = parseSearch(search);
+  // Use query form server context first to avoid unnecessary parsing.
+  // @ts-ignore
+  const query = serverContext?.req?.query || parseSearch(search);
 
   const requestContext: RequestContext = {
     ...(serverContext || {}),


### PR DESCRIPTION
FC 环境下 ctx.req.url 的参数会被错误处理，而 query 对象又是正确的

这里优先使用 ctx.req.query 信息，一方面规避上面的问题，另外一方面也可以减少不必要的解析