### PR TITLE
Feat: add support for custom loaders in rspack configuration

### DIFF
--- a/.changeset/little-dodos-impress.md
+++ b/.changeset/little-dodos-impress.md
@@ -1,0 +1,5 @@
+---
+'@ice/rspack-config': patch
+---
+
+feat: add support for custom loaders in rspack configuration

--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { createRequire } from 'module';
 import { getDefineVars, getCompilerPlugins, getJsxTransformOptions, getAliasWithRoot, skipCompilePackages, getDevtoolValue } from '@ice/shared-config';
 import type { Config, ModifyWebpackConfig, ImportDeclaration } from '@ice/shared-config/types';
-import type { Configuration, rspack as Rspack } from '@rspack/core';
+import type { Configuration, rspack as Rspack, RuleSetRule } from '@rspack/core';
 import lodash from '@ice/bundles/compiled/lodash/index.js';
 import { coreJsPath } from '@ice/bundles';
 import RefreshPlugin from '@ice/bundles/esm/plugin-refresh.js';
@@ -111,6 +111,7 @@ const getConfig: GetConfig = async (options) => {
     https,
     enableCopyPlugin,
     cssExtensionAlias,
+    loaders,
   } = taskConfig || {};
   const isDev = mode === 'development';
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
@@ -205,6 +206,7 @@ const getConfig: GetConfig = async (options) => {
       },
     }];
   }
+  const additionalRules = (loaders || []) as RuleSetRule[];
   const config: Configuration = {
     entry: entry || {
       main: [path.join(rootDir, runtimeTmpDir, 'entry.client.tsx')],
@@ -263,6 +265,7 @@ const getConfig: GetConfig = async (options) => {
           postcssOptions: postcss,
           extensionAlias: cssExtensionAlias ?? [],
         }),
+        ...additionalRules,
       ],
     },
     resolve: {


### PR DESCRIPTION
This pull request introduces a new feature to the `rspack-config` package, allowing support for custom loaders in the rspack configuration. The most important changes include adding a new parameter for custom loaders and updating the configuration to include these loaders.