### PR TITLE
fix(rax-compat): fix createElement runtime import

### DIFF
--- a/.changeset/famous-roses-hide.md
+++ b/.changeset/famous-roses-hide.md
@@ -1,0 +1,5 @@
+---
+'rax-compat': patch
+---
+
+fix createElement runtime import

--- a/packages/rax-compat/package.json
+++ b/packages/rax-compat/package.json
@@ -22,6 +22,7 @@
     "./find-dom-node": "./esm/find-dom-node.js",
     "./is-valid-element": "./esm/is-valid-element.js",
     "./unmount-component-at-node": "./esm/unmount-component-at-node.js",
+    "./runtime": "./esm/runtime/index.js",
     "./runtime/jsx-dev-runtime": "./esm/runtime/jsx-dev-runtime.js",
     "./runtime/jsx-runtime": "./esm/runtime/jsx-runtime.js",
     "./es2017": "./es2017/index.js"

--- a/packages/rax-compat/src/runtime/index.ts
+++ b/packages/rax-compat/src/runtime/index.ts
@@ -1,0 +1,1 @@
+export { createElement } from '../create-element.js';


### PR DESCRIPTION
修正了在特定情况下，swc 的转换代码会进行如下的代码转换：

```tsx
import Rax from 'rax-compat';

import { createElement } from 'rax-compat/runtime';
```

这个PR 为 rax-compat 提供了 `/runtime` 的 subpath。
