### PR TITLE
Fix: support https in speedup mode

### DIFF
--- a/.changeset/strong-zoos-applaud.md
+++ b/.changeset/strong-zoos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ice/rspack-config': patch
+---
+
+fix: support cli option `https` for speedup mode

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -108,6 +108,7 @@ const getConfig: GetConfig = async (options) => {
     redirectImports,
     fastRefresh,
     sourceMap,
+    https,
   } = taskConfig || {};
   const isDev = mode === 'development';
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
@@ -306,6 +307,7 @@ const getConfig: GetConfig = async (options) => {
       client: {
         logging: 'info',
       },
+      https,
       ...devServer,
       setupMiddlewares: middlewares,
     },


### PR DESCRIPTION
Resolve the issue of `--https` did not works in speedup mode.