### PR TITLE
fix: allow decorators-legacy syntax in js file

### DIFF
--- a/.changeset/early-tomatoes-beg.md
+++ b/.changeset/early-tomatoes-beg.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-jsx-plus': patch
+---
+
+fix: allow decorators-legacy syntax in js file

--- a/packages/plugin-jsx-plus/src/index.ts
+++ b/packages/plugin-jsx-plus/src/index.ts
@@ -29,6 +29,7 @@ const babelTransformOptions = {
       'topLevelAwait',
       'classProperties',
       'classPrivateMethods',
+      'decorators-legacy', // allowing decorators by default
     ],
     generatorOpts: {
       decoratorsBeforeExport: true,
@@ -107,7 +108,6 @@ const plugin: Plugin<JSXPlusOptions> = (options: JSXPlusOptions = {}) => ({
           if (/\.tsx?$/.test(id)) {
             // When routes file is a typescript file, add ts parser plugins.
             options.parserOpts.plugins.push('typescript');
-            options.parserOpts.plugins.push('decorators-legacy'); // allowing decorators by default
           }
 
           const { code, map } = transformSync(source, options);


### PR DESCRIPTION
Allow decorators-legacy syntax in js file.