### PR TITLE
feat: support ice2 main app and ice3 micro app

### DIFF
--- a/website/docs/guide/advanced/icestark.md
+++ b/website/docs/guide/advanced/icestark.md
@@ -96,6 +96,16 @@ export default defineConfig(() => ({
 }));
 ```
 
+但如果你的主应用是ice2，微应用是ice3，记得在ice3微应用的入口文件，通常是 app.tsx 文件中，调用 @ice/stark-app 中的 `setLibraryName` 方法，设置子应用模块的全局变量名称，通常是 package.json 中的 `name`。
+```ts
+import {setLibraryName} from '@ice/stark-app';
+
+setLibraryName('microName');
+
+// ...其他app.tsx的代码，如export mount, export unmount等等
+
+```
+
 应用入口可以配置相关生命周期执行行为（可选）：
 
 ```ts title="ice.config.mts"


### PR DESCRIPTION
ice2主应用，ice3子应用的话，加载子应用提示找不到生命周期。原因是ice2的主应用会去读window.ICESTARK.library，获取当前子应用在window下的模块对象，但是ice3子应用不会往window.ICESTARK.library设置子应用的模块名称，而是直接挂到window下，如window.['ice3AppName'] = {mount: xx, unmount: xx}，ice2读不到。

因此在@ice/plugin-stark插件增加了了一个参数，并在插件注入entryCode的部分，增加对这个参数的判断，如果有传入，就往window.ICESTARK.library设置子应用的模块名称。