### PR TITLE
Fix: add export of useAsyncValue in single route mode

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/runtime
 
+## 1.4.9
+
+Fix: add export of useAsyncValue in single route mode
+
 ## 1.4.8
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/runtime",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Runtime module for ice.js",
   "type": "module",
   "types": "./esm/index.d.ts",

--- a/packages/runtime/src/singleRouter.tsx
+++ b/packages/runtime/src/singleRouter.tsx
@@ -309,6 +309,10 @@ export const useRevalidator = () => {
   throw new Error('useRevalidator is not supported in single router mode');
 };
 
+export const useAsyncValue = () => {
+  throw new Error('useAsyncValue is not supported in single router mode');
+};
+
 export const getSingleRoute = async (
   routes: RouteItem[],
   basename: string,


### PR DESCRIPTION
Add export of `useAsyncValue` in single route mode.