### PR TITLE
Fix/provide

### DIFF
--- a/.changeset/gold-foxes-protect.md
+++ b/.changeset/gold-foxes-protect.md
@@ -1,0 +1,7 @@
+---
+'@ice/app': patch
+---
+
+fix: compat esbuild config
+- use AST to get file exports instead of using import()
+- respect compileDependencies in webpack mode

--- a/packages/ice/src/service/webpackServerCompiler/compiler.ts
+++ b/packages/ice/src/service/webpackServerCompiler/compiler.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import fse from 'fs-extra';
 import { swc } from '@ice/bundles';
 import webpack from '@ice/bundles/compiled/webpack/index.js';
 import { getWebpackConfig } from '@ice/webpack-config';
@@ -46,11 +45,12 @@ export class WebpackServerCompiler {
   }
 
   private async createWebpackConfig(options: {
+    compileIncludes: Array<RegExp>;
     userServerConfig: UserConfig['server'];
     rootDir: string;
     [key: string]: any;
   }) {
-    const { userServerConfig } = options;
+    const { userServerConfig, compileIncludes } = options;
     const { webpackConfig = {} } = userServerConfig;
     const definitions = await this.getEsbuildInject();
     return getWebpackConfig({
@@ -92,7 +92,7 @@ export class WebpackServerCompiler {
         define: options.define,
         optimization: { ...webpackConfig.optimization } as any,
         minify: options.minify,
-        compileIncludes: webpackConfig.transformInclude,
+        compileIncludes,
         swcOptions: {
           compilationConfig: {
             jsc: {

--- a/packages/ice/src/types/userConfig.ts
+++ b/packages/ice/src/types/userConfig.ts
@@ -251,14 +251,7 @@ export interface UserConfig {
     /**
      * webpack config, only works when bundler is webpack
      */
-    webpackConfig?: Pick<WebpackConfiguration, 'plugins' | 'optimization' | 'output' | 'module'> & {
-      /**
-       * we exclude the node_modules/* by default
-       *
-       * use this if you need to transform some packages inside of node_modues
-       */
-      transformInclude?: Array<RegExp | string>;
-    };
+    webpackConfig?: Pick<WebpackConfiguration, 'plugins' | 'optimization' | 'output' | 'module'>;
   };
   /**
    * Optimization options for build.

--- a/packages/ice/src/utils/getExportsVariables.ts
+++ b/packages/ice/src/utils/getExportsVariables.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import { swc } from '@ice/bundles';
+
+/**
+ * Parses a JavaScript file and extracts all named exports.
+ *
+ * @param {string} filePath The path to the JavaScript file.
+ * @returns {Promise<string[]>} A promise that resolves to an array of collected export names.
+ */
+export async function getExportsVariables(filePath: string) {
+  const fileContent = await fs.promises.readFile(filePath, 'utf-8');
+  const ast = await swc.parse(fileContent, {
+    syntax: 'ecmascript', // or 'typescript' if you might have TypeScript files
+    jsx: true, // Set to true if you might have JSX
+  });
+
+  const exportNames = new Set();
+
+  for (const node of ast.body) {
+    if (node.type === 'ExportDeclaration') {
+      // Handles: export const a = 1; export class MyClass {}
+      if (node.declaration) {
+        if (node.declaration.type === 'VariableDeclaration') {
+          for (const declarator of node.declaration.declarations) {
+            if (declarator.id.type === 'Identifier') {
+              exportNames.add(declarator.id.value);
+            } else if (declarator.id.type === 'ObjectPattern') {
+              // Handles object destructuring in export: export const { a, b } = {};
+              for (const prop of declarator.id.properties) {
+                if (prop.type === 'Property' && prop.key.type === 'Identifier') {
+                  exportNames.add(prop.key.value);
+                }
+              }
+            }
+          }
+        } else if (node.declaration.type === 'FunctionDeclaration' || node.declaration.type === 'ClassDeclaration') {
+          if (node.declaration.identifier) {
+            exportNames.add(node.declaration.identifier.value);
+          }
+        }
+      }
+    } else if (node.type === 'ExportNamedDeclaration') {
+      // Handles: export { foo } from './foo'; export { foo as foo1 };
+      // export * as aaa from './aaa'
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ExportSpecifier') {
+          exportNames.add((specifier.exported || specifier.orig).value);
+        } else if (specifier.type === 'ExportNamespaceSpecifier') {
+          exportNames.add(specifier.name.value);
+        }
+      }
+    } else if (node.type === 'ExportDefaultExpression') {
+      // Handles: export default ...
+      exportNames.add('default');
+    }
+  }
+
+  return Array.from(exportNames);
+}

--- a/packages/ice/tests/fixtures/exports.ts
+++ b/packages/ice/tests/fixtures/exports.ts
@@ -1,0 +1,11 @@
+//  @ts-nocheck
+export const a = 1;
+export function myFunc() {}
+export class MyClass {}
+const b = 2;
+export { b as c, myFunc as anotherFunc };
+export { foo } from './foo';
+export { default as bar } from './bar';
+export default 'hello';
+export { baz as qux } from './baz';
+export * as aaa from './aaa'

--- a/packages/ice/tests/getExportsVariables.test.ts
+++ b/packages/ice/tests/getExportsVariables.test.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from 'vitest';
+import { getExportsVariables } from '../src/utils/getExportsVariables';
+
+const __dirname = fileURLToPath(path.dirname(import.meta.url));
+
+test('getExportsVariables', async () => {
+  const exports = await getExportsVariables(path.resolve(__dirname, './fixtures/exports.ts'));
+  expect(exports).toStrictEqual(['a', 'myFunc', 'MyClass', 'c', 'anotherFunc', 'foo', 'bar', 'default', 'qux', 'aaa']);
+});


### PR DESCRIPTION
- 修复webpack provide  兼容 esbuild inject 逻辑，由于import()在获取内容时会执行代码，现改为 ast 解析获取
- webpack transformInclude 改为读取 `compileDependencies`， 不再设有单独的配置