### PR TITLE
feat: 新增触发重新渲染事件ICE_RERENDER

### DIFF
--- a/packages/plugin-stream-error/src/index.ts
+++ b/packages/plugin-stream-error/src/index.ts
@@ -14,13 +14,17 @@ const plugin: Plugin<PluginOptions> = (options = {}) => ({
       generator.addEntryCode((originalCode) => {
         return `${originalCode}
 if (import.meta.renderer === 'client') {
-  window.addEventListener('load', (event) => {
+  let hasRendered = false;
+  const tryRerender = (event) => {
     // _$ServerTimePoints will returned at the end of last stream,
     // if the value is undefined, try to re-render app with CSR.
-    if (${activeInDev ? '' : 'process.env.NODE_ENV === \'production\' && '}!window._$ServerTimePoints && window.__ICE_APP_CONTEXT__.renderMode === 'SSR') {
+    if (${activeInDev ? '' : 'process.env.NODE_ENV === \'production\' && '}!window._$ServerTimePoints && window.__ICE_APP_CONTEXT__.renderMode === 'SSR' && !hasRendered) {
+      hasRendered = true;
       render({ hydrate: false });
     }
-  });
+  };
+  window.addEventListener('load', tryRerender);
+  window.addEventListener('ICE_RERENDER', tryRerender);
 }`;
       });
     }


### PR DESCRIPTION
当前stream-error插件能够解决正常加载ice相关js的场景（通过script标签加载）。 但很多场景下，为了更好地渲染性能，业务测会通过`createElement('script')`方式异步加载ice的js， 这种情况下，很大概率load事件的触发会比 ice相关js加载完成更早完成，此时就没有办法做兜底rerender了。

PR中，新增一个window事件`ICE_RERENDER`，业务测在通过`createElement('script')`加载完成之后，dispatch一个`ICE_RERENDER`事件到window上，进行触发。 

同时为了避免race condition，在PR中新增了`hasRendered`状态位，保证最多只会被触发一次。

版本号和Changelog的变更，请@ClarkXia帮忙变更