### PR TITLE
fix: do not log warning message when use router api

### DIFF
--- a/.changeset/orange-sheep-appear.md
+++ b/.changeset/orange-sheep-appear.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: do not log warning message when use router api

--- a/packages/runtime/src/ClientRouter.tsx
+++ b/packages/runtime/src/ClientRouter.tsx
@@ -7,6 +7,7 @@ import App from './App.js';
 import { DataContextProvider } from './singleRouter.js';
 import { useAppContext } from './AppContext.js';
 import { setHistory } from './history.js';
+import { disableHistoryWarning } from './utils/deprecatedHistory.js';
 
 function createRouterHistory(history: History, router: Router) {
   const routerHistory = history;
@@ -39,6 +40,7 @@ function ClientRouter(props: ClientAppRouterProps) {
     clearRouter();
     // @ts-expect-error routes type should be AgnosticBaseRouteObject[]
     router = createRouter(routerContext).initialize();
+    disableHistoryWarning();
     // Replace history methods by router navigate for backwards compatibility.
     setHistory(createRouterHistory({ ...routerContext.history }, router));
   }

--- a/packages/runtime/src/utils/deprecatedHistory.ts
+++ b/packages/runtime/src/utils/deprecatedHistory.ts
@@ -1,14 +1,24 @@
 import type { History, To } from '@remix-run/router';
 
+let disableWarning = false;
+
+export function disableHistoryWarning() {
+  disableWarning = true;
+}
+
 export function deprecatedHistory(history: History) {
   const originHistory = { ...history };
   const deprecatedMessage = 'history.push and history.replace is not recommended to use outside of react component. The usage will be deprecated in the next minor version.';
   history.push = function (to: To, state?: any) {
-    console.warn(deprecatedMessage);
+    if (!disableWarning) {
+      console.warn(deprecatedMessage);
+    }
     originHistory.push(to, state);
   };
   history.replace = function (to: To, state?: any) {
-    console.warn(deprecatedMessage);
+    if (!disableWarning) {
+      console.warn(deprecatedMessage);
+    }
     originHistory.replace(to, state);
   };
   return history;


### PR DESCRIPTION
Do not log warning message when use router api after router has been initialized.