### PR TITLE
feat: support options when call document dataLoader

### DIFF
--- a/.changeset/cyan-maps-do.md
+++ b/.changeset/cyan-maps-do.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+feat: support options when call document dataLoader

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -14,7 +14,8 @@ import type {
   DocumentComponent,
   RuntimeModules,
   AppData,
-  ServerAppRouterProps, DataLoaderConfig,
+  ServerAppRouterProps,
+  DocumentDataLoaderConfig,
 } from './types.js';
 import Runtime from './runtime.js';
 import { AppContextProvider } from './AppContext.js';
@@ -38,7 +39,7 @@ interface RenderOptions {
   assetsManifest: AssetsManifest;
   createRoutes: (options: Pick<RouteLoaderOptions, 'requestContext' | 'renderMode'>) => RouteItem[];
   runtimeModules: RuntimeModules;
-  documentDataLoader?: DataLoaderConfig;
+  documentDataLoader?: DocumentDataLoaderConfig;
   Document?: DocumentComponent;
   documentOnly?: boolean;
   renderMode?: RenderMode;
@@ -270,7 +271,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
   if (renderOptions.documentDataLoader) {
     const { loader } = renderOptions.documentDataLoader;
     if (isFunction(loader)) {
-      documentData = await loader(requestContext);
+      documentData = await loader(requestContext, { documentOnly });
       // @TODO: document should have it's own context, not shared with app.
       appContext.documentData = documentData;
     } else {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -86,6 +86,15 @@ export interface DataLoaderConfig {
   options?: DataLoaderOptions;
 }
 
+interface DocumentLoaderOptions {
+  documentOnly?: boolean;
+}
+export type DocumentDataLoader = (ctx: RequestContext, options: DocumentLoaderOptions) => DataLoaderResult;
+
+export interface DocumentDataLoaderConfig {
+  loader: DocumentDataLoader;
+}
+
 export interface LoadersData {
   [routeId: string]: LoaderData;
 }


### PR DESCRIPTION
Support options when call document dataLoader.
Beta version: @ice/runtime@1.3.2-canary-cc7e3443c-20231019031627