### PR TITLE
fix: rootId not working when integrating with single-spa (fix #7128)

### DIFF
--- a/packages/plugin-icestark/src/index.ts
+++ b/packages/plugin-icestark/src/index.ts
@@ -9,7 +9,7 @@ const PLUGIN_NAME = '@ice/plugin-icestark';
 const plugin: Plugin<PluginOptions> = ({ type, library }) => ({
   name: PLUGIN_NAME,
   setup: ({ onGetConfig, context, generator, modifyUserConfig }) => {
-    const libraryName = library || context.pkg?.name as string || 'microApp';
+    const libraryName = library || (context.pkg?.name as string) || 'microApp';
     onGetConfig((config) => {
       config.configureWebpack ??= [];
       config.configureWebpack.push((webpackConfig) => {
@@ -52,12 +52,13 @@ export async function mount(props) {
     // Props of container if conflict with render node in ice, it may cause node overwritten.
     let runtimeOptions = props;
     if (props.singleSpa) {
-      const iceContainer = props.container?.querySelector('#ice-container');
+      const targetId = app?.default?.app?.rootId || 'ice-container'
+      const iceContainer = props.container?.querySelector('#' + targetId);
       if (iceContainer) {
         runtimeOptions = {...props, container: iceContainer };
       } else {
         const ele = document.createElement('div');
-        ele.id = 'ice-container';
+        ele.id = targetId;
         props.container.appendChild(ele);
         runtimeOptions = {...props, container: ele };
       }
@@ -72,7 +73,7 @@ export async function unmount(props) {
   // Reset root to null when app unmount.
   root = null;
 }`;
-});
+      });
     } else {
       // Plugin icestark do not support ssr yet.
       modifyUserConfig('ssr', false);


### PR DESCRIPTION
ice3作为子应用，在与使用single-spa的主应用集成时，会忽略app.tsx中配置的app.rootId，而使用固定的#ice-container，导致依赖于rootId的方案全部失败。  

本pr改动点在于修改了plugin-icestark编译期的generator.addEntryCode，以在运行时获取正确的rootId，原先的#ice-container作为兜底选项。

相关issue: #7128 