### PR TITLE
fix: assets rule in speedup mode

### DIFF
--- a/.changeset/empty-pillows-bathe.md
+++ b/.changeset/empty-pillows-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ice/rspack-config': patch
+---
+
+fix: assets rule for rspack

--- a/packages/rspack-config/src/assetsRule.ts
+++ b/packages/rspack-config/src/assetsRule.ts
@@ -2,10 +2,7 @@ import type { Configuration } from '@rspack/core';
 
 const getAssetsRule = () => {
   const assetsRule = [
-    [/\.woff2?$/, { mimetype: 'application/font-woff' }],
-    [/\.ttf$/, { mimetype: 'application/octet-stream' }],
-    [/\.eot$/, { mimetype: 'application/vnd.ms-fontobject' }],
-    [/\.svg$/, { mimetype: 'image/svg+xml' }, false],
+    [/\.woff2?$/], [/\.ttf$/], [/\.eot$/], [/\.svg$/],
     [/\.(png|jpg|webp|jpeg|gif)$/i],
   ];
 
@@ -21,13 +18,13 @@ const getAssetsRule = () => {
     return {
       test,
       type: 'asset',
-      parser: {
-        ...(urlCondition ? {
+      ...(urlCondition ? {
+        parser: {
           dataUrlCondition: {
             maxSize: 8 * 1024, // 8kb
           },
-        } : {}),
-      },
+        },
+      } : {}),
       ...(typeof ruleOption === 'object' ? ruleOption : {}),
     };
   }) as Configuration['module']['rules']).concat(queryRules);


### PR DESCRIPTION
It is unnecessary to configure `mimetype` in speedup mode, and it will cause `type: 'asset'` works improperly.

Fix #6628