### PR TITLE
fix: compatible with tag.parentNode is null when update routes config

### DIFF
--- a/.changeset/friendly-olives-relax.md
+++ b/.changeset/friendly-olives-relax.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: compatible with tag.parentNode is null when update routes config

--- a/packages/runtime/src/routesConfig.ts
+++ b/packages/runtime/src/routesConfig.ts
@@ -158,7 +158,8 @@ async function updateAssets(type: string, assets: RouteConfig['links'] | RouteCo
   }));
 
   oldTags.forEach((tag) => {
-    tag.parentNode!.removeChild(tag);
+    // In some parcel case oldTags may be removed by other routes.
+    tag.parentNode?.removeChild(tag);
   });
 }
 


### PR DESCRIPTION
In some parcel case oldTags may be removed by other route. 