### PR TITLE
fix(@ice/app): requireHook in createService

### DIFF
--- a/.changeset/soft-coats-cover.md
+++ b/.changeset/soft-coats-cover.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+move require hijack to createService

--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -6,8 +6,6 @@ import fse from 'fs-extra';
 import { fileURLToPath } from 'url';
 import { program, Option } from 'commander';
 import yargsParser from 'yargs-parser';
-// hijack webpack before import other modules
-import '../esm/requireHook.js';
 import createService from '../esm/createService.js';
 import { TARGETS, WEB } from '../esm/constant.js';
 

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -1,3 +1,5 @@
+// hijack webpack before import other modules
+import './requireHook.js';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';


### PR DESCRIPTION
Move `requireHook` registry to `createService` file, this should **fixes the HMR** when creating ICE server programtically:

```typescript
import createService from '@ice/app/service';

await createService(/* ... */).run();
```