### PR TITLE
Fix: recompile server bundle when assets manifest changed

### DIFF
--- a/.changeset/big-cats-act.md
+++ b/.changeset/big-cats-act.md
@@ -1,0 +1,5 @@
+---
+'@ice/app': patch
+---
+
+fix: recompile server bundle when assets manifest changed


### PR DESCRIPTION
This pull request introduces a fix to ensure the server bundle is recompiled whenever the assets manifest changes. The changes involve detecting modifications to the assets manifest and triggering a rebuild if necessary.