### PR TITLE
fix: should re-export createElement for backwards compatibility

### DIFF
--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -34,7 +34,8 @@
     "jsx-runtime"
   ],
   "dependencies": {
-    "style-unit": "^3.0.4"
+    "style-unit": "^3.0.4",
+    "@swc/helpers": "^0.5.13"
   },
   "devDependencies": {
     "@ice/pkg": "^1.5.0",

--- a/packages/jsx-runtime/src/createElement.ts
+++ b/packages/jsx-runtime/src/createElement.ts
@@ -1,0 +1,5 @@
+import { createElement as reactCreateElement } from 'react';
+import { hijackElementProps } from './style.js';
+export function createElement(type: any, props: any, ...children: any[]) {
+  return reactCreateElement(type, hijackElementProps(props), ...children);
+}

--- a/packages/jsx-runtime/src/index.ts
+++ b/packages/jsx-runtime/src/index.ts
@@ -1,1 +1,2 @@
 export * from './prod.js';
+export { createElement } from 'react';

--- a/packages/jsx-runtime/src/index.ts
+++ b/packages/jsx-runtime/src/index.ts
@@ -1,2 +1,2 @@
 export * from './prod.js';
-export { createElement } from 'react';
+export { createElement } from './createElement.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,6 +1813,9 @@ importers:
 
   packages/jsx-runtime:
     dependencies:
+      '@swc/helpers':
+        specifier: ^0.5.13
+        version: 0.5.13
       style-unit:
         specifier: ^3.0.4
         version: 3.0.5
@@ -8568,6 +8571,12 @@ packages:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.0
+
+  /@swc/helpers@0.5.13:
+    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
 
   /@swc/types@0.1.4:
     resolution: {integrity: sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==}
@@ -22045,6 +22054,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.16.5
       webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
+    dev: true
 
   /terser-webpack-plugin@5.3.7(esbuild@0.17.16)(webpack@5.86.0):
     resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
@@ -22094,7 +22104,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.16.5
       webpack: 5.88.2(esbuild@0.17.16)
-    dev: true
 
   /terser-webpack-plugin@5.3.7(webpack@5.88.2):
     resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
@@ -23299,7 +23308,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
+      webpack: 5.88.2(esbuild@0.17.16)
 
   /webpack-dev-middleware@6.0.2(webpack@5.88.2):
     resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
@@ -23315,7 +23324,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
+      webpack: 5.88.2(esbuild@0.17.16)
     dev: true
 
   /webpack-dev-server@4.13.1(webpack@5.88.2):
@@ -23359,7 +23368,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
+      webpack: 5.88.2(esbuild@0.17.16)
       webpack-dev-middleware: 5.3.4(webpack@5.88.2)
       ws: 8.13.0
     transitivePeerDependencies:
@@ -23512,7 +23521,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.17.16)
+      webpack: 5.88.2(esbuild@0.17.16)
       webpack-dev-middleware: 5.3.4(webpack@5.88.2)
       ws: 8.13.0
     transitivePeerDependencies:
@@ -23661,6 +23670,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack@5.88.2(esbuild@0.17.16):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
@@ -23700,7 +23710,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpackbar@5.0.2(webpack@5.88.2):
     resolution: {integrity: sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==}


### PR DESCRIPTION
## 背景
> https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup

根据 React 文档说明，自定义的 `jsx runtime` 需要兼容一个异常 case，这个 case 需要使用 `createElement` 来进行 jsx 的转换，如果指定了 `importSource`，则会使用 importSource 导出的 createElement
![image](https://github.com/user-attachments/assets/f80278bd-8226-4985-bfd1-afa1145b2c75)


## Case
> 详细阅读 https://github.com/facebook/react/issues/20031#issuecomment-710346866

`<div {...obj} key="foo" />`： 即在 key 前有 spread object 的行为，会编译成使用 importSource(默认 react) 的 createElement 
```tsx
export default function Mod(props) {
  return (
    <>
      <div {...{ key: 123 }} style={props.style} key='sss'>
        hello mod
      </div>
    </>
  );
}
```
编译结果：
```js
import { createElement as _createElement } from "@ice/jsx-runtime";
import { Fragment as _Fragment, jsx as _jsx } from "@ice/jsx-runtime/jsx-runtime";
export default function Mod(props) {
    return _jsx(_Fragment, {
        children: _createElement("div", {
            key: 123,
            style: props.style,
            key: "sss"
        }, "hello mod")
    });
}
```

## 其他
- 保持了 `rpx` 单位的转化

## workaround
开发者可以通过把 key 移到 spread object 之前即可，即
```diff
export default function Mod(props) {
  return (
    <>
      <div 
+      key='sss' 
      {...{ key: 123 }} style={props.style}
-      key='sss' 
>
        hello mod
      </div>
    </>
  );
}

```
编译结果：
```js
import { jsx as _jsx, Fragment as _Fragment } from "@ice/jsx-runtime/jsx-runtime";
export default function Mod(props) {
    return _jsx(_Fragment, {
        children: _jsx("div", {
            key: 123,
            style: props.style,
            children: "hello mod"
        }, 'sss')
    });
}
```