### PR TITLE
Fix: compat with the navigator language return with underslash

### DIFF
--- a/packages/plugin-intl/CHANGELOG.md
+++ b/packages/plugin-intl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @ice/plugin-intl
 
+## 1.0.2
+
+fix: compat with the naviator language return with underslash.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/plugin-intl/CHANGELOG.md
+++ b/packages/plugin-intl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2
 
-fix: compat with the naviator language return with underslash.
+fix: compat with the navigator language return with underslash.
 
 ## 1.0.1
 

--- a/packages/plugin-intl/package.json
+++ b/packages/plugin-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-intl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "react intl plugin for ice.js 3.",
   "files": [
     "esm",

--- a/packages/plugin-intl/src/runtime.tsx
+++ b/packages/plugin-intl/src/runtime.tsx
@@ -9,9 +9,10 @@ const cache = createIntlCache();
 
 const getDefaultLocale = () => {
   // @ts-ignore
-  return (typeof window !== 'undefined' && window.__ICE_DEFAULT_LOCALE__) ||
+  const defaultLocale = (typeof window !== 'undefined' && window.__ICE_DEFAULT_LOCALE__) ||
     (typeof navigator !== 'undefined' && navigator.language) ||
     'zh-CN';
+  return defaultLocale.replace('_', '-');
 };
 
 const getLocaleMessages = () => {


### PR DESCRIPTION
Compat with the navigator language return with underslash.