### PR TITLE
Feat: support optimize package import

### DIFF
--- a/.changeset/five-kids-sit.md
+++ b/.changeset/five-kids-sit.md
@@ -1,0 +1,7 @@
+---
+'@ice/rspack-config': patch
+'@ice/shared-config': patch
+'@ice/app': patch
+---
+
+feat: support optimize package import

--- a/.changeset/thin-ligers-taste.md
+++ b/.changeset/thin-ligers-taste.md
@@ -1,0 +1,5 @@
+---
+'@ice/bundles': patch
+---
+
+fix: update binding version for optimize imports

--- a/examples/with-antd5/ice.config.mts
+++ b/examples/with-antd5/ice.config.mts
@@ -2,4 +2,7 @@ import { defineConfig } from '@ice/app';
 
 export default defineConfig(() => ({
   ssg: false,
+  optimization: {
+    optimizePackageImport: true,
+  }
 }));

--- a/packages/bundles/package.json
+++ b/packages/bundles/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.22.3",
     "zod-validation-error": "1.2.0",
     "terminal-link": "^2.1.1",
-    "@ice/pack-binding": "0.0.6",
+    "@ice/pack-binding": "0.0.8",
     "mime-types": "2.1.35"
   },
   "devDependencies": {

--- a/packages/ice/src/config.ts
+++ b/packages/ice/src/config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'module';
+import { log } from 'console';
 import trustCert from '@ice/bundles/compiled/trusted-cert/index.js';
 import fse from 'fs-extra';
 import type { Config } from '@ice/shared-config/types';
@@ -352,6 +353,83 @@ const userConfig = [
   {
     name: 'optimization',
     validation: 'object',
+    setConfig: (config: Config, optimization: UserConfig['optimization'], context: UserConfigContext) => {
+      const { commandArgs } = context;
+      if (optimization?.optimizePackageImport) {
+        if (!commandArgs.speedup) {
+          logger.warn(`
+            optimizePackageImport only works in speedup mode,
+            try to run \`npm ${commandArgs.command === 'start' ? 'start' : 'run build'} -- --speedup\``,
+          );
+        } else {
+          config.optimizePackageImports = [
+            ...new Set([
+              ...(Array.isArray(optimization?.optimizePackageImport) ? optimization?.optimizePackageImport : []),
+              // Buit-in packages is modified based on
+              // https://github.com/vercel/next.js/blob/7b73f1137b21c7b1fb1612c3389caaaadd18da65/packages/next/src/server/config.ts#L827
+              '@alifd/next',
+              '@ali/uni-api',
+              'lucide-react',
+              'date-fns',
+              'lodash-es',
+              'ramda',
+              'antd',
+              'react-bootstrap',
+              'ahooks',
+              '@ant-design/icons',
+              '@headlessui/react',
+              '@headlessui-float/react',
+              '@heroicons/react/20/solid',
+              '@heroicons/react/24/solid',
+              '@heroicons/react/24/outline',
+              '@visx/visx',
+              '@tremor/react',
+              'rxjs',
+              '@mui/material',
+              '@mui/icons-material',
+              'recharts',
+              'react-use',
+              '@material-ui/core',
+              '@material-ui/icons',
+              '@tabler/icons-react',
+              'mui-core',
+              'react-icons/ai',
+              'react-icons/bi',
+              'react-icons/bs',
+              'react-icons/cg',
+              'react-icons/ci',
+              'react-icons/di',
+              'react-icons/fa',
+              'react-icons/fa6',
+              'react-icons/fc',
+              'react-icons/fi',
+              'react-icons/gi',
+              'react-icons/go',
+              'react-icons/gr',
+              'react-icons/hi',
+              'react-icons/hi2',
+              'react-icons/im',
+              'react-icons/io',
+              'react-icons/io5',
+              'react-icons/lia',
+              'react-icons/lib',
+              'react-icons/lu',
+              'react-icons/md',
+              'react-icons/pi',
+              'react-icons/ri',
+              'react-icons/rx',
+              'react-icons/si',
+              'react-icons/sl',
+              'react-icons/tb',
+              'react-icons/tfi',
+              'react-icons/ti',
+              'react-icons/vsc',
+              'react-icons/wi',
+            ]),
+          ];
+        }
+      }
+    },
   },
   {
     name: 'mock',

--- a/packages/ice/src/config.ts
+++ b/packages/ice/src/config.ts
@@ -1,5 +1,4 @@
 import { createRequire } from 'module';
-import { log } from 'console';
 import trustCert from '@ice/bundles/compiled/trusted-cert/index.js';
 import fse from 'fs-extra';
 import type { Config } from '@ice/shared-config/types';
@@ -356,12 +355,7 @@ const userConfig = [
     setConfig: (config: Config, optimization: UserConfig['optimization'], context: UserConfigContext) => {
       const { commandArgs } = context;
       if (optimization?.optimizePackageImport) {
-        if (!commandArgs.speedup) {
-          logger.warn(`
-            optimizePackageImport only works in speedup mode,
-            try to run \`npm ${commandArgs.command === 'start' ? 'start' : 'run build'} -- --speedup\``,
-          );
-        } else {
+        if (commandArgs.speedup) {
           config.optimizePackageImports = [
             ...new Set([
               ...(Array.isArray(optimization?.optimizePackageImport) ? optimization?.optimizePackageImport : []),
@@ -427,6 +421,11 @@ const userConfig = [
               'react-icons/wi',
             ]),
           ];
+        } else {
+          logger.warn(`
+            optimizePackageImport only works in speedup mode,
+            try to run \`npm ${commandArgs.command === 'start' ? 'start' : 'run build'} -- --speedup\``,
+          );
         }
       }
     },

--- a/packages/ice/src/types/userConfig.ts
+++ b/packages/ice/src/types/userConfig.ts
@@ -22,6 +22,12 @@ interface Optimization {
    * Remove react-router dependencies by force, even if route count is greater than 1.
    */
   disableRouter?: boolean;
+  /**
+   * Automatically the apply modularize imports optimization,
+   * it will remove unused code of package when it is a barrel file.
+   * Note: It is only supported in speedup mode.
+   */
+  optimizePackageImport?: string[] | boolean;
 }
 
 interface MinifyOptions {

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -169,7 +169,7 @@ const getConfig: GetConfig = async (options) => {
           test: /__barrel_optimize__/,
           use: ({ realResource }: { realResource: string }) => {
             const names = (
-              realResource.match(/\?names=([^&]+)/)?.[1] || ''
+              realResource.match(/\?names=([^&]+)!=!/)?.[1] || ''
             ).split(',');
             return [{
               loader: 'builtin:barrel-loader',

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -48,6 +48,7 @@ const getConfig: GetConfig = async (options) => {
   } = options;
 
   const {
+    cacheDir,
     mode,
     minify,
     publicPath = '/',
@@ -68,6 +69,7 @@ const getConfig: GetConfig = async (options) => {
     middlewares,
     configureWebpack = [],
     minimizerOptions = {},
+    optimizePackageImports = [],
   } = taskConfig || {};
   const isDev = mode === 'development';
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
@@ -154,12 +156,28 @@ const getConfig: GetConfig = async (options) => {
               transformFeatures: {
                 removeExport: swcOptions.removeExportExprs,
                 keepExport: swcOptions.keepExports,
+                optimizeImport: optimizePackageImports,
               },
               compileRules: {
                 // "bundles/compiled" is the path when using @ice/bundles.
                 exclude: [...compileExclude, 'bundles/compiled'],
               },
             },
+          },
+        },
+        {
+          test: /__barrel_optimize__/,
+          use: ({ realResource }: { realResource: string }) => {
+            const names = (
+              realResource.match(/\?names=([^&]+)/)?.[1] || ''
+            ).split(',');
+            return [{
+              loader: 'builtin:barrel-loader',
+              options: {
+                names,
+                cacheDir,
+              },
+            }];
           },
         },
         ...getAssetsRule(),

--- a/packages/shared-config/src/types.ts
+++ b/packages/shared-config/src/types.ts
@@ -205,4 +205,6 @@ export interface Config {
   useDevServer?: boolean;
 
   useDataLoader?: boolean;
+
+  optimizePackageImports?: string[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1276,8 +1276,8 @@ importers:
         specifier: 0.0.6
         version: 0.0.6
       '@ice/pack-binding':
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: 0.0.8
+        version: 0.0.8
       '@ice/swc-plugin-keep-export':
         specifier: 0.2.0
         version: 0.2.0
@@ -6658,8 +6658,8 @@ packages:
       '@ice/css-modules-hash-win32-x64-msvc': 0.0.6
     dev: false
 
-  /@ice/pack-binding-darwin-arm64@0.0.6:
-    resolution: {integrity: sha512-vJNdd1rvAA+3l2wlZvZKoOaz+ti7RG4MaHM/T+fEgt9lDpxhY3X+/4MNKdJnzMGsBsX5vMjvifRXS4UFFSg5oQ==}
+  /@ice/pack-binding-darwin-arm64@0.0.8:
+    resolution: {integrity: sha512-dlJEOZCLaxv1S+RUTB4sFRtLP7EISNYXAwN97WiZ+KUG9TRkzvNwV/WjzoOCOmaoNNbqeHwxbliM60gV3O9BVg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -6667,16 +6667,16 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding-darwin-universal@0.0.6:
-    resolution: {integrity: sha512-Y/eDuy667DvUAWl9hpg4D8YCFogW6eCCdOIEMVhxHQOBCMa9QbXCg6TKsI+xKfudUCNCsqg+dQTdRUMCazNjxQ==}
+  /@ice/pack-binding-darwin-universal@0.0.8:
+    resolution: {integrity: sha512-26Ga4Ct7yfOpPNp3cPZgM+XNupKB6IvZ5vsDrnWl9vwmNQszCMyVZcpgaNQ9rPRB/lbP4NgtKc9pQU8T38Ptsg==}
     engines: {node: '>= 10'}
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@ice/pack-binding-darwin-x64@0.0.6:
-    resolution: {integrity: sha512-QEWYkPtzIYLvw9h5K9NjwXjB+XFVRUnpaEjQPoO3xGC/0l0xABOtdl4kbo/ya1ucIwq8hM530fi/STBUy8UaEg==}
+  /@ice/pack-binding-darwin-x64@0.0.8:
+    resolution: {integrity: sha512-AJ7mPitkJ7j37WUYUx+VB3xWQOsL5zSET4CeDBEthxrUScmIjduZ32edB0DHtnsqEFz7NBVN2EHjLq54lHv09A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -6684,8 +6684,8 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding-linux-x64-gnu@0.0.6:
-    resolution: {integrity: sha512-Ol6E62HxLhCPAeTJ7e6vaC1UsKJNt5mCngQVlUAut5QIFccQw6m+ZFGHu/OZfvmtTYwCo4d3m8OlBoTvIyIY5w==}
+  /@ice/pack-binding-linux-x64-gnu@0.0.8:
+    resolution: {integrity: sha512-Zkwn0AdtBt4DyJ3GhNRM/PMzOHWJAuZB0LjgymtbKNqAvkB3cScJTdV7dui2VZJ3W0vosjTQ/wNpWVKdxClXXg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6693,8 +6693,8 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding-linux-x64-musl@0.0.6:
-    resolution: {integrity: sha512-koCI4HhBJk/MhMdeAJiMMza1Y0+HRexl2YsAsgZZLTAuOPhPCqFrofiIAJ1hBJhQpwWdK4Dfi13szeoWp2HIlA==}
+  /@ice/pack-binding-linux-x64-musl@0.0.8:
+    resolution: {integrity: sha512-wQROpPgNKikRMfDp5j7/PrEQ12iarEtKWmnFPl93xeGNBibVLfR+mmWhuBlZu46cHYcFyZmS4UqEJZOmB4vXKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6702,8 +6702,8 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding-win32-arm64-msvc@0.0.6:
-    resolution: {integrity: sha512-4xyVffE2wzI1TAaJhXj3SYGEgPSlg5qwDJxu+8S77sMrFmqGFOkTbo3Jg/wI1FUFsvWCEJZz4ly4AY4CF7dxhA==}
+  /@ice/pack-binding-win32-arm64-msvc@0.0.8:
+    resolution: {integrity: sha512-0eSCL+WLk47Mc9ePPH7Wu36KAOAULFkPJJUssARi59XzfpyOodTy5vjXxoh0X5YXwzuySR4ljEitvSxvY5pgLw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -6711,8 +6711,8 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding-win32-x64-msvc@0.0.6:
-    resolution: {integrity: sha512-7rJF5RMzg2vdyBoSAS9nBSGKHUqWB9S5TN4oAqssrTWbBeCT5Sf8GHUfwzRKBc0a/3muSUPzRxOIKh6yCT859g==}
+  /@ice/pack-binding-win32-x64-msvc@0.0.8:
+    resolution: {integrity: sha512-Iw/JcTJSeuZnYecEEELuL5b67jngfQP3YEdYXwzUp3o4mn3AIKHeBeXN6ErsBb3r698M1AY9DXn2Bl9GyDOqHw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6720,17 +6720,17 @@ packages:
     dev: false
     optional: true
 
-  /@ice/pack-binding@0.0.6:
-    resolution: {integrity: sha512-nH2oBXgSOQfLILVBWDgxvmf2+UbibGGzNaynAxlSM+v1keQqGcy/me//wvwKDFlk/dWYvHQSv2vGZ3AUYshh5g==}
+  /@ice/pack-binding@0.0.8:
+    resolution: {integrity: sha512-kDtJvWdK6w+ooukRIRz25v+LNvEHDj7U9O+33nKf5uaHQFWMsbh8A+kM56yE8EF/BtrgEpxSujUynRmVfuwm0g==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@ice/pack-binding-darwin-arm64': 0.0.6
-      '@ice/pack-binding-darwin-universal': 0.0.6
-      '@ice/pack-binding-darwin-x64': 0.0.6
-      '@ice/pack-binding-linux-x64-gnu': 0.0.6
-      '@ice/pack-binding-linux-x64-musl': 0.0.6
-      '@ice/pack-binding-win32-arm64-msvc': 0.0.6
-      '@ice/pack-binding-win32-x64-msvc': 0.0.6
+      '@ice/pack-binding-darwin-arm64': 0.0.8
+      '@ice/pack-binding-darwin-universal': 0.0.8
+      '@ice/pack-binding-darwin-x64': 0.0.8
+      '@ice/pack-binding-linux-x64-gnu': 0.0.8
+      '@ice/pack-binding-linux-x64-musl': 0.0.8
+      '@ice/pack-binding-win32-arm64-msvc': 0.0.8
+      '@ice/pack-binding-win32-x64-msvc': 0.0.8
     dev: false
 
   /@ice/pkg@1.5.5:


### PR DESCRIPTION
Relate to https://github.com/ice-lab/icepack/pull/30

- [x] update binding version to support optimize package import
- [x] support both build-in and user provided packages to be optimized

在简单使用 antd 的项目，解析模块数量从 `2738` 下降到 `309`，启动时间优化从 `358ms` 到 `166ms`

![image](https://github.com/alibaba/ice/assets/4219965/03b8e44b-0c58-4082-b5f2-076d22af45eb)

![image](https://github.com/alibaba/ice/assets/4219965/f8d3b542-862e-4a02-bdd3-5eaa204aebef)


由于减小的压缩阶段的 treeshaking 处理，让整体 build 提升更加明显，从 `1300ms+` 提升值 `300ms+`

![image](https://github.com/alibaba/ice/assets/4219965/d40ab344-a68d-4f16-be13-9447ffb99bbb)
![image](https://github.com/alibaba/ice/assets/4219965/766939d6-b24c-4397-844e-da88805f40a1)

