### PR TITLE
Fix: improve dev sourcemap

### DIFF
--- a/.changeset/serious-birds-hang.md
+++ b/.changeset/serious-birds-hang.md
@@ -1,0 +1,7 @@
+---
+'@ice/webpack-config': patch
+'@ice/rspack-config': patch
+'@ice/shared-config': patch
+---
+
+fix: imporve dev sourcemap

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { createRequire } from 'module';
-import { getDefineVars, getCompilerPlugins, getJsxTransformOptions, getAliasWithRoot, skipCompilePackages } from '@ice/shared-config';
+import { getDefineVars, getCompilerPlugins, getJsxTransformOptions, getAliasWithRoot, skipCompilePackages, getDevtoolValue } from '@ice/shared-config';
 import type { Config, ModifyWebpackConfig } from '@ice/shared-config/types';
 import type { Configuration, rspack as Rspack } from '@rspack/core';
 import lodash from '@ice/bundles/compiled/lodash/index.js';
@@ -71,6 +71,7 @@ const getConfig: GetConfig = async (options) => {
     configureWebpack = [],
     minimizerOptions = {},
     optimizePackageImports = [],
+    sourceMap,
   } = taskConfig || {};
   const isDev = mode === 'development';
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
@@ -151,8 +152,6 @@ const getConfig: GetConfig = async (options) => {
       rules: [
         {
           test: /\.(jsx?|tsx?|mjs)$/,
-          // Set enforce: 'post' to make sure the compilation-loader is executed after other transformers.
-          enforce: 'post',
           ...(excludeRule ? { exclude: new RegExp(excludeRule) } : {}),
           use: {
             loader: 'builtin:compilation-loader',
@@ -232,6 +231,7 @@ const getConfig: GetConfig = async (options) => {
     infrastructureLogging: {
       level: 'warn',
     },
+    devtool: getDevtoolValue(sourceMap),
     devServer: {
       allowedHosts: 'all',
       headers: {

--- a/packages/shared-config/src/index.ts
+++ b/packages/shared-config/src/index.ts
@@ -5,6 +5,7 @@ import getDefineVars from './getDefineVars.js';
 import getPostcssOpts from './getPostcssOpts.js';
 import getCSSModuleLocalIdent from './getCSSModuleLocalIdent.js';
 import getAliasWithRoot from './getAlias.js';
+import getDevtoolValue from './utils/getDevtool.js';
 
 export {
   getCSSModuleLocalIdent,
@@ -17,4 +18,5 @@ export {
   getDefineVars,
   getPostcssOpts,
   getAliasWithRoot,
+  getDevtoolValue,
 };

--- a/packages/shared-config/src/utils/getDevtool.ts
+++ b/packages/shared-config/src/utils/getDevtool.ts
@@ -1,0 +1,16 @@
+import type { Config } from '../types';
+
+interface GetDevtoolOptions<T = any> {
+  (sourceMap: Config['sourceMap']): T;
+}
+
+const getDevtoolValue: GetDevtoolOptions = (sourceMap) => {
+  if (typeof sourceMap === 'string') {
+    return sourceMap;
+  } else if (sourceMap === false) {
+    return false;
+  }
+  return 'source-map';
+};
+
+export default getDevtoolValue;

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -11,7 +11,7 @@ import ESlintPlugin from '@ice/bundles/compiled/eslint-webpack-plugin/index.js';
 import CopyPlugin from '@ice/bundles/compiled/copy-webpack-plugin/index.js';
 import type { NormalModule, Compiler, Configuration } from 'webpack';
 import type webpack from 'webpack';
-import { compilationPlugin, compileExcludes, getCompilerPlugins, getDefineVars, getAliasWithRoot } from '@ice/shared-config';
+import { compilationPlugin, compileExcludes, getCompilerPlugins, getDefineVars, getAliasWithRoot, getDevtoolValue } from '@ice/shared-config';
 import type { Config, ModifyWebpackConfig } from '@ice/shared-config/types.js';
 import configAssets from './config/assets.js';
 import configCss from './config/css.js';
@@ -427,12 +427,3 @@ export function getWebpackConfig(options: GetWebpackConfigOptions): Configuratio
     .reduce((result, next: ModifyWebpackConfig<Configuration, typeof webpack>) => next(result, ctx), webpackConfig);
 }
 
-function getDevtoolValue(sourceMap: Config['sourceMap']) {
-  if (typeof sourceMap === 'string') {
-    return sourceMap;
-  } else if (sourceMap === false) {
-    return false;
-  }
-
-  return 'source-map';
-}


### PR DESCRIPTION
Remove enforce post of compilation loader, otherwise the fast-refresh injection code will appear in source map.
![image](https://github.com/alibaba/ice/assets/4219965/d073f027-7063-4d00-97f6-1eba8c71ddce)

The order of rules will make sure that the compilation loader will be executed after custom transform plugin.