### PR TITLE
Fix `disappeard` -> `disappeared` typo in appear README

### DIFF
--- a/packages/appear/README.md
+++ b/packages/appear/README.md
@@ -18,7 +18,7 @@ export default function Home() {
         console.log('Something has been shown.')
       }}
       onDisappear={() => {
-        console.log('Something has disappeard.')
+        console.log('Something has disappeared.')
       }}
     >
       Anything you want to show.


### PR DESCRIPTION
Line 21 of `packages/appear/README.md` has `disappeard` (missing letter) inside the `onDisappear` console.log example.