### PR TITLE
Fix: request config is not work in dataLoader compilation

### DIFF
--- a/.changeset/odd-crews-sing.md
+++ b/.changeset/odd-crews-sing.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: do not remove request config of dataLoader compilation in speedup mode

--- a/examples/with-request/src/app.tsx
+++ b/examples/with-request/src/app.tsx
@@ -1,7 +1,7 @@
 import { request as requestAPI, defineDataLoader } from 'ice';
 import { defineRequestConfig } from '@ice/plugin-request/types';
 
-export const dataLader = defineDataLoader(async () => {
+export const dataLoader = defineDataLoader(async () => {
   try {
     return await requestAPI('/user');
   } catch (err) {

--- a/packages/ice/src/bundler/rspack/getConfig.ts
+++ b/packages/ice/src/bundler/rspack/getConfig.ts
@@ -14,6 +14,7 @@ import {
 import { getReCompilePlugin, getServerPlugin, getSpinnerPlugin } from '../config/plugins.js';
 import { getExpandedEnvs } from '../../utils/runtimeEnv.js';
 import type { BundlerOptions, Context } from '../types.js';
+import type { PluginData } from '../../types/plugin.js';
 
 type GetConfig = (
   context: Context,
@@ -94,9 +95,17 @@ export const getDataLoaderConfig: GetDataLoaderRspackConfig = async (context, ta
     extendsPluginAPI: {
       generator,
     },
+    getAllPlugin,
   } = context;
   const { config } = task;
   const frameworkExports = generator.getExportList('framework', config.target);
+  const plugins = getAllPlugin(['keepExports']) as PluginData[];
+  let keepExports = ['dataLoader'];
+  plugins.forEach(plugin => {
+    if (plugin.keepExports) {
+      keepExports = keepExports.concat(plugin.keepExports);
+    }
+  });
   return await getRspackConfig({
     rootDir,
     rspack,
@@ -115,7 +124,7 @@ export const getDataLoaderConfig: GetDataLoaderRspackConfig = async (context, ta
         'data-loader': path.join(rootDir, RUNTIME_TMP_DIR, 'data-loader.ts'),
       },
       swcOptions: {
-        keepExports: ['dataLoader'],
+        keepExports,
       },
       splitChunks: false,
       redirectImports: frameworkExports,


### PR DESCRIPTION
Do not remove request config of dataLoader compilation in speedup mode.

Fix #6868