### PR TITLE
fix: data loader output

### DIFF
--- a/.changeset/orange-onions-relate.md
+++ b/.changeset/orange-onions-relate.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: check let support by browserslist

--- a/packages/ice/src/webpack/DataLoaderPlugin.ts
+++ b/packages/ice/src/webpack/DataLoaderPlugin.ts
@@ -58,6 +58,7 @@ export default class DataLoaderPlugin {
               supported: {
                 // Do not wrap arrow function when format as IIFE.
                 arrow: false,
+                'const-and-let': false,
               },
               write: false,
               logLevel: 'silent', // The main server compile process will log it.

--- a/packages/ice/src/webpack/DataLoaderPlugin.ts
+++ b/packages/ice/src/webpack/DataLoaderPlugin.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import fse from 'fs-extra';
 import type { Compiler } from 'webpack';
 import webpack from '@ice/bundles/compiled/webpack/index.js';
+import { isSupportedFeature } from '@ice/shared-config';
 import type { Context } from 'build-scripts';
 import type { ServerCompiler, PluginData } from '../types/plugin.js';
 import type { DeclarationData } from '../types/generator.js';
@@ -50,6 +51,7 @@ export default class DataLoaderPlugin {
         // Check file data-loader.ts if it is exists.
         const filePath = path.join(this.rootDir, RUNTIME_TMP_DIR, 'data-loader.ts');
         if (fse.existsSync(filePath)) {
+          const isLetSupported = isSupportedFeature('let', this.rootDir);
           const { outputFiles, error } = await this.serverCompiler(
             {
               target: 'es6', // should not set to esnext, https://github.com/alibaba/ice/issues/5830
@@ -58,7 +60,7 @@ export default class DataLoaderPlugin {
               supported: {
                 // Do not wrap arrow function when format as IIFE.
                 arrow: false,
-                'const-and-let': false,
+                'const-and-let': isLetSupported,
               },
               write: false,
               logLevel: 'silent', // The main server compile process will log it.


### PR DESCRIPTION
esbuild 在构建 dataLoader 时会额外引入 let 变量，导致部分浏览器下报错，需要加入黑名单


<img width="691" alt="image" src="https://github.com/alibaba/ice/assets/1303018/4184df0a-83a6-4594-81c1-3310bb6c3019">
