### PR TITLE
Fix: ignore basename in single route mode when route do not match

### DIFF
--- a/.changeset/metal-turtles-design.md
+++ b/.changeset/metal-turtles-design.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: compat with the route path did not match when single route mode

--- a/packages/runtime/src/singleRouter.tsx
+++ b/packages/runtime/src/singleRouter.tsx
@@ -257,13 +257,13 @@ export const matchRoutes = (
   location: Partial<Location> | string,
   basename: string,
 ) => {
-  const pathname = typeof location === 'string' ? location : location.pathname;
+  const pathname = (typeof location === 'string' ? location : location.pathname) || '/';
 
-  let stripedPathname = stripBasename(pathname || '/', basename || '/');
+  let stripedPathname = stripBasename(pathname, basename || '/');
   if (!stripedPathname && basename !== '/') {
     // If pathname is not match, we should ignore the basename,
     // in case of the basename is customized.
-    stripedPathname = stripBasename(pathname || '/', '/');
+    stripedPathname = stripBasename(pathname, '/');
   }
   let branches = flattenRoutes(routes);
   if (branches.length === 1) {

--- a/packages/runtime/src/singleRouter.tsx
+++ b/packages/runtime/src/singleRouter.tsx
@@ -258,7 +258,8 @@ export const matchRoutes = (
   basename: string,
 ) => {
   const pathname = typeof location === 'string' ? location : location.pathname;
-  const stripedPathname = stripBasename(pathname || '/', basename || '/');
+  // If striped pathname is not match and return null, we should fallback to the default value "/".
+  const stripedPathname = stripBasename(pathname || '/', basename || '/') || '/';
   let branches = flattenRoutes(routes);
   if (branches.length === 1) {
     // Just one branch, no need to match.

--- a/packages/runtime/src/singleRouter.tsx
+++ b/packages/runtime/src/singleRouter.tsx
@@ -258,8 +258,13 @@ export const matchRoutes = (
   basename: string,
 ) => {
   const pathname = typeof location === 'string' ? location : location.pathname;
-  // If striped pathname is not match and return null, we should fallback to the default value "/".
-  const stripedPathname = stripBasename(pathname || '/', basename || '/') || '/';
+
+  let stripedPathname = stripBasename(pathname || '/', basename || '/');
+  if (!stripedPathname && basename !== '/') {
+    // If pathname is not match, we should ignore the basename,
+    // in case of the basename is customized.
+    stripedPathname = stripBasename(pathname || '/', '/');
+  }
   let branches = flattenRoutes(routes);
   if (branches.length === 1) {
     // Just one branch, no need to match.


### PR DESCRIPTION
Try to ignore `basename` in single route mode when route do not match.