### PR TITLE
fix: support cjs files in compileDependencies (fix #7181)

### DIFF
--- a/packages/rspack-config/src/index.ts
+++ b/packages/rspack-config/src/index.ts
@@ -227,7 +227,7 @@ const getConfig: GetConfig = async (options) => {
     module: {
       rules: [
         {
-          test: /\.(jsx?|tsx?|mjs)$/,
+          test: /\.(jsx?|tsx?|mjs|cjs)$/,
           ...(excludeRule ? { exclude: new RegExp(excludeRule) } : {}),
           use: {
             loader: 'builtin:compilation-loader',

--- a/packages/shared-config/src/unPlugins/compilation.ts
+++ b/packages/shared-config/src/unPlugins/compilation.ts
@@ -63,7 +63,7 @@ const compilationPlugin = (options: Options): UnpluginOptions => {
     return /(.*)src\/app.(ts|tsx|js|jsx)/.test(id);
   }
 
-  const extensionRegex = /\.(jsx?|tsx?|mjs)$/;
+  const extensionRegex = /\.(jsx?|tsx?|mjs|cjs)$/;
   return {
     name: 'compilation-plugin',
     transformInclude(id) {

--- a/packages/shared-config/tests/compileDependencies.test.ts
+++ b/packages/shared-config/tests/compileDependencies.test.ts
@@ -1,0 +1,58 @@
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, describe, it } from 'vitest';
+import compilationPlugin from '../src/unPlugins/compilation';
+import compileExcludes from '../src/compileExcludes';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Bundler-style ids use forward slashes; match compileDependencies RegExp sources. */
+const toPosix = (p: string) => p.split(path.sep).join('/');
+
+/**
+ * Mirrors compileDependencies -> compileIncludes for a single package name
+ * (non-speed-up mode), so dependency paths under node_modules match.
+ */
+const compileIncludesForPkg = (pkg: string) => [new RegExp(`node_modules/?.+${pkg}/`)];
+
+describe('compileDependencies (compilation transformInclude)', () => {
+  const rootDir = path.join(__dirname, '..');
+
+  const createPlugin = (compileIncludes: (string | RegExp)[]) =>
+    compilationPlugin({
+      rootDir,
+      mode: 'production',
+      fastRefresh: false,
+      compileIncludes,
+      compileExcludes,
+      enableEnv: true,
+    });
+
+  it('includes .cjs files from a dependency matched by compileIncludes in the transpile pipeline', () => {
+    const { transformInclude, transform } = createPlugin(compileIncludesForPkg('animejs'));
+    const id = toPosix(path.join(rootDir, 'node_modules', 'animejs', 'dist', 'modules', 'index.cjs'));
+
+    expect(transformInclude!(id)).toBe(true);
+
+    const src = 'const o = null;\nconst z = o?.x;\nexport { z };\n';
+    return expect(transform!.call({}, src, id)).resolves.toMatchObject({
+      code: expect.any(String),
+    });
+  });
+
+  it('still includes .mjs, .js, .jsx, .ts, and .tsx for matched dependencies', () => {
+    const { transformInclude } = createPlugin(compileIncludesForPkg('animejs'));
+    const base = toPosix(path.join(rootDir, 'node_modules', 'animejs', 'dist', 'modules', 'index'));
+    expect(transformInclude!(`${base}.mjs`)).toBe(true);
+    expect(transformInclude!(`${base}.js`)).toBe(true);
+    expect(transformInclude!(`${base}.jsx`)).toBe(true);
+    expect(transformInclude!(`${base}.ts`)).toBe(true);
+    expect(transformInclude!(`${base}.tsx`)).toBe(true);
+  });
+
+  it('skips .cjs under node_modules when the package is not matched by compileIncludes', () => {
+    const { transformInclude } = createPlugin(compileIncludesForPkg('animejs'));
+    const id = toPosix(path.join(rootDir, 'node_modules', 'other-pkg', 'dist', 'index.cjs'));
+    expect(transformInclude!(id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds **`.cjs`** support to `compileDependencies`.

### The Problem
Previously, `.cjs` dependency files were excluded from the compilation matching logic. As a result, packages resolving to `.cjs` entry points could ship modern syntax (like **optional chaining**) without being transpiled for older targets, causing runtime errors.

## Changes

- **Added `.cjs` support**: Included the extension in the dependency compilation matching logic.
- **Cross-engine update**: Updated both **Webpack** and **Rspack** compilation paths.
- **Regression Testing**: Added coverage for `.cjs` files used through `compileDependencies`.
- **Backward Compatibility**: Kept existing behavior unchanged for `.js`, `.jsx`, `.ts`, `.tsx`, and `.mjs`.

## Verification

Ran the targeted regression test suite:

```bash
pnpm exec vitest run packages/shared-config/tests/compileDependencies.test.ts 
```
## Results:
- **Test Files: 1 passed**
- **Tests: 3 passed**
- **Status: Verified**
Fixes  #7181