### PR TITLE
fix: compatible with API matchRoutes when basename is not provided

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/runtime
 
+## 1.3.5
+
+- fix: compatible with API `matchRoutes` when basename is not provided.
+
 ## 1.3.4
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Runtime module for ice.js",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/packages/runtime/src/singleRouter.tsx
+++ b/packages/runtime/src/singleRouter.tsx
@@ -48,7 +48,7 @@ const stripString = (str: string) => {
 };
 
 export const matchRoutes = (routes: any[], location: Partial<Location> | string, basename: string) => {
-  const stripedBasename = stripString(basename);
+  const stripedBasename = basename ? stripString(basename) : basename;
   const pathname = typeof location === 'string' ? location : location.pathname;
   let stripedPathname = stripString(pathname);
   if (stripedBasename) {


### PR DESCRIPTION
Compatible with API matchRoutes when basename is not provided in single route mode.