### PR TITLE
Fix: glob pattern for document file

### DIFF
--- a/.changeset/metal-poems-dance.md
+++ b/.changeset/metal-poems-dance.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: glob pattern for document

--- a/packages/ice/src/utils/hasDocument.ts
+++ b/packages/ice/src/utils/hasDocument.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import fg from 'fast-glob';
 
 export default function hasDocument(rootDir: string) {
-  const document = fg.sync('document.{tsx,ts,jsx.js}', {
+  const document = fg.sync('document.{tsx,ts,jsx,js}', {
     cwd: path.join(rootDir, 'src'),
   });
   return document.length > 0;


### PR DESCRIPTION
This pull request includes a fix to the glob pattern for document files in the `@ice/app` package. The most important changes are:

Fixes:

* [`.changeset/metal-poems-dance.md`](diffhunk://#diff-1576c0734f81ee7dc1657c0d1d9b75a6807b9e9bcc1ab5dff3ada207aece80c8R1-R5): Added a changeset entry to document the patch fix for the glob pattern.
* [`packages/ice/src/utils/hasDocument.ts`](diffhunk://#diff-41f2637c3932d33b7526cfc223948f7e2bb455fdb5206872d133d0184ffaf102L5-R5): Corrected the glob pattern to properly include `.js` files by changing `document.{tsx,ts,jsx.js}` to `document.{tsx,ts,jsx,js}`.