### PR TITLE
fix: do not minify assets in public by default

### DIFF
--- a/.changeset/gorgeous-coins-scream.md
+++ b/.changeset/gorgeous-coins-scream.md
@@ -1,0 +1,5 @@
+---
+'@ice/webpack-config': patch
+---
+
+fix: do not minify assets in public by default

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -310,6 +310,10 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
           // ignore assets already in compilation.assets such as js and css files
           force: false,
           noErrorOnMissing: true,
+          // Skip minimization by default.
+          info: {
+            minimized: true,
+          },
           globOptions: {
             dot: true,
             gitignore: true,


### PR DESCRIPTION
`ice.js` should not deal with the assets in public by default, it may cause unexpected error when minify JS while it had been already done.