### PR TITLE
Support legacy mode for plugin-rax-compat

### DIFF
--- a/.changeset/empty-islands-unite.md
+++ b/.changeset/empty-islands-unite.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-rax-compat': minor
+---
+
+support legacy option for legacy rax compat

--- a/packages/plugin-rax-compat/package.json
+++ b/packages/plugin-rax-compat/package.json
@@ -40,7 +40,9 @@
   },
   "scripts": {
     "watch": "tsc -w --sourceMap",
-    "build": "tsc && cp src/rax-compat.d.ts  esm/rax-compat.d.ts"
+    "copy:dts": "cp src/rax-compat.d.ts esm/rax-compat.d.ts",
+    "copy:legacy": "cp src/rax-compat-legacy-exports.ts.template esm/rax-compat-legacy-exports.ts.template",
+    "build": "tsc && npm run copy:dts && npm run copy:legacy"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-rax-compat/src/rax-compat-legacy-exports.ts.template
+++ b/packages/plugin-rax-compat/src/rax-compat-legacy-exports.ts.template
@@ -1,0 +1,22 @@
+export * from 'rax-compat';
+
+const typeChecker = () => {};
+
+export const PropTypes = {
+  array: typeChecker,
+  bool: typeChecker,
+  func: typeChecker,
+  number: typeChecker,
+  object: typeChecker,
+  string: typeChecker,
+  symbol: typeChecker,
+  element: typeChecker,
+  node: typeChecker,
+  any: typeChecker,
+  arrayOf: typeChecker,
+  instanceOf: typeChecker,
+  objectOf: typeChecker,
+  oneOf: typeChecker,
+  oneOfType: typeChecker,
+  shape: typeChecker,
+};


### PR DESCRIPTION
Add `legacy` option for `plugin-rax-compat`, which enables compatibility for legacy version rax version like `v0.6.x`.

When `legacy` option enbaled:

- Create `.ice/rax-compat-legacy-exports.ts` file, which patches the exports from `rax-compat`, add missing(removed) exports like `PropTypes`.
- Update `config.alias`, use the created file above as the alias for imports target `rax`, so they can import `PropTypes` from `rax` now.