### PR TITLE
Removed atom in the IDE section

### DIFF
--- a/website/docs/guide/basic/development.md
+++ b/website/docs/guide/basic/development.md
@@ -56,7 +56,6 @@ nrm use taobao
 - [Visual Studio Code](https://code.visualstudio.com/)（推荐）
 - [WebStorm](https://www.jetbrains.com/webstorm/)（推荐）
 - [Sublime Text](https://www.sublimetext.com/)
-- [Atom](https://atom.io/)
 
 ## 小程序开发者工具
 


### PR DESCRIPTION
Atom is no longer maintained, the team recommends to use other code editors like VSCode.

https://github.blog/news-insights/product-news/sunsetting-atom/