### PR TITLE
Fix: align the order and content of custom transformer with webpack

### DIFF
--- a/.changeset/gentle-trainers-check.md
+++ b/.changeset/gentle-trainers-check.md
@@ -1,0 +1,6 @@
+---
+'@ice/shared-config': patch
+'@ice/bundles': patch
+---
+
+fix: align the transform order and content with webpack mode

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "packageManager": "pnpm@8.9.2",
   "pnpm": {
     "patchedDependencies": {
-      "@rspack/core@0.5.4": "patches/@rspack__core@0.5.4.patch"
+      "@rspack/core@0.5.4": "patches/@rspack__core@0.5.4.patch",
+      "unplugin@1.6.0": "patches/unplugin@1.6.0.patch"
     }
   }
 }

--- a/packages/shared-config/src/getCompilerPlugins.ts
+++ b/packages/shared-config/src/getCompilerPlugins.ts
@@ -89,8 +89,10 @@ function getCompilerPlugins(rootDir: string, config: Config, compiler: Compiler,
     }));
   }
   if (clientBundlers.includes(compiler)) {
-    return compilerPlugins
+    const transformPlugins = compilerPlugins
       .map((plugin) => createUnplugin(() => getPluginTransform(plugin, transformOptions))[compiler]()) as Config['plugins'];
+    // Reverse the transformPlugins for rspack, because the unplugin order has been change in rspack mode.
+    return compiler === 'rspack' ? transformPlugins.reverse() : transformPlugins;
   } else {
     return compilerPlugins.map(plugin => getPluginTransform(plugin, transformOptions));
   }

--- a/patches/unplugin@1.6.0.patch
+++ b/patches/unplugin@1.6.0.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/index.js b/dist/index.js
+index 631e1459fbcb948d5089ae5432350c91d9853b5c..00cd831ddaf72e181f6260a99ce40e3ee5220f59 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1535,7 +1535,7 @@ function getRspackPlugin(factory) {
+           });
+           const externalModules = /* @__PURE__ */ new Set();
+           if (plugin.load) {
+-            compiler.options.module.rules.unshift({
++            compiler.options.module.rules.push({
+               enforce: plugin.enforce,
+               include(id) {
+                 return shouldLoad(id, plugin, externalModules);
+@@ -1549,7 +1549,7 @@ function getRspackPlugin(factory) {
+             });
+           }
+           if (plugin.transform) {
+-            compiler.options.module.rules.unshift({
++            compiler.options.module.rules.push({
+               enforce: plugin.enforce,
+               use(data) {
+                 return transformUse(data, plugin, TRANSFORM_LOADER);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index bca4a4f9ccf06032f8e8af17ec12307c9176b440..5be1848ae866cb181c486b59ecdbf26921b5e5c8 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1501,7 +1501,7 @@ function getRspackPlugin(factory) {
+           });
+           const externalModules = /* @__PURE__ */ new Set();
+           if (plugin.load) {
+-            compiler.options.module.rules.unshift({
++            compiler.options.module.rules.push({
+               enforce: plugin.enforce,
+               include(id) {
+                 return shouldLoad(id, plugin, externalModules);
+@@ -1515,7 +1515,7 @@ function getRspackPlugin(factory) {
+             });
+           }
+           if (plugin.transform) {
+-            compiler.options.module.rules.unshift({
++            compiler.options.module.rules.push({
+               enforce: plugin.enforce,
+               use(data) {
+                 return transformUse(data, plugin, TRANSFORM_LOADER);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@rspack/core@0.5.4':
     hash: cx7wc7uikmrb5dsrfcy5wrjzui
     path: patches/@rspack__core@0.5.4.patch
+  unplugin@1.6.0:
+    hash: z2z7uvjbiarznogeja262ejlha
+    path: patches/unplugin@1.6.0.patch
 
 importers:
 
@@ -1561,7 +1564,7 @@ importers:
         version: 4.9.5
       unplugin:
         specifier: 1.6.0
-        version: 1.6.0
+        version: 1.6.0(patch_hash=z2z7uvjbiarznogeja262ejlha)
       webpack:
         specifier: 5.88.2
         version: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
@@ -1768,7 +1771,7 @@ importers:
         version: 1.50.0
       unplugin:
         specifier: ^1.6.0
-        version: 1.6.0
+        version: 1.6.0(patch_hash=z2z7uvjbiarznogeja262ejlha)
       webpack:
         specifier: ^5.88.0
         version: 5.88.2(esbuild@0.17.16)
@@ -22550,7 +22553,7 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  /unplugin@1.6.0:
+  /unplugin@1.6.0(patch_hash=z2z7uvjbiarznogeja262ejlha):
     resolution: {integrity: sha512-BfJEpWBu3aE/AyHx8VaNE/WgouoQxgH9baAiH82JjX8cqVyi3uJQstqwD5J+SZxIK326SZIhsSZlALXVBCknTQ==}
     dependencies:
       acorn: 8.11.2
@@ -22558,6 +22561,7 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1
     dev: true
+    patched: true
 
   /unquote@1.1.1:
     resolution: {integrity: sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==}


### PR DESCRIPTION
Ensure that custom transformers, when running in rspack mode, are defined after the built-in loaders. This order is crucial because if a custom transformer precedes the built-in loaders, the code passed to the unplugin may differ from what would be passed in webpack mod.