### PR TITLE
chore: add export type of @ice/runtime

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/runtime
 
+## 1.4.4
+
+- chore: add ts type for `@ice/runtime/data-loader`
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/runtime/data-loader.d.ts
+++ b/packages/runtime/data-loader.d.ts
@@ -1,0 +1,1 @@
+export * from './esm/dataLoader';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Runtime module for ice.js",
   "type": "module",
   "types": "./esm/index.d.ts",


### PR DESCRIPTION
Add export type for `@ice/runtime/data-loader`.