### PR TITLE
docs: fix request base url env

### DIFF
--- a/website/docs/guide/advanced/request.md
+++ b/website/docs/guide/advanced/request.md
@@ -509,11 +509,11 @@ export const requestConfig = defineRequestConfig({
 
 ```shell title=".env.local"
 # The should not be committed.
-BASEURL=http://localhost:9999/api
+ICE_BASE_URL=http://localhost:9999/api
 ```
 
-```shell title=".env.prod"
-BASEURL=https://example.com/api
+```shell title=".env.production"
+ICE_BASE_URL=https://example.com/api
 ```
 
 在 `src/app.tsx` 中配置 `request.baseURL`:
@@ -522,6 +522,6 @@ BASEURL=https://example.com/api
 import { defineRequestConfig } from '@ice/plugin-request/types';
 
 export const requestConfig = defineRequestConfig({
-  baseURL: process.env.BASEURL,
+  baseURL: process.env.ICE_BASE_URL,
 });
 ```


### PR DESCRIPTION
运行时的配置需要加上 `ICE_` 前缀 https://v3.ice.work/docs/guide/basic/env#%E8%BF%90%E8%A1%8C%E6%97%B6