### PR TITLE
Feat: support externals field in assets-manifest (#7116)

### DIFF
--- a/.changeset/fluffy-items-argue.md
+++ b/.changeset/fluffy-items-argue.md
@@ -1,0 +1,6 @@
+---
+'@ice/plugin-externals': patch
+'@ice/runtime': patch
+---
+
+fix: support externals field in assets-manifest

--- a/packages/plugin-externals/src/webpack-plugin.ts
+++ b/packages/plugin-externals/src/webpack-plugin.ts
@@ -26,7 +26,9 @@ export default class InjectExternalScriptsWebpackPlugin {
           if (assetsManifest) {
             const json = JSON.parse(assetsManifest.source().toString());
             delete compilation.assets[ASSET_MANIFEST_JSON_NAME];
-            json.entries.main.unshift(...this.options.externals);
+            // Ensure externals array exists and add new externals at the beginning.
+            json.externals ||= [];
+            json.externals.unshift(...this.options.externals);
             compilation.emitAsset(
               ASSET_MANIFEST_JSON_NAME,
               new webpack.sources.RawSource(JSON.stringify(json)),

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -129,6 +129,9 @@ export const Scripts: ScriptsType = (props: ScriptsProps) => {
   return (
     <>
       <Data ScriptElement={ScriptElement} />
+      {assetsManifest.externals?.map(external => (
+        <ScriptElement key={external} src={external} {...rest} data-external-script />
+      ))}
       {
         routeScripts.map(routeScriptProps => {
           return <ScriptElement key={routeScriptProps.src} {...rest} {...routeScriptProps} data-route-script />;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -205,6 +205,7 @@ export interface RouteModules {
 }
 
 export interface AssetsManifest {
+  externals?: string[];
   dataLoader?: string;
   publicPath: string;
   entries: {


### PR DESCRIPTION
This pull request introduces changes to support an `externals` field in the `assets-manifest` and ensures external scripts are properly handled in the runtime. The most important changes include updating the `assets-manifest` structure, modifying the webpack plugin to manage external scripts, and enhancing the runtime to render these external scripts dynamically.