### PR TITLE
[WIP] Feat: support lazy compile of routes

### DIFF
--- a/packages/ice/src/bundler/rspack/index.ts
+++ b/packages/ice/src/bundler/rspack/index.ts
@@ -18,6 +18,7 @@ async function bundler(
     routeManifest,
     appConfig,
     hasDataLoader,
+    generator,
   } = options;
   let compiler: MultiCompiler;
   let dataLoaderCompiler: Compiler;
@@ -63,6 +64,7 @@ async function bundler(
     hooksAPI,
     taskConfigs,
     rspackConfigs,
+    generator,
   };
   if (command === 'start') {
     // @ts-expect-error dev-server has been pre-packed, so it will have different type.

--- a/packages/ice/src/bundler/rspack/start.ts
+++ b/packages/ice/src/bundler/rspack/start.ts
@@ -16,6 +16,7 @@ const start = async ({
   compiler,
   appConfig,
   hooksAPI,
+  generator,
 }: BuildOptions, dataLoaderCompiler?: Compiler) => {
   const { rootDir, applyHook, commandArgs, userConfig, extendsPluginAPI: { excuteServerEntry } } = context;
   const customMiddlewares = rspackConfigs[0].devServer?.setupMiddlewares;
@@ -34,6 +35,7 @@ const start = async ({
         mock: commandArgs.mock,
         rootDir,
         dataLoaderCompiler,
+        generator,
       });
       return customMiddlewares ? customMiddlewares(builtInMiddlewares, devServer) : builtInMiddlewares;
     },

--- a/packages/ice/src/bundler/types.ts
+++ b/packages/ice/src/bundler/types.ts
@@ -8,6 +8,7 @@ import type { ServerCompiler, GetAppConfig, GetRoutesConfig, GetDataloaderConfig
 import type { UserConfig } from '../types/userConfig.js';
 import type RouteManifest from '../utils/routeManifest.js';
 import type ServerRunner from '../service/ServerRunner.js';
+import type Generator from '../service/runtimeGenerator.js';
 
 export type Context = DefaultContext<Config, ExtendsPluginAPI>;
 
@@ -19,9 +20,11 @@ export interface BuildOptions {
   appConfig: BundlerOptions['appConfig'];
   hooksAPI: BundlerOptions['hooksAPI'];
   taskConfigs: BundlerOptions['taskConfigs'];
+  generator: Generator;
 }
 
 export interface BundlerOptions {
+  generator: Generator;
   taskConfigs: TaskConfig<Config>[];
   spinner: ora.Ora;
   hooksAPI: {

--- a/packages/ice/src/bundler/webpack/start.ts
+++ b/packages/ice/src/bundler/webpack/start.ts
@@ -27,6 +27,7 @@ export async function startDevServer(
     routeManifest,
     userConfig,
     appConfig,
+    generator,
   } = options;
   const routePaths = routeManifest.getFlattenRoute().sort((a, b) =>
     // Sort by length, shortest path first.
@@ -40,6 +41,7 @@ export async function startDevServer(
     ...defaultDevServerConfig,
     setupMiddlewares: (middlewares, devServer) => {
       const builtInMiddlewares = getMiddlewares(middlewares, {
+        generator,
         userConfig,
         routeManifest,
         getAppConfig: hooksAPI.getAppConfig,

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -221,6 +221,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const { userConfig } = ctx;
   const { routes: routesConfig, server, syntaxFeatures, polyfill } = userConfig;
 
+
   const coreEnvKeys = getCoreEnvKeys();
 
   const routesInfo = await generateRoutesInfo(rootDir, routesConfig, routeManifest.getRoutesDefinitions());
@@ -252,6 +253,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const { routeImports, routeDefinition } = getRoutesDefinition({
     manifest: routesInfo.routes,
     lazy,
+    compileRoutes: routesConfig.lazyCompile ? [] : undefined,
   });
   const loaderExports = hasExportAppData || Boolean(routesInfo.loaders);
   const hasDataLoader = Boolean(userConfig.dataLoader) && loaderExports;
@@ -301,6 +303,9 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     generator.addRenderFile('core/entry.server.ts.ejs', FALLBACK_ENTRY, { hydrate: false });
   }
 
+  if (routesConfig?.lazyCompile) {
+    generator.addRenderFile('core/empty.tsx.ejs', 'empty.tsx');
+  }
   if (typeof userConfig.dataLoader === 'object' && userConfig.dataLoader.fetcher) {
     const {
       packageName,
@@ -401,6 +406,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
         userConfig,
         configFile,
         hasDataLoader,
+        generator,
       };
       try {
         if (command === 'test') {

--- a/packages/ice/src/middlewares/proxyModuleMiddleware.ts
+++ b/packages/ice/src/middlewares/proxyModuleMiddleware.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { ExpressRequestHandler, Middleware } from 'webpack-dev-server';
+import type { NestedRouteManifest } from '@ice/route-manifest';
+import { getRoutesDefinition } from '../routes.js';
+import { RUNTIME_TMP_DIR } from '../constant.js';
+import type Generator from '../service/runtimeGenerator.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface Options {
+  manifest: NestedRouteManifest[];
+  generator: Generator;
+  rootDir: string;
+}
+
+export default function createRenderMiddleware(options: Options): Middleware {
+  const {
+    manifest,
+    generator,
+    rootDir,
+  } = options;
+  const accessedPath = new Set<string>();
+
+  const middleware: ExpressRequestHandler = async function (req, res, next) {
+    if (req.path === '/proxy-module') {
+      if (!accessedPath.has(req.query.pathname)) {
+        accessedPath.add(req.query.pathname);
+        const { routeImports, routeDefinition } = getRoutesDefinition({
+          manifest,
+          lazy: true,
+          compileRoutes: Array.from(accessedPath),
+        });
+        const templateDir = path.join(__dirname, '../../templates/core/');
+        generator.renderFile(
+          path.join(templateDir, 'routes.tsx.ejs'),
+          path.join(rootDir, RUNTIME_TMP_DIR, 'routes.tsx'),
+          { routeImports, routeDefinition },
+        );
+      }
+
+      res.send('');
+    } else {
+      next();
+    }
+  };
+
+  return {
+    name: 'proxy-module',
+    middleware,
+  };
+}

--- a/packages/ice/src/types/userConfig.ts
+++ b/packages/ice/src/types/userConfig.ts
@@ -153,6 +153,10 @@ export interface UserConfig {
      * inject initial route path for each route html.
      */
     injectInitialEntry?: boolean;
+    /**
+     * Enable lazy compile for routes.
+     */
+    lazyCompile?: boolean;
   };
   /**
    * Add ice.js plugin to customize framework config.

--- a/packages/ice/templates/core/empty.tsx.ejs
+++ b/packages/ice/templates/core/empty.tsx.ejs
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'ice';
+
+const ProxyModule =  () => {
+  const location = useLocation();
+  useEffect(() => {
+    fetch(`/proxy-module?pathname=${location.pathname}`);
+  }, []);
+  return <></>;
+};
+
+export default ProxyModule;


### PR DESCRIPTION
Enable routes compilation will help to optimize the dev startup performance of an application with a large number of pages, each route will only be built when it is actually accessed.
This is not to be confused with webpack's experimental.lazyCompilation, which can also be enabled by user configuration.