### PR TITLE
chore: update plugin option type of plugin-icestark

### DIFF
--- a/packages/plugin-icestark/CHANGELOG.md
+++ b/packages/plugin-icestark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+- fix: plugin type definition of `library`
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/plugin-icestark/package.json
+++ b/packages/plugin-icestark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/plugin-icestark",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Easy use `icestark` in icejs.",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "",

--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -2,7 +2,7 @@ import type { Plugin } from '@ice/app/types';
 
 interface PluginOptions {
   type: 'child' | 'framework';
-  library?: string;
+  library?: string | string[];
 }
 
 const PLUGIN_NAME = '@ice/plugin-icestark';


### PR DESCRIPTION
This pull request includes changes to the `@ice/plugin-icestark` package to fix a type definition and update the version. The most important changes include fixing the plugin type definition for `library` and updating the version in the `package.json` file.