### PR TITLE
fix: remove version check in compiled rspack

### DIFF
--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -54,7 +54,7 @@
     "@ice/shared-config": "workspace:*",
     "@ice/webpack-config": "workspace:*",
     "@ice/rspack-config": "workspace:*",
-    "@swc/helpers": "0.5.1",
+    "@swc/helpers": "0.5.15",
     "@types/express": "^4.17.14",
     "address": "^1.1.2",
     "build-scripts": "^2.1.2-0",

--- a/packages/jsx-runtime/package.json
+++ b/packages/jsx-runtime/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "style-unit": "^3.0.4",
-    "@swc/helpers": "^0.5.13"
+    "@swc/helpers": "^0.5.15"
   },
   "devDependencies": {
     "@ice/pkg": "^1.5.0",

--- a/packages/plugin-i18n/package.json
+++ b/packages/plugin-i18n/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@ice/jsx-runtime": "^0.3.1",
-    "@swc/helpers": "^0.5.1",
+    "@swc/helpers": "^0.5.15",
     "accept-language-parser": "^1.5.0",
     "universal-cookie": "^4.0.4",
     "url-join": "^5.0.0"

--- a/packages/rax-compat/package.json
+++ b/packages/rax-compat/package.json
@@ -100,7 +100,7 @@
   ],
   "dependencies": {
     "@ice/appear": "^0.2.1",
-    "@swc/helpers": "^0.5.1",
+    "@swc/helpers": "^0.5.15",
     "style-unit": "^3.0.5"
   },
   "devDependencies": {

--- a/patches/@rspack__core@1.2.2.patch
+++ b/patches/@rspack__core@1.2.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index 57955f085ab0ccf9cb514390a6d2472531a1e6c1..d333b82dcbc299c4580288955df54f1d77ff625b 100644
+index 57955f085ab0ccf9cb514390a6d2472531a1e6c1..07bf7c4a7addf83ebbb13bd38e56e271244e9945 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -694,6 +694,7 @@ __export(src_exports, {
@@ -31,7 +31,120 @@ index 57955f085ab0ccf9cb514390a6d2472531a1e6c1..d333b82dcbc299c4580288955df54f1d
  // src/builtin-plugin/css-extract/index.ts
  var import_binding11 = require("@rspack/binding");
  var import_node_path3 = require("path");
-@@ -20545,6 +20553,7 @@ module.exports = rspack;
+@@ -13128,110 +13136,9 @@ var Watching = class {
+ };
+ 
+ // src/util/bindingVersionCheck.ts
+-var import_node_fs3 = require("fs");
+-var import_node_path11 = __toESM(require("path"));
+-var NodePlatformArchToAbi = {
+-  android: {
+-    arm64: "",
+-    arm: "eabi"
+-  },
+-  win32: {
+-    x64: "msvc",
+-    ia32: "msvc",
+-    arm64: "msvc"
+-  },
+-  darwin: {
+-    x64: "",
+-    arm64: ""
+-  },
+-  freebsd: {
+-    x64: ""
+-  },
+-  linux: {
+-    x64: {
+-      musl: "musl",
+-      gnu: "gnu"
+-    },
+-    arm64: {
+-      musl: "musl",
+-      gnu: "gnu"
+-    },
+-    arm: "gnueabihf"
+-  }
+-};
+-function isMusl() {
+-  if (!process.report || typeof process.report.getReport !== "function") {
+-    try {
+-      const lddPath = require("child_process").execSync("which ldd").toString().trim();
+-      return (0, import_node_fs3.readFileSync)(lddPath, "utf8").includes("musl");
+-    } catch (e) {
+-      return true;
+-    }
+-  } else {
+-    const { glibcVersionRuntime } = process.report.getReport().header;
+-    return !glibcVersionRuntime;
+-  }
+-}
+-var BINDING_VERSION = require("@rspack/binding/package.json").version;
+-var CORE_VERSION = require("../package.json").version;
+-var getAddonPlatformArchAbi = () => {
+-  const { platform, arch } = process;
+-  let binding9 = "";
+-  binding9 += platform;
+-  const abi = NodePlatformArchToAbi[platform][arch];
+-  if (abi === void 0) return new Error(`unsupported cpu arch: ${arch}`);
+-  binding9 += `-${arch}`;
+-  if (typeof abi === "string") {
+-    binding9 += abi.length ? `-${abi}` : "";
+-  } else if (typeof abi === "object") {
+-    binding9 += `-${abi[isMusl() ? "musl" : "gnu"]}`;
+-  } else {
+-    return new Error(`unsupported abi: ${abi}`);
+-  }
+-  return binding9;
+-};
+-var result;
+ var checkVersion = () => {
+-  if (result !== void 0) {
+-    return result;
+-  }
+-  const platformArchAbi = getAddonPlatformArchAbi();
+-  if (platformArchAbi instanceof Error) {
+-    return result = platformArchAbi;
+-  }
+-  let ADDON_VERSION;
+-  try {
+-    const BINDING_PKG_DIR = import_node_path11.default.dirname(
+-      require.resolve("@rspack/binding/package.json")
+-    );
+-    const isLocal = (0, import_node_fs3.readdirSync)(BINDING_PKG_DIR).some(
+-      (item) => item === `rspack.${platformArchAbi}.node`
+-    );
+-    if (isLocal) {
+-      ADDON_VERSION = BINDING_VERSION;
+-    } else {
+-      ADDON_VERSION = require(require.resolve(`@rspack/binding-${platformArchAbi}/package.json`, {
+-        paths: [BINDING_PKG_DIR]
+-      })).version;
+-    }
+-  } catch (error) {
+-    if (error instanceof Error) {
+-      return result = new Error(
+-        `${error.toString()}. Maybe you forget to install the correct addon package ${`@rspack/binding-${platformArchAbi}`} or forget to build binding locally?`
+-      );
+-    }
+-    return result = new Error(error);
+-  }
+-  const isMatch = [CORE_VERSION, BINDING_VERSION, ADDON_VERSION].every(
+-    (v, _, arr) => v === arr[0]
+-  );
+-  if (!isMatch) {
+-    return result = new Error(
+-      `Unmatched version @rspack/core@${CORE_VERSION}, @rspack/binding@${BINDING_VERSION}, @rspack/binding-${platformArchAbi}@${ADDON_VERSION}.
+-Rspack requires these versions to be the same or you may have installed the wrong version. Otherwise, Rspack may not work properly.`
+-    );
+-  }
+-  return result = null;
++  // Remove version check, ice framework will handle it.
++  return null;
+ };
+ 
+ // src/builtin-plugin/html-plugin/taps.ts
+@@ -20545,6 +20452,7 @@ module.exports = rspack;
    Compiler,
    ContextReplacementPlugin,
    CopyRspackPlugin,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rspack/core@1.2.2':
-    hash: zafckinz57wigcrzsptv47qi5q
+    hash: fzipwdaf5fmyshxckn3sl2ndba
     path: patches/@rspack__core@1.2.2.patch
   unplugin@1.6.0:
     hash: z2z7uvjbiarznogeja262ejlha
@@ -1462,7 +1462,7 @@ importers:
         version: 0.5.15(react-refresh@0.14.0)(webpack-dev-server@5.0.4)(webpack@5.88.2)
       '@rspack/core':
         specifier: 1.2.2
-        version: 1.2.2(patch_hash=zafckinz57wigcrzsptv47qi5q)(@swc/helpers@0.5.1)
+        version: 1.2.2(patch_hash=fzipwdaf5fmyshxckn3sl2ndba)(@swc/helpers@0.5.15)
       '@rspack/dev-server':
         specifier: 1.0.10
         version: 1.0.10(@rspack/core@1.2.2)(@types/express@4.17.21)(webpack@5.88.2)
@@ -1703,8 +1703,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack-config
       '@swc/helpers':
-        specifier: 0.5.1
-        version: 0.5.1
+        specifier: 0.5.15
+        version: 0.5.15
       '@types/express':
         specifier: ^4.17.14
         version: 4.17.21
@@ -1789,7 +1789,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 1.2.2
-        version: 1.2.2(patch_hash=zafckinz57wigcrzsptv47qi5q)(@swc/helpers@0.5.1)
+        version: 1.2.2(patch_hash=fzipwdaf5fmyshxckn3sl2ndba)(@swc/helpers@0.5.15)
       '@rspack/dev-server':
         specifier: 1.0.10
         version: 1.0.10(@rspack/core@1.2.2)(@types/express@4.17.21)(webpack@5.88.2)
@@ -1845,7 +1845,7 @@ importers:
   packages/jsx-runtime:
     dependencies:
       '@swc/helpers':
-        specifier: ^0.5.13
+        specifier: ^0.5.15
         version: 0.5.15
       style-unit:
         specifier: ^3.0.4
@@ -2024,7 +2024,7 @@ importers:
         specifier: ^0.3.1
         version: link:../jsx-runtime
       '@swc/helpers':
-        specifier: ^0.5.1
+        specifier: ^0.5.15
         version: 0.5.15
       accept-language-parser:
         specifier: ^1.5.0
@@ -2379,7 +2379,7 @@ importers:
         specifier: ^0.2.1
         version: link:../appear
       '@swc/helpers':
-        specifier: ^0.5.1
+        specifier: ^0.5.15
         version: 0.5.15
       style-unit:
         specifier: ^3.0.5
@@ -2427,7 +2427,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 1.2.2
-        version: 1.2.2(patch_hash=zafckinz57wigcrzsptv47qi5q)(@swc/helpers@0.5.1)
+        version: 1.2.2(patch_hash=fzipwdaf5fmyshxckn3sl2ndba)(@swc/helpers@0.5.15)
 
   packages/runtime:
     dependencies:
@@ -8290,7 +8290,7 @@ packages:
       '@rspack/binding-win32-x64-msvc': 1.2.2
     dev: true
 
-  /@rspack/core@1.2.2(patch_hash=zafckinz57wigcrzsptv47qi5q)(@swc/helpers@0.5.1):
+  /@rspack/core@1.2.2(patch_hash=fzipwdaf5fmyshxckn3sl2ndba)(@swc/helpers@0.5.15):
     resolution: {integrity: sha512-EeHAmY65Uj62hSbUKesbrcWGE7jfUI887RD03G++Gj8jS4WPHEu1TFODXNOXg6pa7zyIvs2BK0Bm16Kwz8AEaQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -8305,7 +8305,7 @@ packages:
       '@module-federation/runtime-tools': 0.8.4
       '@rspack/binding': 1.2.2
       '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.1
+      '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001690
     dev: true
     patched: true
@@ -8316,7 +8316,7 @@ packages:
     peerDependencies:
       '@rspack/core': '*'
     dependencies:
-      '@rspack/core': 1.2.2(patch_hash=zafckinz57wigcrzsptv47qi5q)(@swc/helpers@0.5.1)
+      '@rspack/core': 1.2.2(patch_hash=fzipwdaf5fmyshxckn3sl2ndba)(@swc/helpers@0.5.15)
       chokidar: 3.6.0
       connect-history-api-fallback: 2.0.0
       express: 4.21.2
@@ -8765,11 +8765,6 @@ packages:
 
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  /@swc/helpers@0.5.1:
-    resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
-    dependencies:
-      tslib: 2.8.1
 
   /@swc/helpers@0.5.15:
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}


### PR DESCRIPTION
This pull request includes several updates and patches across multiple packages, primarily focusing on updating the `@swc/helpers` dependency and modifying the version check in `@rspack/core`.