### PR TITLE
feat: support suspense event

### DIFF
--- a/examples/with-suspense-ssr/src/document.tsx
+++ b/examples/with-suspense-ssr/src/document.tsx
@@ -13,7 +13,13 @@ function Document() {
       </head>
       <body>
         <Main />
-        <script dangerouslySetInnerHTML={{ __html: 'window.addEventListener(\'suspense\', (d) => console.log(\'suspence event=\', d))' }} />
+        <script
+          defer
+          dangerouslySetInnerHTML={{
+            __html:
+              "window.addEventListener('load', () => console.log(performance.getEntriesByName('ice-suspense-loaded')));",
+          }}
+        />
         <Scripts async />
       </body>
     </html>

--- a/examples/with-suspense-ssr/src/document.tsx
+++ b/examples/with-suspense-ssr/src/document.tsx
@@ -16,8 +16,7 @@ function Document() {
         <script
           defer
           dangerouslySetInnerHTML={{
-            __html:
-              "window.addEventListener('load', () => console.log(performance.getEntriesByName('ice-suspense-loaded')));",
+            __html: "window.addEventListener('ice-suspense', (e) => console.log('ice-suspense', e));",
           }}
         />
         <Scripts async />

--- a/packages/runtime/src/Suspense.tsx
+++ b/packages/runtime/src/Suspense.tsx
@@ -158,7 +158,7 @@ export function withSuspense(Component) {
           <Data id={id} />
           <script
             dangerouslySetInnerHTML={{
-              __html: `performance && typeof performance.mark === "function" && performance.mark("ice-suspense-loaded", { detail: "suspense:${id}" })`,
+              __html: `window.dispatchEvent(new CustomEvent('ice-suspense', { detail: { id: '${id}' } }));`,
             }}
           />
         </SuspenseContext.Provider>

--- a/packages/runtime/src/Suspense.tsx
+++ b/packages/runtime/src/Suspense.tsx
@@ -156,6 +156,11 @@ export function withSuspense(Component) {
         <SuspenseContext.Provider value={suspenseState}>
           <Component {...componentProps} />
           <Data id={id} />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `performance && typeof performance.mark === "function" && performance.mark("ice-suspense-loaded", { detail: "suspense:${id}" })`,
+            }}
+          />
         </SuspenseContext.Provider>
       </React.Suspense>
     );
@@ -166,6 +171,13 @@ function Data(props) {
   const data = useSuspenseData();
 
   return (
-    <script dangerouslySetInnerHTML={{ __html: `!function(){window['${LOADER}'] = window['${LOADER}'] || {};window['${LOADER}']['${props.id}'] = ${JSON.stringify(data)}}();` }} />
+    <script
+      id={props.id ? `suspenseScript:${props.id}` : ''}
+      dangerouslySetInnerHTML={{
+        __html: `!function(){window['${LOADER}'] = window['${LOADER}'] || {};window['${LOADER}']['${
+          props.id
+        }'] = ${JSON.stringify(data)}}();`,
+      }}
+    />
   );
 }


### PR DESCRIPTION
https://github.com/alibaba/ice/pull/6994

改为使用 `performance.mark` 以避免事件监听时可能存在的时序问题

