### PR TITLE
Fix: serverDataLoader is not work when dataLoader is not defined

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/runtime
 
+## 1.4.6
+
+- Fix: serverDataLoader is not work when dataLoader is not defined.
+
 ## 1.4.5
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Runtime module for ice.js",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -184,7 +184,8 @@ export function createRouteLoader(options: RouteLoaderOptions): LoaderFunction {
   }
 
   // if ICE_CORE_REMOVE_DATA_LOADER is true, dataLoaderConfig should be null and it already return above.
-  if (process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
+  // dataLoader should be always called in server side because of the serverDataLoader.
+  if (import.meta.renderer !== 'client' || process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
     let loader: Loader;
     let loaderOptions: DataLoaderOptions;
 
@@ -198,7 +199,7 @@ export function createRouteLoader(options: RouteLoaderOptions): LoaderFunction {
 
     const getData = (requestContext: RequestContext) => {
       let routeData: any;
-      if (process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
+      if (import.meta.renderer !== 'client' || process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
         if (globalLoader) {
           routeData = globalLoader.getData(routeId, { renderMode, requestContext });
         } else {

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -159,7 +159,7 @@ export function createRouteLoader(options: RouteLoaderOptions): LoaderFunction {
   const { requestContext: defaultRequestContext, renderMode, routeId } = options;
   const globalLoader = (typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__) ? (window as any).__ICE_DATA_LOADER__ : null;
 
-  if (process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
+  if (import.meta.renderer !== 'client' || process.env.ICE_CORE_REMOVE_DATA_LOADER !== 'true') {
     if (globalLoader) {
       dataLoaderConfig = globalLoader.getLoader(routeId);
     } else if (renderMode === 'SSG') {


### PR DESCRIPTION
`serverDataLoader` will been remove if dataLoader is not defined. 
Route loader should always been called in server side because of the serverDataLoader.