### PR TITLE
RaxCompat(Plugin) 0.3.0

### DIFF
--- a/.changeset/clean-dragons-beam.md
+++ b/.changeset/clean-dragons-beam.md
@@ -1,0 +1,6 @@
+---
+'@ice/plugin-rax-compat': patch
+---
+
+- 修正 inlineStyleFilter 在 SSR 下不生效的问题
+- 修正 esbuild-inline-style 中对 less 文件相对引用解析的问题

--- a/packages/plugin-rax-compat/src/transform-styles.ts
+++ b/packages/plugin-rax-compat/src/transform-styles.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { createRequire } from 'module';
 import css from 'css';
 import transformerModule from 'stylesheet-loader/lib/transformer.js';
@@ -20,12 +21,14 @@ const CSS_VAR_NAME = ':root';
 // @ts-ignore
 const transformer = transformerModule.default;
 
-async function styleSheetLoader(source, type = 'css') {
+async function styleSheetLoader(source: string, sourcePath: string, type = 'css') {
   let cssContent = source;
   if (type === 'less') {
     // compact for @import "~bootstrap/less/bootstrap";
     cssContent = cssContent.replace(/@import "~/g, '@import "');
-    cssContent = (await less.render(cssContent)).css;
+    cssContent = (await less.render(cssContent, {
+      paths: [path.dirname(sourcePath), 'node_modules'],
+    })).css;
   }
 
   const newContent = await postcss([require('@ice/bundles/compiled/postcss-plugin-rpx2vw/index.js')({ unitPrecision: 4 })]).process(cssContent).css;


### PR DESCRIPTION
## Todos

- [x] [Fix] [plugin] inlineStyle 在 SSR（`applyStylesheetLoaderForServer`） 下完全没有生效
- [x] [Fix] [plugin] SSR 下 `esbuild-plugin-inline-style` 无法处理 less 文件中的相对引用支持（`@import './variables.less'`）
- [ ] [Fix] [plugin] inlineStyle 对 `less`、`scss` 文件目前不生效
- [ ] [Fix] [rax-compat] 兼容 Rax 0.x 时代的 `styles=[styles.foo, styles.bar]` 语法
- [ ] [Feat] [plugin] SCSS 样式支持
- [ ] [Chore] [plugin] 整体功能重构与完善