### PR TITLE
fix: better error handling of build script

### DIFF
--- a/.changeset/slimy-rats-dance.md
+++ b/.changeset/slimy-rats-dance.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+chore: better error handling for build script

--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -36,7 +36,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
         ...parseUnknownOptions(ctx.args),
         ...commandArgs,
       } });
-      service.run();
+      service.run().catch((error) => {
+        console.log(chalk.red('Build Error'), error);
+        // Set exit code to 1 to exit process with failure code, otherwise CI may regard build as success.
+        process.exit(1);
+      });
     });
 
   program


### PR DESCRIPTION
Set exit code to 1 to exit process with failure code, otherwise CI may regard build as success.