### PR TITLE
fix: fix default document import

### DIFF
--- a/packages/ice/templates/core/document.tsx.ejs
+++ b/packages/ice/templates/core/document.tsx.ejs
@@ -1,4 +1,4 @@
-import { Meta, Title, Links, Main, Scripts } from 'ice';
+import { Meta, Title, Links, Main, Scripts } from '@ice/runtime';
 
 function Document() {
   return (


### PR DESCRIPTION
```diff
- import { Meta, Title, Links, Main, Scripts } from 'ice';
+ import { Meta, Title, Links, Main, Scripts } from '@ice/runtime';
```
Import from `'@ice/runtime'` instead of `'ice'` as default document was located in the alias resolution path.