### PR TITLE
chore: remove types export

### DIFF
--- a/.changeset/sharp-carrots-protect.md
+++ b/.changeset/sharp-carrots-protect.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+chore: remove `./types` export in `typesVersions` field to be compatible with `/// <reference types="@ice/app/types" />` in scaffolds

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -12,9 +12,6 @@
   },
   "typesVersions": {
     "*": {
-      "types": [
-        "./esm/types/index.d.ts"
-      ],
       "analyze": [
         "./esm/service/analyze.d.ts"
       ],


### PR DESCRIPTION
remove `./types` export in `typesVersions` field to be compatible with `/// <reference types="@ice/app/types" />` in scaffolds