### PR TITLE
fix(miniapp-runtime): enter same page twice then exit should not throw error

### DIFF
--- a/.changeset/six-zebras-sniff.md
+++ b/.changeset/six-zebras-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ice/miniapp-runtime': patch
+---
+
+fix: enter same page twice then exit should not throw error

--- a/packages/miniapp-runtime/src/dsl/common.ts
+++ b/packages/miniapp-runtime/src/dsl/common.ts
@@ -130,7 +130,7 @@ export function createPageConfig(
       this.config = miniappPageConfig || {};
 
       // this.$icePath 是页面唯一标识
-      const uniqueOptions = Object.assign({}, options);
+      const uniqueOptions = Object.assign({}, options, { $iceTimestamp: Date.now() });
       const $icePath = this.$icePath = getPath(id, uniqueOptions);
       // this.$iceParams 作为暴露给开发者的页面参数对象，可以被随意修改
       if (this.$iceParams == null) {


### PR DESCRIPTION
小程序先进入同一个页面两次，然后退出，此时触发生命周期事件会报错。
主要由两个原因：
- 页面的 id 使用的是路径，会导致同一个页面打开多次的时候冲突，从而让上一个页面退出后把后一个页面的事件存储实例也清除了。解决方式就是给 id 添加一个时间戳，保证每个页面的唯一性
- 在触发生命周期的方法中，没有正确判断为空的情况。解决方法是判空

