### PR TITLE
Feat: support the simple solution of intl

### DIFF
--- a/.changeset/sweet-fishes-draw.md
+++ b/.changeset/sweet-fishes-draw.md
@@ -1,0 +1,5 @@
+---
+'@ice/plugin-intl': minor
+---
+
+feat: support the simple mode of intl solution

--- a/packages/plugin-intl/README.md
+++ b/packages/plugin-intl/README.md
@@ -71,3 +71,49 @@ function alertMessage() {
   alert(intl.formatMessage({ id: 'app.welcome' }));
 }
 ```
+
+## Simple mode
+
+Simple mode for remove the dependency of `react-intl`:
+
+Define the plugin in `ice.config.mts`:
+
+```ts
+import { defineConfig } from '@ice/app';
+import intl from '@ice/plugin-intl';
+
+export default defineConfig({
+  plugins: [
+    // Add intlSolution to remove the dependency of react-intl
+    intl({ intlSolution: 'simple' }),
+  ],
+});
+```
+
+When you use the `simple` mode, you can only use the `intl.formateMessage` function to get the locale message:
+
+```tsx
+import { ice } from 'ice';
+
+export default function Home() {
+  console.log(intl.formatMessage({ id: 'new' }));
+  return <h1>home</h1>;
+}
+```
+
+Function `intl.formatMessage` is limited, you can only use the syntax below to get the locale message:
+
+Simple Usage:
+
+```tsx
+intl.formatMessage({ id: 'app.welcome', defaultMessage: 'Welcome to my application!' });
+intl.formatMessage('app.welcome');
+```
+
+With Variables:
+
+```tsx
+intl.formatMessage({ id: 'app.welcome' }, { name: 'icejs' });
+```
+
+> Caution: the message Syntax only support the pattern like `{name}`.

--- a/packages/plugin-intl/package.json
+++ b/packages/plugin-intl/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": "./esm/index.js",
     "./runtime": "./esm/runtime.js",
+    "./runtime-simple": "./esm/runtime-simple.js",
     "./types": "./esm/types.js"
   },
   "sideEffects": false,

--- a/packages/plugin-intl/runtime-simple.d.ts
+++ b/packages/plugin-intl/runtime-simple.d.ts
@@ -1,0 +1,1 @@
+export * from './esm/runtime-simple';

--- a/packages/plugin-intl/src/index.ts
+++ b/packages/plugin-intl/src/index.ts
@@ -10,12 +10,14 @@ interface PluginOptions {
   localeMessagesKey?: string;
   defaultLocaleKey?: string;
   useCDN?: boolean;
+  intlSolution?: 'react-intl' | 'simple';
 }
 
 const plugin: Plugin<PluginOptions> = ({
   localeMessagesKey = '__LOCALE_MESSAGES__',
   defaultLocaleKey = '__DEFAULT_LOCALE__',
   useCDN = false,
+  intlSolution = 'react-intl',
 } = {}) => ({
   name: 'plugin-intl',
   setup: ({ generator, context, createLogger, watch }) => {
@@ -83,12 +85,19 @@ const plugin: Plugin<PluginOptions> = ({
     }
 
     // Add intl export from ice.
-    generator.addExport({
-      specifier: ['useIntl', 'intl'],
-      source: '@ice/plugin-intl/runtime',
-    });
+    if (intlSolution === 'simple') {
+      generator.addExport({
+        specifier: ['intl'],
+        source: '@ice/plugin-intl/runtime-simple',
+      });
+    } else {
+      generator.addExport({
+        specifier: ['useIntl', 'intl'],
+        source: '@ice/plugin-intl/runtime',
+      });
+    }
   },
-  runtime: '@ice/plugin-intl/runtime',
+  runtime: intlSolution === 'simple' ? '@ice/plugin-intl/runtime-simple' : '@ice/plugin-intl/runtime',
 });
 
 export default plugin;

--- a/packages/plugin-intl/src/intl-until.ts
+++ b/packages/plugin-intl/src/intl-until.ts
@@ -1,0 +1,15 @@
+export const EXPORT_NAME = 'locale';
+
+export const getDefaultLocale = () => {
+  // @ts-ignore
+  const defaultLocale = (typeof window !== 'undefined' && window.__ICE_DEFAULT_LOCALE__) ||
+    (typeof navigator !== 'undefined' && navigator.language) ||
+    'zh-CN';
+  return defaultLocale.replace('_', '-');
+};
+
+export const getLocaleMessages = () => {
+  // @ts-ignore
+  const localeMessages = typeof window === 'undefined' ? global.__ICE_LOCALE_MESSAGES__ : window.__ICE_LOCALE_MESSAGES__;
+  return localeMessages || {};
+};

--- a/packages/plugin-intl/src/runtime-simple.ts
+++ b/packages/plugin-intl/src/runtime-simple.ts
@@ -1,0 +1,46 @@
+import type { RuntimePlugin } from '@ice/runtime/types';
+import { getDefaultLocale, getLocaleMessages, EXPORT_NAME } from './intl-until.js';
+
+let currentLocale = getDefaultLocale();
+let localeMessages = getLocaleMessages();
+
+const runtime: RuntimePlugin = async ({
+  appContext,
+}) => {
+  const { appExport } = appContext;
+  const { getLocale, ...l } = appExport?.[EXPORT_NAME] || {};
+  if (Object.keys(l)?.length > 0) {
+    console.error('The locale config is not supported in the simple mode.');
+  }
+  const locale = getLocale ? getLocale() : getDefaultLocale();
+  currentLocale = locale;
+  // Refresh locale messages for server side because of import hoisting.
+  localeMessages = getLocaleMessages();
+};
+
+interface MessageDescriptor {
+  id: string;
+  defaultMessage?: string;
+}
+
+const intl = {
+  formatMessage: (message: MessageDescriptor | string, values?: Record<string, string>) => {
+    let messageId = typeof message === 'string' ? message : message.id;
+    const defaultMessage = typeof message === 'string' ? message : message.defaultMessage;
+    let content = localeMessages?.[currentLocale]?.[messageId];
+    if (!content) {
+      console.error(`Message with id "${messageId}" not found in locale "${currentLocale}"`);
+      return defaultMessage || messageId;
+    }
+    if (values) {
+      Object.keys(values).forEach((key) => {
+        content = content.replace(new RegExp(`{${key}}`, 'g'), values[key]);
+      });
+    }
+    return content;
+  },
+};
+
+export { intl };
+
+export default runtime;

--- a/packages/plugin-intl/src/runtime.tsx
+++ b/packages/plugin-intl/src/runtime.tsx
@@ -2,24 +2,10 @@ import * as React from 'react';
 import { createIntl, createIntlCache, RawIntlProvider, useIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import type { RuntimePlugin } from '@ice/runtime/types';
+import { getDefaultLocale, getLocaleMessages, EXPORT_NAME } from './intl-until.js';
 import type { LocaleConfig } from './types.js';
 
-const EXPORT_NAME = 'locale';
 const cache = createIntlCache();
-
-const getDefaultLocale = () => {
-  // @ts-ignore
-  const defaultLocale = (typeof window !== 'undefined' && window.__ICE_DEFAULT_LOCALE__) ||
-    (typeof navigator !== 'undefined' && navigator.language) ||
-    'zh-CN';
-  return defaultLocale.replace('_', '-');
-};
-
-const getLocaleMessages = () => {
-  // @ts-ignore
-  const localeMessages = typeof window === 'undefined' ? global.__ICE_LOCALE_MESSAGES__ : window.__ICE_LOCALE_MESSAGES__;
-  return localeMessages || {};
-};
 
 const defaultLocale = getDefaultLocale();
 let intl: IntlShape = createIntl({


### PR DESCRIPTION
Support new options `intlSolution` to support remove `react-intl` in the scenario of using `intl` for simple case. 