### PR TITLE
Fix: remove deprecated api of addTargetExport

### DIFF
--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -76,9 +76,6 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     addExport: (declarationData: DeclarationData) => {
       generator.addDeclaration('framework', declarationData);
     },
-    addTargetExport: () => {
-      logger.error('`addTargetExport` is deprecated, please use `addExport` instead.');
-    },
     addExportTypes: (declarationData: DeclarationData) => {
       generator.addDeclaration('frameworkTypes', declarationData);
     },

--- a/packages/ice/src/types/plugin.ts
+++ b/packages/ice/src/types/plugin.ts
@@ -137,11 +137,6 @@ export interface ExtendsPluginAPI {
   registerTask: RegisterTask<Config>;
   generator: {
     addExport: AddExport;
-    /**
-     * @deprecated
-     * API will be removed in the next major version.
-     */
-    addTargetExport: () => void;
     addExportTypes: AddExport;
     addRuntimeOptions: AddExport;
     removeRuntimeOptions: RemoveExport;


### PR DESCRIPTION
The build process completing successfully even if the deprecated API addTargetExport is called. However this usage will lead to an unexpected runtime error.
To ensure reliability and prevent such issues, the deprecated api should be removed.