### PR TITLE
fix: avoid infinite setOutlets loop when config keepAlivePaths

### DIFF
--- a/.changeset/happy-cars-punch.md
+++ b/.changeset/happy-cars-punch.md
@@ -1,0 +1,5 @@
+---
+'@ice/runtime': patch
+---
+
+fix: avoid infinite setOutlets loop when config keepAlivePaths

--- a/packages/runtime/src/KeepAliveOutlet.tsx
+++ b/packages/runtime/src/KeepAliveOutlet.tsx
@@ -41,10 +41,11 @@ export default function KeepAliveOutlet(props: OutletProps) {
     if (outlets.length !== 0 ||
       outletRef.current?.pathname !== location.pathname) {
       let currentOutlets = outletRef.current ? [outletRef.current] : outlets;
+      // Check current path if exsist before filter, to avoid infinite setOutlets loop.
+      const result = currentOutlets.some(o => o.pathname === location.pathname);
       if (keepAlivePaths && keepAlivePaths.length > 0) {
         currentOutlets = currentOutlets.filter(o => keepAlivePaths.includes(o.pathname));
       }
-      const result = currentOutlets.some(o => o.pathname === location.pathname);
       if (!result) {
         setOutlets([
           ...currentOutlets,


### PR DESCRIPTION
Avoid infinite setOutlets loop when config keepAlivePaths.