### PR TITLE
useRequest 接口入参类型报错

### DIFF
--- a/packages/plugin-request/src/hooks.ts
+++ b/packages/plugin-request/src/hooks.ts
@@ -8,7 +8,7 @@ interface RequestResult<R, P extends any[]> extends Result<R, P> {
   requestAsync: Result<R, P>['runAsync'];
 }
 
-export function useRequest<TData, TParams extends any[] = []>(
+export function useRequest<TData, TParams extends any[]>(
   service: string | AxiosRequestConfig | Service<TData, TParams>,
   options?: Options<TData, TParams>,
   plugins?: Plugin<TData, TParams>[]) {


### PR DESCRIPTION
去掉默认空数组的赋值，避免 ts 报错
`useRequest(
    id => {
      return api.publishMicModuleDelete({ ids: [id] });
    }
  )`
对这种写法，做友好兼容