### PR TITLE
Fix: splitChunk config in speedup mode

### DIFF
--- a/.changeset/breezy-ants-clap.md
+++ b/.changeset/breezy-ants-clap.md
@@ -1,0 +1,5 @@
+---
+'@ice/rspack-config': patch
+---
+
+fix: update splitChunk config

--- a/packages/rspack-config/src/splitChunks.ts
+++ b/packages/rspack-config/src/splitChunks.ts
@@ -88,7 +88,7 @@ export const getVendorStrategy = (options: Configuration['splitChunks']) => {
 const getSplitChunks = (_: string, strategy: string | boolean) => {
   if (strategy === false) {
     // Empty splitChunks configuration if strategy is false.
-    return {};
+    return { minChunks: Infinity, cacheGroups: { default: false } };
   } else if (typeof strategy === 'string' && ['page-vendors', 'vendors'].includes(strategy)) {
     const splitChunksOptions = strategy === 'page-vendors' ? { chunks: 'all' } : {};
     return getVendorStrategy(splitChunksOptions);

--- a/packages/rspack-config/src/splitChunks.ts
+++ b/packages/rspack-config/src/splitChunks.ts
@@ -87,7 +87,9 @@ export const getVendorStrategy = (options: Configuration['splitChunks']) => {
 
 const getSplitChunks = (_: string, strategy: string | boolean) => {
   if (strategy === false) {
-    return { minChunks: Infinity, cacheGroups: { default: false } };
+    // Set minChunks to a large number to disable the splitChunks feature.
+    // the value of Infinity is not work properly for this version of rspack.
+    return { minChunks: 100000, cacheGroups: { default: false } };
   } else if (typeof strategy === 'string' && ['page-vendors', 'vendors'].includes(strategy)) {
     const splitChunksOptions = strategy === 'page-vendors' ? { chunks: 'all' } : {};
     return getVendorStrategy(splitChunksOptions);

--- a/packages/rspack-config/src/splitChunks.ts
+++ b/packages/rspack-config/src/splitChunks.ts
@@ -87,7 +87,6 @@ export const getVendorStrategy = (options: Configuration['splitChunks']) => {
 
 const getSplitChunks = (_: string, strategy: string | boolean) => {
   if (strategy === false) {
-    // Empty splitChunks configuration if strategy is false.
     return { minChunks: Infinity, cacheGroups: { default: false } };
   } else if (typeof strategy === 'string' && ['page-vendors', 'vendors'].includes(strategy)) {
     const splitChunksOptions = strategy === 'page-vendors' ? { chunks: 'all' } : {};


### PR DESCRIPTION
Fix  the issue which `splitChunk: false` do not work properly in speedup mode.