### PR TITLE
fix: provide missing PropTypes export for rax-compat

### DIFF
--- a/.changeset/chatty-nails-reply.md
+++ b/.changeset/chatty-nails-reply.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+fix: provide missing PropTypes export

--- a/packages/rax-compat/src/index.ts
+++ b/packages/rax-compat/src/index.ts
@@ -17,6 +17,8 @@ import { Component, PureComponent, memo } from './component.js';
 import { createContext } from './context.js';
 import shared from './shared.js';
 
+export { default as PropTypes } from './prop-types.js';
+
 // Mocked version for rax.
 const version = '1.2.2-compat';
 

--- a/packages/rax-compat/src/prop-types.ts
+++ b/packages/rax-compat/src/prop-types.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck Doesnot take effect in runtime validation, for imports compatibility only.
+/*
+ * Current PropTypes only export some api with react, not validate in runtime.
+ */
+
+function createChainableTypeChecker(validate) {
+  function checkType(isRequired, props, propName, componentName, location, propFullName) {
+    return typeChecker;
+  }
+
+  let chainedCheckType = checkType.bind(null, false);
+  chainedCheckType.isRequired = checkType.bind(null, true);
+
+  return chainedCheckType;
+}
+
+function createTypeChecker(expectedType) {
+  function validate(props, propName, componentName, location, propFullName) {
+    // Noop
+  }
+  return createChainableTypeChecker(validate);
+}
+
+let typeChecker = createTypeChecker();
+
+export default {
+  array: typeChecker,
+  bool: typeChecker,
+  func: typeChecker,
+  number: typeChecker,
+  object: typeChecker,
+  string: typeChecker,
+  symbol: typeChecker,
+  element: typeChecker,
+  node: typeChecker,
+  any: typeChecker,
+  arrayOf: typeChecker,
+  instanceOf: typeChecker,
+  objectOf: typeChecker,
+  oneOf: typeChecker,
+  oneOfType: typeChecker,
+  shape: typeChecker,
+};


### PR DESCRIPTION
Add missing `PropTypes` at Rax v 0.6.x for compat.